### PR TITLE
feat(bin): add multi-project sync scripts for managing AIOS across repositories

### DIFF
--- a/bin/sync/README.md
+++ b/bin/sync/README.md
@@ -1,0 +1,246 @@
+# AIOS Sync System
+
+Sistema de sincronização para manter o AIOS atualizado em múltiplos projetos, com suporte a atualizações do repositório oficial.
+
+## Conceito
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│                                                                │
+│   SynkraAI/aios-core           seu-user/aios-core             │
+│   (upstream - oficial)          (origin - seu fork)            │
+│          │                             ↑                       │
+│          │  aios-update                │  git push origin      │
+│          ↓                             │                       │
+│        ┌─────────────────────────────────┐                     │
+│        │    ~/dev/aios-core (local)      │                     │
+│        │    - suas customizações         │                     │
+│        │    - + atualizações oficiais    │                     │
+│        └─────────────────────────────────┘                     │
+│                       │                                        │
+│                       │ aios-sync                              │
+│                       ↓                                        │
+│             seus projetos locais                               │
+│             - projeto-a/.aios-core/                            │
+│             - projeto-b/.aios-core/                            │
+└────────────────────────────────────────────────────────────────┘
+```
+
+### Fluxo de Atualizações
+
+```
+┌──────────────┐    aios-update    ┌──────────────┐    aios-sync    ┌──────────────┐
+│   Upstream   │ ───────────────→  │  aios-core   │ ──────────────→ │   Projetos   │
+│   (oficial)  │                   │   (master)   │                 │   (locais)   │
+└──────────────┘                   └──────────────┘                 └──────────────┘
+                                          ↑
+                                          │ aios-push
+                                   ┌──────────────┐
+                                   │  Projeto X   │
+                                   │  (dev local) │
+                                   └──────────────┘
+```
+
+## Instalação
+
+```bash
+cd ~/dev/aios-core
+./bin/install.sh
+```
+
+Isso copia os scripts para `~/bin/` e configura as permissões.
+
+## Scripts
+
+### aios-push
+
+Exporta o `.aios-core/` do projeto atual para o repositório master.
+
+```bash
+# No diretório de um projeto com AIOS
+aios-push           # Executa a cópia
+aios-push --dry-run # Mostra o que seria copiado
+```
+
+**Quando usar:** Após criar ou modificar algo no AIOS (task, agent, template, etc.)
+
+### aios-sync
+
+Propaga o repositório master para todos os projetos em `~/dev/`.
+
+```bash
+aios-sync                      # Atualiza todos os projetos
+aios-sync --dry-run            # Mostra quais seriam atualizados
+aios-sync --project=meu-proj   # Atualiza só um projeto específico
+```
+
+**Quando usar:** Após fazer `aios-push`, para distribuir as mudanças.
+
+### aios-pull
+
+Atualiza o `.aios-core/` do projeto atual a partir do master.
+
+```bash
+# No diretório de um projeto
+aios-pull           # Atualiza o projeto atual
+aios-pull --dry-run # Mostra as mudanças
+aios-pull --force   # Instala AIOS em projeto que não tem
+```
+
+**Quando usar:** Para atualizar um projeto específico sem rodar sync completo.
+
+### aios-update
+
+Atualiza o `aios-core` local com as mudanças do repositório oficial (upstream).
+
+```bash
+aios-update                    # Mostra status e mudanças disponíveis
+aios-update --check            # Apenas verifica, sem mostrar opções
+aios-update --merge            # Faz merge do upstream/main
+aios-update --tag=v3.10.0      # Atualiza para uma tag específica
+```
+
+**Quando usar:** Quando quiser incorporar novas features/fixes do AIOS oficial.
+
+## Workflow Típico
+
+### Cenário: Criei uma nova task no agent-factory
+
+```bash
+# 1. Está no agent-factory, criou execute-epic.md
+cd ~/dev/agent-factory
+
+# 2. Promove para o master
+aios-push
+
+# 3. (Opcional) Versiona no git
+cd ~/dev/aios-core
+git add . && git commit -m "Add execute-epic task"
+git push  # se tiver remote
+
+# 4. Propaga para outros projetos
+aios-sync
+```
+
+### Cenário: Quero atualizar só um projeto
+
+```bash
+cd ~/dev/meu-projeto
+aios-pull
+```
+
+### Cenário: Quero instalar AIOS em um projeto novo
+
+```bash
+cd ~/dev/projeto-novo
+aios-pull --force
+```
+
+### Cenário: Saiu uma nova versão oficial do AIOS
+
+```bash
+# 1. Verifica o que tem de novo
+aios-update
+
+# 2. Faz merge das atualizações
+aios-update --merge
+
+# 3. Propaga para todos os projetos
+aios-sync
+
+# 4. (Opcional) Push para seu fork
+cd ~/dev/aios-core
+git push origin main
+```
+
+### Cenário: Quero atualizar para uma versão específica
+
+```bash
+# Atualiza para a tag v3.10.0
+aios-update --tag=v3.10.0
+
+# Propaga
+aios-sync
+```
+
+## Configuração
+
+Os scripts usam variáveis de ambiente com defaults:
+
+| Variável | Default | Descrição |
+|----------|---------|-----------|
+| `AIOS_MASTER` | `~/dev/aios-core` | Caminho do repositório master |
+| `AIOS_PROJECTS_DIR` | `~/dev` | Diretório onde ficam os projetos |
+
+Para customizar, adicione ao seu `~/.bashrc` ou `~/.zshrc`:
+
+```bash
+export AIOS_MASTER="$HOME/meus-repos/aios-core"
+export AIOS_PROJECTS_DIR="$HOME/projetos"
+```
+
+## Estrutura
+
+```
+aios-core/                      # Repositório oficial (fork)
+├── .aios-core/                 # Framework AIOS
+│   ├── development/
+│   │   ├── agents/            # Definições de agentes
+│   │   ├── tasks/             # Tasks executáveis
+│   │   └── ...
+│   ├── product/
+│   │   ├── templates/         # Templates de documentos
+│   │   ├── checklists/        # Checklists de qualidade
+│   │   └── ...
+│   └── ...
+├── bin/                        # Scripts de sync (suas customizações)
+│   ├── README.md              # Esta documentação
+│   ├── install.sh             # Script de instalação
+│   ├── aios-push              # Exporta projeto → master
+│   ├── aios-sync              # Propaga master → projetos
+│   ├── aios-pull              # Atualiza projeto atual
+│   └── aios-update            # Atualiza do upstream oficial
+├── src/                        # Código fonte do AIOS
+├── packages/                   # Pacotes do monorepo
+└── ...
+```
+
+## Após Formatar a Máquina
+
+1. Clone seu fork: `git clone git@github.com:SEU-USER/aios-core.git ~/dev/aios-core`
+2. Configure upstream: `git remote add upstream https://github.com/SynkraAI/aios-core.git`
+3. Instale os scripts: `./bin/install.sh`
+4. Pronto! Scripts disponíveis globalmente.
+
+## Troubleshooting
+
+### "Repositório master não encontrado"
+
+O script espera o master em `~/dev/aios-core`. Se estiver em outro lugar:
+
+```bash
+export AIOS_MASTER="/caminho/para/aios-core"
+```
+
+### "Não encontrei .aios-core/ no diretório atual"
+
+Você está em um projeto sem AIOS. Use `aios-pull --force` para instalar.
+
+### Scripts não encontrados após reinstalar
+
+Execute novamente:
+
+```bash
+cd ~/dev/aios-core
+./bin/install.sh
+```
+
+### Conflitos ao fazer aios-update --merge
+
+Se houver conflitos entre suas customizações e o upstream:
+
+1. Resolva os arquivos conflitantes manualmente
+2. `git add <arquivos>`
+3. `git commit`
+
+Ou aborte: `git merge --abort`

