### PR TITLE
feat: sync devops agent with new commands

### DIFF
--- a/.aios-core/development/agents/devops.md
+++ b/.aios-core/development/agents/devops.md
@@ -156,6 +156,15 @@ commands:
   - name: cleanup
     visibility: [full, quick]
     description: 'Identify and remove stale branches/files'
+  - name: update-aios
+    visibility: [full, quick, key]
+    description: 'Git-native sync of AIOS framework from upstream repository'
+  - name: pr-aios
+    visibility: [full, quick, key]
+    description: 'Create PR from local customizations to upstream AIOS repo'
+  - name: publish-npm
+    visibility: [full, quick]
+    description: 'npm publishing pipeline (preview → latest)'
   - name: init-project-status
     visibility: [full]
     description: 'Initialize dynamic project status tracking (Story 6.1.2.4)'
@@ -233,6 +242,10 @@ dependencies:
     - ci-cd-configuration.md
     - github-devops-repository-cleanup.md
     - release-management.md
+    # AIOS Framework Management
+    - update-aios.md
+    - pr-aios.md
+    - publish-npm.md
     # MCP Management Tasks [Story 6.14]
     - search-mcp.md
     - add-mcp.md


### PR DESCRIPTION
## Summary

- Syncs devops agent definition with 3 new commands (`*update-aios`, `*pr-aios`, `*publish-npm`) and their task dependencies

### Files Modified

- `.aios-core/development/agents/devops.md` — added commands + dependencies

## Test Plan

- [x] Tested locally in marketing-strategist project
- [x] Commands visible in `*help` output

---

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Three new DevOps commands added: update-aios, pr-aios, and publish-npm.
  * Corresponding documentation updated to support the new commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->