### PR TITLE
feat: sync devops agent with update-aios, pr-aios, publish-npm commands

### DIFF
--- a/.aios-core/development/agents/devops.md
+++ b/.aios-core/development/agents/devops.md
@@ -156,6 +156,15 @@ commands:
   - name: cleanup
     visibility: [full, quick]
     description: 'Identify and remove stale branches/files'
+  - name: update-aios
+    visibility: [full, quick, key]
+    description: 'Git-native sync of AIOS framework from upstream repository'
+  - name: pr-aios
+    visibility: [full, quick, key]
+    description: 'Create PR from local customizations to upstream AIOS repo'
+  - name: publish-npm
+    visibility: [full, quick]
+    description: 'npm publishing pipeline (preview → latest)'
   - name: init-project-status
     visibility: [full]
     description: 'Initialize dynamic project status tracking (Story 6.1.2.4)'
@@ -233,6 +242,10 @@ dependencies:
     - ci-cd-configuration.md
     - github-devops-repository-cleanup.md
     - release-management.md
+    # AIOS Framework Management
+    - update-aios.md
+    - pr-aios.md
+    - publish-npm.md
     # MCP Management Tasks [Story 6.14]
     - search-mcp.md
     - add-mcp.md


### PR DESCRIPTION
## Summary

- Adds 3 missing commands to devops agent: `*update-aios`, `*pr-aios`, `*publish-npm`
- Adds corresponding task dependencies in the dependencies section

### Files Modified

- `.aios-core/development/agents/devops.md` — 3 new commands + 3 task dependencies

## Context

The devops agent had these tasks available (`update-aios.md`, `pr-aios.md`, `publish-npm.md`) but they were not registered as commands or dependencies in the agent definition.

## Test Plan

- [x] Verified commands appear in `*help` output
- [x] Verified task files exist and are referenced correctly

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `update-aios` command for Git-native synchronization with upstream AIOS framework
  * Added `pr-aios` command to create pull requests from local customizations
  * Added `publish-npm` command for npm publishing pipeline (preview → latest)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->