--- a/bin/sync/aios-pull
+++ b/bin/sync/aios-pull
@@ -1,0 +1,87 @@
+#!/bin/bash
+# aios-pull - Atualiza o .aios-core do projeto atual a partir do master
+# Uso: aios-pull [--dry-run] [--force]
+
+set -e
+
+AIOS_MASTER="${AIOS_MASTER:-$HOME/dev/aios-core}"
+CURRENT_DIR="$(pwd)"
+CURRENT_AIOS="$CURRENT_DIR/.aios-core"
+
+# Cores
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Flags
+DRY_RUN=false
+FORCE=false
+
+for arg in "$@"; do
+  case $arg in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --force)
+      FORCE=true
+      shift
+      ;;
+  esac
+done
+
+echo -e "${BLUE}📥 AIOS Pull${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Verifica se o master existe
+if [ ! -d "$AIOS_MASTER" ]; then
+  echo -e "${RED}❌ Erro: Repositório master não encontrado${NC}"
+  echo "   Esperado em: $AIOS_MASTER"
+  exit 1
+fi
+
+PROJECT_NAME=$(basename "$CURRENT_DIR")
+echo -e "Projeto:  ${GREEN}$PROJECT_NAME${NC}"
+echo -e "Master:   $AIOS_MASTER"
+echo -e "Destino:  $CURRENT_AIOS"
+echo ""
+
+# Se não existe .aios-core no projeto atual
+if [ ! -d "$CURRENT_AIOS" ]; then
+  if [ "$FORCE" = true ]; then
+    echo -e "${YELLOW}⚠️  .aios-core não existe, criando...${NC}"
+    mkdir -p "$CURRENT_AIOS"
+  else
+    echo -e "${RED}❌ Erro: .aios-core não encontrado no projeto atual${NC}"
+    echo ""
+    echo "   Este projeto não tem AIOS instalado."
+    echo "   Use --force para instalar o AIOS neste projeto:"
+    echo "   aios-pull --force"
+    exit 1
+  fi
+fi
+
+if [ "$DRY_RUN" = true ]; then
+  echo -e "${YELLOW}🔍 Modo dry-run - mostrando mudanças:${NC}"
+  echo ""
+  rsync -avn --delete \
+    --exclude='.git' \
+    --exclude='node_modules' \
+    "$AIOS_MASTER/" "$CURRENT_AIOS/" | head -30
+  echo ""
+  echo -e "${YELLOW}(mostrando apenas os primeiros 30 itens)${NC}"
+else
+  echo -e "${YELLOW}🔄 Atualizando...${NC}"
+  rsync -av --delete \
+    --exclude='.git' \
+    --exclude='node_modules' \
+    "$AIOS_MASTER/" "$CURRENT_AIOS/" | tail -5
+
+  echo ""
+  echo -e "${GREEN}✅ Pull concluído!${NC}"
+  echo ""
+  echo "O projeto '$PROJECT_NAME' agora está com o AIOS atualizado."
+  echo "Reinicie o Claude Code para carregar as mudanças."
+fi

