### PR TITLE
fix(aios-master): correct workflow dependencies and add missing workflows

### DIFF
--- a/.aios-core/development/agents/aios-master.md
+++ b/.aios-core/development/agents/aios-master.md
@@ -160,6 +160,9 @@ commands:
     description: 'Break document into parts'
   - name: document-project
     description: 'Generate project documentation'
+  - name: add-tech-doc
+    args: '{file-path} [preset-name]'
+    description: 'Create tech-preset from documentation file'
 
   # Story Creation
   - name: create-next-story
@@ -203,6 +206,7 @@ security:
 
 dependencies:
   tasks:
+    - add-tech-doc.md
     - advanced-elicitation.md
     - analyze-framework.md
     - correct-course.md
@@ -257,12 +261,14 @@ dependencies:
     - workflow-management.md
     - yaml-validator.js
   workflows:
-    - brownfield-fullstack.md
-    - brownfield-service.md
-    - brownfield-ui.md
-    - greenfield-fullstack.md
-    - greenfield-service.md
-    - greenfield-ui.md
+    - brownfield-fullstack.yaml
+    - brownfield-service.yaml
+    - brownfield-ui.yaml
+    - design-system-build-quality.yaml
+    - greenfield-fullstack.yaml
+    - greenfield-service.yaml
+    - greenfield-ui.yaml
+    - story-development-cycle.yaml
   checklists:
     - architect-checklist.md
     - change-checklist.md


### PR DESCRIPTION
## Summary

- Fix workflow file extensions (`.md` → `.yaml`)
- Add `design-system-build-quality.yaml` workflow reference
- Add `story-development-cycle.yaml` workflow reference
- Add `add-tech-doc` command and task for creating tech presets from docs

## Test plan

- [ ] Verify @aios-master loads without errors
- [ ] Check workflow references resolve correctly
- [ ] Test `*add-tech-doc` command execution

🤖 Generated with [Claude Code](https://claude.ai/code)