### PR TITLE
docs: clarify installation steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,17 @@ Se é sua primeira vez no AIOS, siga este caminho linear:
 
 1. Instale em um projeto novo ou existente:
 ```bash
-# novo projeto
+# novo projeto (cria a pasta automaticamente)
 npx aios-core init meu-projeto
+cd meu-projeto
 
-# projeto existente
+# ou em projeto existente
 cd seu-projeto
 npx aios-core install
 ```
+
+> **O que `npx aios-core init` faz?** O `npx` baixa e executa o pacote `aios-core` sem instalar globalmente. O comando `init` inicia um assistente interativo que cria a pasta do projeto, configura o framework (agentes, tasks, workflows), detecta sua IDE e instala as dependências — tudo em um único passo.
+
 2. Escolha sua IDE/CLI e o caminho de ativação:
 - Claude Code: `/agent-name`
 - Gemini CLI: `/aios-menu` → `/aios-<agent>`


### PR DESCRIPTION
## Summary
- Adds `cd meu-projeto` step after `npx aios-core init` for new projects
- Adds blockquote explaining what `npx aios-core init` does (npx, assistente interativo, IDE detection)
- Helps first-time users understand the complete flow

## Context
First-time users were confused about the installation sequence. This makes the "Comece Aqui" section self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the initialization process by explaining what the setup command does: automatically creates the project folder, configures the framework, detects your IDE, and installs dependencies.
  * Updated installation instructions to reflect automatic folder creation with a subsequent navigation step into the new project directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->