### PR TITLE
ci: add pro integration workflow for submodule tests

### DIFF
--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -1,0 +1,129 @@
+# Pro Integration Tests
+#
+# Separate workflow for tests that require the aios-pro submodule.
+# aios-core CI runs standalone (ADR-PRO-001). This workflow validates
+# the integration boundary between core and pro.
+#
+# Requires PRO_SUBMODULE_TOKEN secret (PAT with repo scope for SynkraAI/aios-pro).
+#
+# Tests covered:
+#   - tests/pro/**          (integration tests in aios-core)
+#   - pro/**/__tests__/**   (unit tests inside aios-pro submodule)
+
+name: Pro Integration
+
+on:
+  # When submodule pointer or pro-related tests change
+  push:
+    branches: [main]
+    paths:
+      - 'pro'
+      - 'tests/pro/**'
+      - 'bin/utils/pro-detector.js'
+      - '.github/workflows/pro-integration.yml'
+
+  pull_request:
+    branches: [main]
+    paths:
+      - 'pro'
+      - 'tests/pro/**'
+      - 'bin/utils/pro-detector.js'
+      - '.github/workflows/pro-integration.yml'
+
+  # Manual trigger for on-demand validation
+  workflow_dispatch:
+
+  # Weekly scheduled run (Monday 6am UTC)
+  schedule:
+    - cron: '0 6 * * 1'
+
+concurrency:
+  group: pro-integration-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pro-tests:
+    name: Pro Integration Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    # Skip if secret is not configured (forks, new setups)
+    # The job will still appear but steps will be skipped gracefully
+    env:
+      HAS_PRO_TOKEN: ${{ secrets.PRO_SUBMODULE_TOKEN != '' }}
+
+    steps:
+      - name: Check token availability
+        id: token-check
+        run: |
+          if [ "$HAS_PRO_TOKEN" != "true" ]; then
+            echo "⚠️ PRO_SUBMODULE_TOKEN not configured. Skipping pro integration tests."
+            echo "See: .github/workflows/pro-integration.yml for setup instructions."
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout with submodules
+        if: steps.token-check.outputs.skip != 'true'
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PRO_SUBMODULE_TOKEN }}
+          submodules: 'recursive'
+
+      - name: Setup Node.js
+        if: steps.token-check.outputs.skip != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install core dependencies
+        if: steps.token-check.outputs.skip != 'true'
+        run: npm ci
+
+      - name: Install pro dependencies
+        if: steps.token-check.outputs.skip != 'true'
+        run: |
+          if [ -f pro/package.json ]; then
+            cd pro && npm ci
+          else
+            echo "⚠️ pro/package.json not found — submodule may not be initialized"
+            exit 1
+          fi
+
+      - name: Verify submodule checkout
+        if: steps.token-check.outputs.skip != 'true'
+        run: |
+          echo "=== Pro Submodule Status ==="
+          git submodule status
+          echo ""
+          echo "=== Pro Version ==="
+          node -e "const p = require('./pro/package.json'); console.log(p.name + '@' + p.version)"
+          echo ""
+          echo "=== Pro Contents ==="
+          ls pro/
+
+      - name: Run core→pro integration tests
+        if: steps.token-check.outputs.skip != 'true'
+        run: |
+          echo "=== Running tests/pro/ (integration tests in aios-core) ==="
+          npx jest tests/pro/ --no-coverage --verbose
+
+      - name: Run pro internal tests
+        if: steps.token-check.outputs.skip != 'true'
+        run: |
+          echo "=== Running pro/**/__tests__/ (unit tests in aios-pro) ==="
+          npx jest 'pro/**/__tests__/**/*.test.js' --no-coverage --verbose
+
+      - name: Summary
+        if: steps.token-check.outputs.skip != 'true' && always()
+        run: |
+          echo "=== Pro Integration Summary ==="
+          echo "Core integration tests: tests/pro/"
+          echo "Pro unit tests: pro/**/__tests__/"
+          echo "Submodule ref: $(git submodule status | awk '{print $1}')"


### PR DESCRIPTION
## Summary

- Add dedicated `pro-integration.yml` workflow for tests requiring the `aios-pro` submodule
- Maintains ADR-PRO-001: aios-core CI stays standalone (no submodule checkout in main CI)
- New workflow handles the integration boundary between core and pro

## How It Works

**Main CI (`ci.yml`)** — unchanged, no submodule checkout:
- `tests/pro/extractor.test.js` → graceful `describe.skip` (PR #117)
- `tests/pro/pro-detector.test.js` → uses mocks, always passes

**Pro Integration (`pro-integration.yml`)** — with submodule checkout:
- `tests/pro/**` → core→pro integration tests (real require)
- `pro/**/__tests__/**` → pro internal unit tests

## Triggers

| Trigger | When |
|---------|------|
| Push to main | `pro` pointer, `tests/pro/**`, `bin/utils/pro-detector.js` changes |
| Pull request | Same paths as push |
| Schedule | Weekly (Monday 6am UTC) |
| Manual | `workflow_dispatch` |

## Setup Required

Add a GitHub PAT as repository secret:

```bash
gh secret set PRO_SUBMODULE_TOKEN
# Paste a PAT with `repo` scope for SynkraAI org
```

The workflow gracefully skips if the token is not configured (safe for forks).

## Test Plan

- [x] Workflow syntax validated
- [x] Token check gracefully skips when secret not available
- [x] Path triggers cover submodule pointer + test files
- [x] Concurrency group prevents parallel runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated integration validation workflow to ensure compatibility between core and pro modules during development and pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->