### PR TITLE
feat(synapse): SYN Wave 2 — Hook Entry Point + Registration [Story SYN-7]

### DIFF
--- a/.claude/hooks/synapse-engine.js
+++ b/.claude/hooks/synapse-engine.js
@@ -29,6 +29,7 @@ function readStdin() {
   return new Promise((resolve, reject) => {
     let data = '';
     process.stdin.setEncoding('utf8');
+    process.stdin.on('error', (e) => reject(e));
     process.stdin.on('data', (chunk) => { data += chunk; });
     process.stdin.on('end', () => {
       try { resolve(JSON.parse(data)); }
@@ -41,6 +42,7 @@ function readStdin() {
 async function main() {
   const input = await readStdin();
   const { sessionId, cwd, prompt } = input;
+  if (!cwd) return;
   const synapsePath = path.join(cwd, '.synapse');
   if (!fs.existsSync(synapsePath)) return;
 


### PR DESCRIPTION
## Summary

- Implement Claude Code `UserPromptSubmit` hook (`.claude/hooks/synapse-engine.js`) that integrates SynapseEngine for per-prompt context injection via stdin/stdout JSON protocol
- 75-line thin wrapper: reads JSON from stdin, delegates to `SynapseEngine.process()`, writes `<synapse-rules>` context to stdout
- Safety timeout (`HOOK_TIMEOUT_MS=5000`) with `timer.unref()` as defense-in-depth alongside Claude Code's external timeout
- `.gitignore` updated with SYNAPSE runtime entries (`.synapse/sessions/`, `.synapse/cache/`) and `!.claude/hooks/synapse-engine.js` exception

## Key Design Decisions

- **CommonJS** (not ESM) — consistent with all SYNAPSE modules
- **Zero external deps** — Node.js stdlib only (`path`, `fs`)
- **Graceful degradation** — silent exit (code 0) on any error, never blocks user prompt
- **`require.main === module` guard** — enables both direct script execution and Jest import for coverage tracking
- **Dynamic requires** — deferred past `.synapse/` existence check for fast-exit path

## Test Plan

- [x] 36/36 tests passing (spawn integration + direct Jest coverage)
- [x] 425/425 full synapse regression passing
- [x] Coverage: Stmts 93.93%, Branch 75%, Funcs 87.5%, Lines 100%
- [x] QA Gate: PASS 98/100 — all 3 issues resolved (coverage, timeout, thresholds)
- [ ] Verify hook executes correctly with real SynapseEngine after SYN-6 merge (already on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Synapse Engine hook integration with prompt processing and result handling capabilities.

* **Tests**
  * Added comprehensive test suite for Synapse Engine hook covering input/output protocol, error handling, and edge cases.

* **Chores**
  * Updated tracking configuration to include new Synapse runtime directories and documentation guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->