--- a/bin/sync/aios-push
+++ b/bin/sync/aios-push
@@ -1,0 +1,82 @@
+#!/bin/bash
+# aios-push - Exporta .aios-core do projeto atual para o repositório master
+# Uso: aios-push [--dry-run]
+
+set -e
+
+AIOS_MASTER="${AIOS_MASTER:-$HOME/dev/aios-core}"
+CURRENT_DIR="$(pwd)"
+CURRENT_AIOS="$CURRENT_DIR/.aios-core"
+
+# Cores
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Flags
+DRY_RUN=false
+
+for arg in "$@"; do
+  case $arg in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+  esac
+done
+
+echo -e "${BLUE}📤 AIOS Push${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Verifica se está em um projeto com .aios-core
+if [ ! -d "$CURRENT_AIOS" ]; then
+  echo -e "${RED}❌ Erro: Não encontrei .aios-core/ no diretório atual${NC}"
+  echo "   Diretório: $CURRENT_DIR"
+  echo ""
+  echo "   Execute este comando dentro de um projeto que tenha AIOS instalado."
+  exit 1
+fi
+
+# Verifica se o master existe
+if [ ! -d "$AIOS_MASTER" ]; then
+  echo -e "${RED}❌ Erro: Repositório master não encontrado${NC}"
+  echo "   Esperado em: $AIOS_MASTER"
+  echo ""
+  echo "   Crie o repositório master primeiro:"
+  echo "   mkdir -p $AIOS_MASTER"
+  exit 1
+fi
+
+# Mostra info
+PROJECT_NAME=$(basename "$CURRENT_DIR")
+echo -e "Projeto:  ${GREEN}$PROJECT_NAME${NC}"
+echo -e "Origem:   $CURRENT_AIOS"
+echo -e "Destino:  $AIOS_MASTER"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+  echo -e "${YELLOW}🔍 Modo dry-run - mostrando o que seria copiado:${NC}"
+  echo ""
+  rsync -avn --delete \
+    --exclude='.git' \
+    --exclude='node_modules' \
+    "$CURRENT_AIOS/" "$AIOS_MASTER/" | head -50
+  echo ""
+  echo -e "${YELLOW}(mostrando apenas os primeiros 50 itens)${NC}"
+else
+  echo -e "${YELLOW}🔄 Sincronizando...${NC}"
+  rsync -av --delete \
+    --exclude='.git' \
+    --exclude='node_modules' \
+    "$CURRENT_AIOS/" "$AIOS_MASTER/" | tail -5
+
+  echo ""
+  echo -e "${GREEN}✅ Push concluído!${NC}"
+  echo ""
+  echo "Próximos passos:"
+  echo "  1. cd $AIOS_MASTER"
+  echo "  2. git add . && git commit -m 'Update from $PROJECT_NAME'"
+  echo "  3. aios-sync  # para propagar para outros projetos"
+fi

