### PR TITLE
fix(installer): include .claude/hooks in npm package [INS-1]

### DIFF
--- a/.aios-core/install-manifest.yaml
+++ b/.aios-core/install-manifest.yaml
@@ -7,8 +7,8 @@
 # - SHA256 hashes for change detection
 # - File types for categorization
 #
-version: 4.0.1
-generated_at: "2026-02-13T01:15:06.572Z"
+version: 4.0.2
+generated_at: "2026-02-13T01:34:54.608Z"
 generator: scripts/generate-install-manifest.js
 file_count: 971
 files:
@@ -953,7 +953,7 @@ files:
     type: data
     size: 34780
   - path: data/entity-registry.yaml
-    hash: sha256:2b04f4429715e2e4aae58fcfbc5ab1261b56bcdb12b1bfb0cea277f8b6e48325
+    hash: sha256:c02059828c5708815bf6ac1cb3664c2898ecfff06f9d47413fe68caf1fa969ae
     type: data
     size: 279148
   - path: data/learned-patterns.yaml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aios-core",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Synkra AIOS: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aios": "bin/aios.js",
@@ -18,6 +18,9 @@
     ".aios-core/",
     ".claude/CLAUDE.md",
     ".claude/rules/",
+    ".claude/hooks/synapse-engine.js",
+    ".claude/hooks/precompact-session-digest.js",
+    ".claude/hooks/README.md",
     "README.md",
     "LICENSE"
   ],

--- a/packages/installer/src/installer/aios-core-installer.js
+++ b/packages/installer/src/installer/aios-core-installer.js
@@ -324,8 +324,9 @@ async function installAiosCore(options = {}) {
     // BUG-2 fix (INS-1): Install .aios-core dependencies after copy
     // The copied .aios-core/package.json has dependencies (js-yaml, execa, etc.)
     // that must be installed for the activation pipeline to work
-    if (await fs.pathExists(path.join(targetAiosCore, 'package.json'))) {
-      spinner.text = 'Installing .aios-core dependencies...';
+    const aiosCorePackageJson = path.join(targetAiosCore, 'package.json');
+    if (await fs.pathExists(aiosCorePackageJson)) {
+      spinner.text = 'Installing .aios-core dependencies (js-yaml, etc.)...';
       try {
         const { exec } = require('child_process');
         const { promisify } = require('util');
@@ -334,8 +335,11 @@ async function installAiosCore(options = {}) {
           cwd: targetAiosCore,
           timeout: 60000,
         });
+        spinner.succeed('Installed .aios-core dependencies');
+        spinner.start('Finishing installation...');
       } catch (depError) {
-        // Non-fatal: dependencies may already exist or network unavailable
+        spinner.warn(`Could not install .aios-core dependencies: ${depError.message}`);
+        spinner.start('Continuing installation...');
         result.errors.push(`Dependencies warning: ${depError.message}`);
       }
     }


### PR DESCRIPTION
## Summary
- `.claude/hooks/` was missing from `package.json` `files` array, causing hooks to be excluded from npm package
- `copyClaudeHooksFolder()` silently returned empty because source didn't exist in published package
- Improved `npm install --production` feedback with spinner succeed/warn messages
- Bumps version to 4.0.2

## Root Cause
The v4.0.1 installer code correctly implemented `copyClaudeHooksFolder()` and `npm install --production`, but the npm package never included `.claude/hooks/` because it wasn't in the `files` whitelist.

## Changes
| File | Change |
|------|--------|
| `package.json` | Added `.claude/hooks/{synapse-engine.js,precompact-session-digest.js,README.md}` to `files` |
| `aios-core-installer.js` | Added spinner succeed/warn feedback for dependency installation |
| `install-manifest.yaml` | Regenerated |

## Test plan
- [ ] `npm pack --dry-run` shows `.claude/hooks/` files
- [ ] `npx aios-core install` in fresh project creates `.claude/hooks/`
- [ ] `npx aios-core install` installs `.aios-core/node_modules/js-yaml`
- [ ] Agent activation works without `Cannot find module 'js-yaml'` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 4.0.2
  * Updated manifest and file registry entries

* **Bug Fixes**
  * Enhanced dependency installation process with improved error messaging and handling during setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->