### PR TITLE
fix(updater): use correct npm package name and guard against null version

### DIFF
--- a/packages/installer/src/updater/index.js
+++ b/packages/installer/src/updater/index.js
@@ -19,7 +19,7 @@
 const fs = require('fs-extra');
 const path = require('path');
 const https = require('https');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 const { hashFile, hashesMatch } = require('../installer/file-hasher');
 const { PostInstallValidator, formatReport: formatValidationReport } = require('../installer/post-install-validator');
 
@@ -47,16 +47,16 @@ const FileAction = {
 };
 
 /**
- * AIOS Updater Class
- * Handles intelligent updates while preserving user customizations
- */
-/**
  * Published npm package name.
  * The package is published as unscoped 'aios-core' on the npm registry.
  * @constant {string}
  */
 const NPM_PACKAGE_NAME = 'aios-core';
 
+/**
+ * AIOS Updater Class
+ * Handles intelligent updates while preserving user customizations
+ */
 class AIOSUpdater {
   /**
    * Create a new AIOSUpdater instance
@@ -598,11 +598,11 @@ class AIOSUpdater {
     }
 
     try {
-      // Use npm to update the package
-      const cmd = `npm install ${NPM_PACKAGE_NAME}@${targetVersion} --save-exact`;
-      this.log(`Running: ${cmd}`);
+      // Use npm to update the package (execFileSync avoids shell injection)
+      const args = ['install', `${NPM_PACKAGE_NAME}@${targetVersion}`, '--save-exact'];
+      this.log(`Running: npm ${args.join(' ')}`);
 
-      execSync(cmd, {
+      execFileSync('npm', args, {
         cwd: this.projectRoot,
         stdio: this.options.verbose ? 'inherit' : 'pipe',
         timeout: 120000, // 2 minutes


### PR DESCRIPTION
## Summary

- Fixes `aios-core update` failing with `npm error 404 Not Found - @synkra/aios-core`
- Fixes `aios-core update --force` trying to install `@synkra/aios-core@null`
- The published npm package is `aios-core` (unscoped), not `@synkra/aios-core`

## Root Cause

The updater module (`packages/installer/src/updater/index.js`) had `@synkra/aios-core` hardcoded in 4 places:

| Location | Impact |
|----------|--------|
| Line 202: Registry URL | Version check hits wrong endpoint, returns null |
| Line 168: node_modules path | Fallback version detection fails |
| Line 121: Error message | Misleading error shown to user |
| Line 590: npm install command | `npm install @synkra/aios-core@null` → 404 |

## Changes

- Extracted `NPM_PACKAGE_NAME` constant (`'aios-core'`) to prevent future drift
- Fixed all 4 hardcoded references to use the constant
- Added null version guard in `applyUpdate()` — if version resolution fails, it now returns a clear error instead of passing `null` to npm

## Before (broken)
```
[AIOSUpdater] Running: npm install @synkra/aios-core@null --save-exact
npm error 404 Not Found - GET https://registry.npmjs.org/@synkra%2faios-core
```

## After (fixed)
```
[AIOSUpdater] Running: npm install aios-core@4.2.13 --save-exact
✅ Updated to v4.2.13
```

## Test plan

- [ ] Run `npx aios-core update --check` — should correctly detect installed vs latest version
- [ ] Run `npx aios-core update --force --verbose` — should install from correct package
- [ ] Verify offline/error scenarios show clear error messages

Closes #174
Related: #159


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better validation to detect missing/invalid target versions and return clearer, actionable errors before applying updates.
  * Error messages now consistently reference the updater package when registry/offline checks or version fetches fail.

* **Chores**
  * Safer update execution path to reduce command-injection risk and ensure consistent installs.
  * Unified package name usage in user-facing messages and version checks for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->