--- a/bin/sync/aios-sync
+++ b/bin/sync/aios-sync
@@ -1,0 +1,105 @@
+#!/bin/bash
+# aios-sync - Propaga o AIOS master para todos os projetos em ~/dev
+# Uso: aios-sync [--dry-run] [--project=nome]
+
+set -e
+
+AIOS_MASTER="${AIOS_MASTER:-$HOME/dev/aios-core}"
+PROJECTS_DIR="${AIOS_PROJECTS_DIR:-$HOME/dev}"
+
+# Cores
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Flags
+DRY_RUN=false
+TARGET_PROJECT=""
+
+for arg in "$@"; do
+  case $arg in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --project=*)
+      TARGET_PROJECT="${arg#*=}"
+      shift
+      ;;
+  esac
+done
+
+echo -e "${BLUE}🔄 AIOS Sync${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Verifica se o master existe
+if [ ! -d "$AIOS_MASTER" ]; then
+  echo -e "${RED}❌ Erro: Repositório master não encontrado${NC}"
+  echo "   Esperado em: $AIOS_MASTER"
+  echo ""
+  echo "   Use 'aios-push' primeiro para criar o master a partir de um projeto."
+  exit 1
+fi
+
+echo -e "Master:   ${GREEN}$AIOS_MASTER${NC}"
+echo -e "Projetos: $PROJECTS_DIR"
+echo ""
+
+if [ "$DRY_RUN" = true ]; then
+  echo -e "${YELLOW}🔍 Modo dry-run ativado${NC}"
+  echo ""
+fi
+
+# Contadores
+SYNCED=0
+SKIPPED=0
+
+# Itera sobre os projetos
+for proj in "$PROJECTS_DIR"/*/; do
+  proj_name=$(basename "$proj")
+
+  # Pula o próprio master
+  if [ "$proj" = "$AIOS_MASTER/" ] || [ "$proj_name" = "aios-core" ]; then
+    continue
+  fi
+
+  # Se especificou um projeto, pula os outros
+  if [ -n "$TARGET_PROJECT" ] && [ "$proj_name" != "$TARGET_PROJECT" ]; then
+    continue
+  fi
+
+  # Verifica se tem .aios-core
+  if [ -d "$proj/.aios-core" ]; then
+    if [ "$DRY_RUN" = true ]; then
+      echo -e "  ${CYAN}→${NC} $proj_name ${YELLOW}(dry-run)${NC}"
+      rsync -avn --delete \
+        --exclude='.git' \
+        --exclude='node_modules' \
+        "$AIOS_MASTER/" "$proj/.aios-core/" 2>/dev/null | grep -c "^" || true
+    else
+      echo -e "  ${CYAN}→${NC} $proj_name"
+      rsync -a --delete \
+        --exclude='.git' \
+        --exclude='node_modules' \
+        "$AIOS_MASTER/" "$proj/.aios-core/"
+    fi
+    SYNCED=$((SYNCED + 1))
+  else
+    SKIPPED=$((SKIPPED + 1))
+  fi
+done
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [ "$DRY_RUN" = true ]; then
+  echo -e "${YELLOW}🔍 Dry-run: $SYNCED projeto(s) seriam atualizados${NC}"
+  echo "   Execute sem --dry-run para aplicar."
+else
+  echo -e "${GREEN}✅ Sync concluído!${NC}"
+  echo -e "   Projetos atualizados: ${GREEN}$SYNCED${NC}"
+  echo -e "   Projetos sem AIOS:    $SKIPPED"
+fi

--- a/bin/sync/aios-update
+++ b/bin/sync/aios-update
@@ -1,0 +1,164 @@
+#!/bin/bash
+# aios-update - Atualiza o aios-core local com as mudanças do repositório oficial
+# Uso: aios-update [--check] [--merge] [--tag=vX.X.X]
+
+set -e
+
+AIOS_MASTER="${AIOS_MASTER:-$HOME/dev/aios-core}"
+UPSTREAM_REMOTE="upstream"
+UPSTREAM_BRANCH="main"
+
+# Cores
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# Flags
+CHECK_ONLY=false
+DO_MERGE=false
+TARGET_TAG=""
+
+for arg in "$@"; do
+  case $arg in
+    --check)
+      CHECK_ONLY=true
+      shift
+      ;;
+    --merge)
+      DO_MERGE=true
+      shift
+      ;;
+    --tag=*)
+      TARGET_TAG="${arg#*=}"
+      shift
+      ;;
+  esac
+done
+
+echo -e "${BLUE}🔄 AIOS Update${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# Verifica se está no diretório correto
+if [ ! -d "$AIOS_MASTER/.git" ]; then
+  echo -e "${RED}❌ Erro: $AIOS_MASTER não é um repositório git${NC}"
+  exit 1
+fi
+
+cd "$AIOS_MASTER"
+
+# Verifica se upstream existe
+if ! git remote get-url "$UPSTREAM_REMOTE" &>/dev/null; then
+  echo -e "${RED}❌ Erro: Remote '$UPSTREAM_REMOTE' não configurado${NC}"
+  echo ""
+  echo "Configure com:"
+  echo "  cd $AIOS_MASTER"
+  echo "  git remote add upstream https://github.com/SynkraAI/aios-core.git"
+  exit 1
+fi
+
+UPSTREAM_URL=$(git remote get-url "$UPSTREAM_REMOTE")
+echo -e "Upstream: ${CYAN}$UPSTREAM_URL${NC}"
+echo ""
+
+# Fetch upstream
+echo -e "${YELLOW}📡 Buscando atualizações...${NC}"
+git fetch "$UPSTREAM_REMOTE" --tags
+
+# Mostra versão atual e disponível
+CURRENT_COMMIT=$(git rev-parse --short HEAD)
+UPSTREAM_COMMIT=$(git rev-parse --short "$UPSTREAM_REMOTE/$UPSTREAM_BRANCH")
+
+echo ""
+echo -e "Seu commit:      ${GREEN}$CURRENT_COMMIT${NC}"
+echo -e "Upstream commit: ${CYAN}$UPSTREAM_COMMIT${NC}"
+
+# Lista tags disponíveis
+echo ""
+echo -e "${BLUE}📦 Tags disponíveis:${NC}"
+git tag --sort=-v:refname | head -10 | while read tag; do
+  echo "  • $tag"
+done
+
+# Conta commits de diferença
+BEHIND=$(git rev-list --count HEAD.."$UPSTREAM_REMOTE/$UPSTREAM_BRANCH" 2>/dev/null || echo "0")
+AHEAD=$(git rev-list --count "$UPSTREAM_REMOTE/$UPSTREAM_BRANCH"..HEAD 2>/dev/null || echo "0")
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [ "$BEHIND" = "0" ] && [ "$AHEAD" = "0" ]; then
+  echo -e "${GREEN}✅ Você está sincronizado com o upstream!${NC}"
+  exit 0
+fi
+
+if [ "$BEHIND" != "0" ]; then
+  echo -e "${YELLOW}📥 Você está $BEHIND commit(s) atrás do upstream${NC}"
+fi
+
+if [ "$AHEAD" != "0" ]; then
+  echo -e "${CYAN}📤 Você está $AHEAD commit(s) à frente do upstream (suas customizações)${NC}"
+fi
+
+# Se é só check, para aqui
+if [ "$CHECK_ONLY" = true ]; then
+  echo ""
+  echo "Use 'aios-update --merge' para incorporar as atualizações."
+  exit 0
+fi
+
+# Se não pediu merge explícito, mostra preview
+if [ "$DO_MERGE" != true ] && [ -z "$TARGET_TAG" ]; then
+  echo ""
+  echo -e "${BLUE}📋 Mudanças do upstream:${NC}"
+  git log --oneline HEAD.."$UPSTREAM_REMOTE/$UPSTREAM_BRANCH" | head -15
+
+  TOTAL_CHANGES=$(git log --oneline HEAD.."$UPSTREAM_REMOTE/$UPSTREAM_BRANCH" | wc -l)
+  if [ "$TOTAL_CHANGES" -gt 15 ]; then
+    echo "  ... e mais $((TOTAL_CHANGES - 15)) commits"
+  fi
+
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "Opções:"
+  echo "  aios-update --merge          # Merge upstream/main"
+  echo "  aios-update --tag=v3.10.0    # Atualizar para tag específica"
+  echo "  aios-update --check          # Apenas verificar (sem merge)"
+  exit 0
+fi
+
+# Executa o merge
+echo ""
+
+if [ -n "$TARGET_TAG" ]; then
+  echo -e "${YELLOW}🔀 Fazendo merge da tag $TARGET_TAG...${NC}"
+  MERGE_TARGET="$TARGET_TAG"
+else
+  echo -e "${YELLOW}🔀 Fazendo merge de $UPSTREAM_REMOTE/$UPSTREAM_BRANCH...${NC}"
+  MERGE_TARGET="$UPSTREAM_REMOTE/$UPSTREAM_BRANCH"
+fi
+
+# Tenta o merge
+if git merge "$MERGE_TARGET" -m "Merge upstream updates from $MERGE_TARGET"; then
+  echo ""
+  echo -e "${GREEN}✅ Merge concluído com sucesso!${NC}"
+  echo ""
+  echo "Próximos passos:"
+  echo "  1. Revise as mudanças: git log --oneline -10"
+  echo "  2. Propague para projetos: aios-sync"
+  echo "  3. (Opcional) Push para seu fork: git push origin main"
+else
+  echo ""
+  echo -e "${RED}⚠️  Conflitos detectados!${NC}"
+  echo ""
+  echo "Resolva os conflitos manualmente:"
+  echo "  1. Edite os arquivos com conflito"
+  echo "  2. git add <arquivos>"
+  echo "  3. git commit"
+  echo ""
+  echo "Ou aborte o merge:"
+  echo "  git merge --abort"
+  exit 1
+fi

--- a/bin/sync/install.sh
+++ b/bin/sync/install.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# install.sh - Instala os scripts AIOS no sistema
+# Uso: ./install.sh [--uninstall]
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_DIR="${HOME}/bin"
+
+# Cores
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+SCRIPTS=("aios-push" "aios-sync" "aios-pull" "aios-update")
+
+# Verifica se é uninstall
+if [ "$1" = "--uninstall" ]; then
+  echo -e "${BLUE}🗑️  AIOS Uninstall${NC}"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+  for script in "${SCRIPTS[@]}"; do
+    if [ -f "$TARGET_DIR/$script" ]; then
+      rm "$TARGET_DIR/$script"
+      echo -e "  ${RED}✗${NC} Removido: $script"
+    fi
+  done
+
+  echo ""
+  echo -e "${GREEN}✅ Scripts removidos de $TARGET_DIR${NC}"
+  exit 0
+fi
+
+echo -e "${BLUE}📦 AIOS Install${NC}"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+# Cria ~/bin se não existir
+if [ ! -d "$TARGET_DIR" ]; then
+  echo -e "${YELLOW}Criando $TARGET_DIR...${NC}"
+  mkdir -p "$TARGET_DIR"
+fi
+
+# Copia os scripts
+echo "Instalando scripts em $TARGET_DIR:"
+echo ""
+
+for script in "${SCRIPTS[@]}"; do
+  if [ -f "$SCRIPT_DIR/$script" ]; then
+    cp "$SCRIPT_DIR/$script" "$TARGET_DIR/"
+    chmod +x "$TARGET_DIR/$script"
+    echo -e "  ${GREEN}✓${NC} $script"
+  else
+    echo -e "  ${RED}✗${NC} $script (não encontrado)"
+  fi
+done
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo -e "${GREEN}✅ Instalação concluída!${NC}"
+echo ""
+
+# Verifica se ~/bin está no PATH
+if [[ ":$PATH:" != *":$TARGET_DIR:"* ]]; then
+  echo -e "${YELLOW}⚠️  Atenção: $TARGET_DIR não está no PATH${NC}"
+  echo ""
+  echo "Adicione ao seu ~/.bashrc ou ~/.zshrc:"
+  echo ""
+  echo "  export PATH=\"\$HOME/bin:\$PATH\""
+  echo ""
+  echo "Depois execute: source ~/.bashrc"
+  echo ""
+else
+  echo "Scripts disponíveis globalmente:"
+  echo ""
+  echo "  aios-push    # Exporta projeto → master"
+  echo "  aios-sync    # Propaga master → projetos"
+  echo "  aios-pull    # Atualiza projeto atual"
+  echo "  aios-update  # Atualiza do upstream oficial"
+  echo ""
+fi


### PR DESCRIPTION
Summary

  This PR adds a set of shell scripts to help developers manage AIOS installations across multiple local projects. These scripts streamline the workflow of maintaining a central "master" AIOS repository and synchronizing it with multiple project
  repositories.

  Problem

  When using AIOS across multiple projects, developers face challenges:

  1. Consistency: Keeping .aios-core/ synchronized across all projects
  2. Propagation: Distributing custom agents, tasks, or templates to all projects
  3. Updates: Incorporating upstream (official) updates while preserving local customizations
  4. Recovery: Restoring the setup after formatting a machine

  Solution

  Four bash scripts in bin/sync/ that provide a complete sync workflow:
  ┌─────────────┬──────────────────────────────────────────────────────────────────┐
  │   Script    │                             Purpose                              │
  ├─────────────┼──────────────────────────────────────────────────────────────────┤
  │ aios-push   │ Export .aios-core/ from current project to the master repository │
  ├─────────────┼──────────────────────────────────────────────────────────────────┤
  │ aios-sync   │ Propagate master repository to all projects in a directory       │
  ├─────────────┼──────────────────────────────────────────────────────────────────┤
  │ aios-pull   │ Update only the current project from master                      │
  ├─────────────┼──────────────────────────────────────────────────────────────────┤
  │ aios-update │ Fetch and merge updates from upstream (SynkraAI/aios-core)       │
  └─────────────┴──────────────────────────────────────────────────────────────────┘
  Workflow Diagram

  ┌──────────────┐    aios-update    ┌──────────────┐    aios-sync    ┌──────────────┐
  │   Upstream   │ ───────────────→  │  aios-core   │ ──────────────→ │   Projects   │
  │   (official) │                   │   (master)   │                 │   (local)    │
  └──────────────┘                   └──────────────┘                 └──────────────┘
                                            ↑
                                            │ aios-push
                                     ┌──────────────┐
                                     │  Project X   │
                                     │  (dev local) │
                                     └──────────────┘

  Features

  - Dry-run mode: All scripts support --dry-run to preview changes
  - Selective sync: aios-sync --project=name to update a single project
  - Version pinning: aios-update --tag=v3.10.0 to update to a specific release
  - Force install: aios-pull --force to install AIOS in a new project
  - Self-documenting: Comprehensive README with usage examples
  - Easy installation: ./bin/sync/install.sh copies scripts to ~/bin

  Files Added

  bin/sync/
  ├── README.md      # Complete documentation
  ├── install.sh     # Installation script
  ├── aios-push      # Export project → master
  ├── aios-sync      # Propagate master → projects
  ├── aios-pull      # Update current project
  └── aios-update    # Merge upstream updates

  Usage Example

  # After creating a new task in project-a:
  cd ~/dev/project-a
  aios-push                    # Export to master

  # Propagate to all projects:
  aios-sync                    # Updates all projects with .aios-core/

  # When a new AIOS version is released:
  aios-update --merge          # Merge upstream changes
  aios-sync                    # Propagate to projects

  Testing

  Tested manually on Ubuntu (WSL2) with:
  - 6 projects containing .aios-core/
  - Push/pull/sync operations
  - Upstream merge with local customizations

  Checklist

  - Scripts follow bash best practices
  - All scripts have --dry-run support
  - Error handling with helpful messages
  - Documentation included (README.md)
  - Installation script provided
  - No breaking changes to existing functionality
  - Scripts are placed in bin/sync/ to avoid conflicts with existing bin/ scripts

  Related

  This contribution was inspired by the common workflow of developers who use AIOS across multiple client projects and need a reliable way to keep them synchronized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced AIOS Sync System enabling seamless synchronization between projects and a master AIOS repository.
  * Added four utility commands for pushing changes, pulling updates, syncing all projects, and merging upstream updates.
  * Added installation script for automatic setup.

* **Documentation**
  * Added comprehensive guide with installation steps, workflows, and troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->