### PR TITLE
test(ide-sync): add redirect-generator unit test coverage

### DIFF
--- a/tests/ide-sync/redirect-generator.test.js
+++ b/tests/ide-sync/redirect-generator.test.js
@@ -158,6 +158,7 @@ describe('redirect-generator', () => {
       const redirects = generateAllRedirects({ 'dry-old': 'dry-new' }, tmpDir, 'full-markdown-yaml');
       const result = writeRedirects(redirects, true);
 
+      // In dry-run, written tracks what *would* be written, but no file is created
       expect(result.written).toHaveLength(1);
       expect(fs.existsSync(path.join(tmpDir, 'dry-old.md'))).toBe(false);
     });
@@ -172,12 +173,14 @@ describe('redirect-generator', () => {
     });
 
     it('should handle write errors gracefully', () => {
+      // Use os.devNull for cross-platform compatibility
+      const impossiblePath = path.join(os.devNull, 'impossible', 'bad.md');
       const redirects = [
         {
           oldId: 'bad',
           newId: 'target',
           filename: 'bad.md',
-          path: '/dev/null/impossible/bad.md',
+          path: impossiblePath,
           content: 'test',
         },
       ];


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for `redirect-generator.js` which previously had **zero test coverage**
- 20 test cases covering all 6 exported functions: `DEFAULT_REDIRECTS`, `generateRedirectContent`, `generateRedirect`, `generateAllRedirects`, `writeRedirects`, `getRedirectFilenames`
- Tests cover all 4 format variations (`full-markdown-yaml`, `xml-tagged-markdown`, `condensed-rules`, `cursor-style`), dry-run mode, filesystem writes, error handling, and edge cases

## Test plan

- [x] All 20 tests pass locally (`npx jest tests/ide-sync/redirect-generator.test.js`)
- [x] Follows existing test patterns from `gemini-commands.test.js` and `transformers.test.js`
- [x] Uses temp directories for filesystem isolation
- [x] Cross-platform write error test using `os.devNull`
- [ ] CI pipeline validation

Closes #194
Refs #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite validating redirect generation functionality. Coverage includes redirect structure and properties, content formatting across multiple formats, file operations with error handling and dry-run mode support, configuration management and fallback behavior, filename derivation logic, batch operations, and edge cases for empty or invalid configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->