### PR TITLE
chore(ci): update quarterly-gap-audit to latest GitHub Actions

### DIFF
--- a/.github/workflows/quarterly-gap-audit.yml
+++ b/.github/workflows/quarterly-gap-audit.yml
@@ -12,12 +12,13 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
+          cache: 'npm'
 
       - name: Install dependencies
         run: npm ci
@@ -46,7 +47,7 @@ jobs:
           echo "gap_count=$(cat outputs/architecture-map/reports/gap-count.txt)" >> $GITHUB_OUTPUT
 
       - name: Upload audit artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gap-audit-${{ github.run_number }}
           path: |
@@ -56,7 +57,7 @@ jobs:
             outputs/architecture-map/reports/gap-trend-history.json
 
       - name: Create GitHub issue
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary

- Update `quarterly-gap-audit.yml` to use latest GitHub Actions versions
- Upgrade `actions/checkout`, `actions/setup-node`, `actions/upload-artifact` from v3 to v4
- Upgrade `actions/github-script` from v6 to v7
- Add `cache: 'npm'` to `setup-node` step for faster CI runs (consistent with all other workflows)

## Test plan

- [x] All changes are version bumps — no logic changes
- [x] Consistent with all other workflow files in the repo
- [ ] CI pipeline validation

Closes #197