### PR TITLE
fix(ci): graceful skip for pro/ submodule tests in CI

### DIFF
--- a/tests/pro/memory/session-digest/extractor.test.js
+++ b/tests/pro/memory/session-digest/extractor.test.js
@@ -1,6 +1,9 @@
 /**
  * Session Digest Extractor Tests
  * Story MIS-3: Session Digest (PreCompact Hook)
+ *
+ * Requires pro/ submodule. Tests skip gracefully in CI
+ * where the submodule is not available.
  */
 
 // Mock fs FIRST (before any requires)
@@ -14,14 +17,21 @@ jest.mock('fs', () => ({
 const fs = require('fs');
 const path = require('path');
 const yaml = require('yaml');
-const {
-  extractSessionDigest,
-  _analyzeConversation,
-  _generateDigestDocument,
-  _writeDigest,
-} = require('../../../../pro/memory/session-digest/extractor');
 
-describe('Session Digest Extractor', () => {
+let extractorModule;
+try {
+  extractorModule = require('../../../../pro/memory/session-digest/extractor');
+} catch (e) {
+  // pro/ submodule not available (CI environment)
+}
+
+const isProAvailable = !!extractorModule;
+const extractSessionDigest = isProAvailable ? extractorModule.extractSessionDigest : undefined;
+const _analyzeConversation = isProAvailable ? extractorModule._analyzeConversation : undefined;
+const _generateDigestDocument = isProAvailable ? extractorModule._generateDigestDocument : undefined;
+const _writeDigest = isProAvailable ? extractorModule._writeDigest : undefined;
+
+(isProAvailable ? describe : describe.skip)('Session Digest Extractor', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     fs.promises.mkdir.mockClear();


### PR DESCRIPTION
## Summary

- Wrap `require('../../../../pro/memory/session-digest/extractor')` in try-catch
- Use `describe.skip` when `pro/` submodule is not available (CI environment)
- Tests still run fully when submodule is checked out locally

## Root Cause

The `pro/` directory is a private git submodule. CI does not checkout submodules,
causing `Cannot find module` error that fails the entire test suite.

## Test Plan

- [x] 12/12 tests still pass locally (submodule available)
- [x] In CI: test suite will be skipped instead of failing
- [x] No functional changes to test logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)