### PR TITLE
fix(tests): resolve flaky integration tests

### DIFF
--- a/tests/integration/squad/squad-analyze-extend.test.js
+++ b/tests/integration/squad/squad-analyze-extend.test.js
@@ -15,15 +15,11 @@
 const path = require('path');
 const fs = require('fs').promises;
 const yaml = require('js-yaml');
-const {
-  SquadAnalyzer,
-} = require('../../../.aios-core/development/scripts/squad/squad-analyzer');
-const {
-  SquadExtender,
-} = require('../../../.aios-core/development/scripts/squad/squad-extender');
+const { SquadAnalyzer } = require('../../../.aios-core/development/scripts/squad/squad-analyzer');
+const { SquadExtender } = require('../../../.aios-core/development/scripts/squad/squad-extender');
 
-// Test directory for integration tests
-const INTEGRATION_PATH = path.join(__dirname, 'temp-integration');
+// Test directory for integration tests - use unique directory to avoid parallel test collisions
+const INTEGRATION_PATH = path.join(__dirname, 'temp-analyze-extend');
 
 describe('Squad Analyze & Extend Integration', () => {
   let analyzer;
@@ -76,10 +72,7 @@ describe('Squad Analyze & Extend Integration', () => {
         data: [],
       },
     };
-    await fs.writeFile(
-      path.join(testSquadPath, 'squad.yaml'),
-      yaml.dump(manifest)
-    );
+    await fs.writeFile(path.join(testSquadPath, 'squad.yaml'), yaml.dump(manifest));
 
     // Create initial agent
     await fs.writeFile(
@@ -156,10 +149,7 @@ describe('Squad Analyze & Extend Integration', () => {
       expect(content).toContain('A new agent for testing');
 
       // Verify manifest updated
-      const manifestContent = await fs.readFile(
-        path.join(testSquadPath, 'squad.yaml'),
-        'utf8'
-      );
+      const manifestContent = await fs.readFile(path.join(testSquadPath, 'squad.yaml'), 'utf8');
       expect(manifestContent).toContain('new-agent.md');
     });
 
@@ -353,10 +343,7 @@ describe('Squad Analyze & Extend Integration', () => {
       }
 
       // Verify manifest has all components
-      const manifestContent = await fs.readFile(
-        path.join(testSquadPath, 'squad.yaml'),
-        'utf8'
-      );
+      const manifestContent = await fs.readFile(path.join(testSquadPath, 'squad.yaml'), 'utf8');
       const manifest = yaml.load(manifestContent);
 
       expect(manifest.components.agents).toContain('agent-1.md');
@@ -376,7 +363,7 @@ describe('Squad Analyze & Extend Integration', () => {
 
       // Add custom content to manifest
       const manifestPath = path.join(testSquadPath, 'squad.yaml');
-      let manifest = yaml.load(await fs.readFile(manifestPath, 'utf8'));
+      const manifest = yaml.load(await fs.readFile(manifestPath, 'utf8'));
       manifest.customField = 'custom-value';
       manifest.config = { setting1: true, setting2: 'value' };
       await fs.writeFile(manifestPath, yaml.dump(manifest));


### PR DESCRIPTION
## Summary
- Use unique temp directories in squad integration tests to prevent parallel test collisions (ENOTEMPTY errors)
- Add mockReset() in wizard tests to properly isolate test-specific mock chains
- Fix mock chain order for language prompt in wizard tests

## Problem
Integration tests were intermittently failing due to:
1. **squad-download-publish.test.js** and **squad-analyze-extend.test.js** shared the same temp directory (`temp-integration`), causing ENOTEMPTY errors when Jest runs tests in parallel
2. **wizard/integration.test.js** had mock chain issues where test-specific mocks weren't overriding beforeEach defaults

## Solution
1. Each squad integration test now uses a unique temp directory
2. Tests that need custom mock chains now call `mockReset()` before setting up their mocks
3. Language prompt mock (`{ language: 'en' }`) is properly included in all mock chains

## Test plan
- [x] All integration tests pass reliably
- [x] Tests pass with parallel execution (Jest default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation and reliability with enhanced mock resets and unique test directory configuration to support parallel test execution.
  * Refactored integration tests for better code clarity and maintainability.
  * Updated wizard integration tests to reflect improved prompt flow handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->