### PR TITLE
feat(hooks): add Stop hook for mandatory session handoff enforcement

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -250,6 +250,7 @@ Seguir Conventional Commits:
 - Atualize checkboxes imediatamente após completar tasks
 - Mantenha contexto da story atual sendo trabalhada
 - Salve estado importante antes de operações longas
+- **MANDATORY**: Crie handoff em `docs/sessions/YYYY-MM/handoff-YYYY-MM-DD-<tema>.md` após QUALQUER git commit/push — enforced pelo Stop hook
 
 ### Recuperação de Erros
 - Sempre forneça sugestões de recuperação para falhas

--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -112,7 +112,7 @@ Garante que um handoff seja criado sempre que houver commits/pushes na sessão.
 2. Um modelo LLM analisa a conversa e verifica:
    - Se houve `git commit` ou `git push` via Bash tool
    - Se um arquivo `docs/sessions/*/handoff-*.md` foi criado via Write tool
-3. Se houve commits mas **não** houve handoff → `decision='block'`
+3. Se houve commits, mas **não** houve handoff → `decision='block'`
 4. Se não houve commits ou handoff já existe → `decision='approve'`
 
 **Por que Stop e não PreToolUse?**
@@ -125,7 +125,7 @@ Garante que um handoff seja criado sempre que houver commits/pushes na sessão.
 O Stop hook resolve um problema diferente: enforcement de **obrigações pós-trabalho**. Não é sobre impedir uma ação, é sobre garantir que algo foi feito antes de encerrar.
 
 **Cenários:**
-```
+```text
 Sessão sem commits        → approve (sem interferência)
 Commits + handoff criado  → approve (obrigação cumprida)
 Commits SEM handoff       → block   (agente forçado a criar handoff)


### PR DESCRIPTION
## Problema

O CLAUDE.md do AIOS inclui a regra:

> *"Crie handoff em `docs/sessions/YYYY-MM/` at end of session"*

Na prática, essa regra **nunca é cumprida espontaneamente** porque:

1. **"End of session" é ambíguo** — o Claude não sabe quando a sessão vai acabar. O usuário simplesmente para de mandar mensagens, fecha o terminal, ou o contexto estoura
2. **É puramente advisory** — depende de "boa vontade" do agente, sem enforcement automatizado
3. **Não tem gatilho concreto** — diferente de um `PreToolUse` hook que intercepta ações específicas, não existe um evento de "fim de sessão" para se conectar

Resultado: handoffs são esquecidos, contexto entre sessões se perde, e a rastreabilidade do projeto sofre.

## Solução

Usar um **Stop hook** (tipo de hook do Claude Code que roda quando o agente tenta encerrar sua resposta) com `type: "prompt"` para:

1. Analisar a conversa e detectar se houve `git commit` ou `git push`
2. Verificar se um handoff (`docs/sessions/*/handoff-*.md`) foi criado na sessão
3. **Bloquear** o encerramento se commits existem sem handoff correspondente
4. **Aprovar** silenciosamente se não houve commits ou se o handoff já foi criado

Isso muda o gatilho de **"end of session" (vago)** para **"fez commit/push" (concreto e detectável)**.

## Implementação

Configuração do Stop hook em `settings.json`:

```json
{
  "hooks": {
    "Stop": [
      {
        "matcher": "",
        "hooks": [
          {
            "type": "prompt",
            "prompt": "Review the conversation. If ANY git commits or git pushes were executed (via Bash tool with 'git commit' or 'git push' in the command), check if a handoff document was created in docs/sessions/ during this session (via Write tool creating a file matching 'docs/sessions/*/handoff-*.md'). If commits/pushes happened but NO handoff was created, return decision='block' with reason='Handoff obrigatório: crie um handoff em docs/sessions/YYYY-MM/handoff-YYYY-MM-DD-<tema>.md antes de encerrar.'. Otherwise return decision='approve'."
          }
        ]
      }
    ]
  }
}
```

## Como funciona na prática

```
Sessão sem commits        → Stop hook aprova → encerra normalmente
Commits + handoff criado  → Stop hook aprova → encerra normalmente
Commits SEM handoff       → Stop hook BLOQUEIA → agente cria handoff → tenta de novo → aprova
```

## Por que Stop hook (e não PreToolUse)?

O AIOS já tem 12 hooks `PreToolUse` em `.claude/hooks/` que interceptam ações **antes** de acontecerem (read-protection, sql-governance, etc).

O Stop hook resolve um problema diferente: enforcement de **obrigações pós-trabalho**. Não é sobre impedir uma ação, é sobre garantir que algo foi feito antes de encerrar.

| Tipo | Quando roda | O que resolve |
|------|------------|---------------|
| `PreToolUse` | Antes de uma tool call | Impedir ações proibidas |
| `Stop` | Quando agente tenta encerrar | Garantir que obrigações foram cumpridas |

## Alterações

- `.claude/CLAUDE.md` — Adicionada regra MANDATORY de handoff na seção Gerenciamento de Sessão
- `.claude/hooks/README.md` — Documentação do Stop hook, configuração, e diagrama de arquitetura atualizado

## Testado em

- Projeto real (Flowi/Blessy) — bloqueia corretamente quando handoff ausente, aprova quando presente ou sem commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing the mandatory handoff procedure required after git commits and pushes.

* **Chores**
  * Introduced an enforcement check that requires creating a handoff document after commit/push; operations are blocked until a valid handoff is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->