### PR TITLE
docs: fix broken documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Synkra AIOS
 
-> **[Versao em Portugues](CONTRIBUTING-PT.md)**
+> **[Versao em Portugues](docs/pt/contributing.md)**
 
 Welcome to AIOS! Thank you for your interest in contributing. This guide will help you understand our development workflow, contribution process, and how to submit your changes.
 
@@ -500,7 +500,7 @@ git push --force-with-lease
 
 ### Q: Can I contribute in Portuguese?
 
-**A:** Yes! We accept PRs in Portuguese. See [CONTRIBUTING-PT.md](CONTRIBUTING-PT.md).
+**A:** Yes! We accept PRs in Portuguese. See [CONTRIBUTING-PT](docs/pt/contributing.md).
 
 ### Q: How do I become a maintainer?
 

--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ O Synkra AIOS vem com 11 agentes especializados:
 ### Guias Essenciais
 
 - 📖 **[Guia do Usuário](docs/guides/user-guide.md)** - Passo a passo completo desde a concepção até a conclusão do projeto
-- 🏗️ **[Arquitetura Principal](docs/architecture/ARCHITECTURE-INDEX.md)** - Mergulho técnico profundo e design do sistema
+- 🏗️ **[Arquitetura Principal](docs/architecture/AIOS-VISUAL-OVERVIEW.md)** - Mergulho técnico profundo e design do sistema
 - 🚀 **[Guia de Squads](docs/guides/squads-guide.md)** - Estenda o AIOS para qualquer domínio além do desenvolvimento de software
 
 ### Documentação Adicional
@@ -488,7 +488,7 @@ O Synkra AIOS vem com 11 agentes especializados:
 - 📋 **[Primeiros Passos](docs/getting-started.md)** - Tutorial passo a passo para iniciantes
 - 🔧 **[Solução de Problemas](docs/troubleshooting.md)** - Soluções para problemas comuns
 - 🎯 **[Princípios Orientadores](docs/GUIDING-PRINCIPLES.md)** - Filosofia e melhores práticas do AIOS
-- 🏛️ **[Visão Geral da Arquitetura](docs/architecture/ARCHITECTURE-INDEX.md)** - Visão detalhada da arquitetura do sistema
+- 🏛️ **[Visão Geral da Arquitetura](docs/architecture/AIOS-VISUAL-OVERVIEW.md)** - Visão detalhada da arquitetura do sistema
 - ⚙️ **[Guia de Ajuste de Performance](docs/performance-tuning-guide.md)** - Otimize seu fluxo de trabalho AIOS
 - 🔒 **[Melhores Práticas de Segurança](docs/security-best-practices.md)** - Segurança e proteção de dados
 - 🔄 **[Guia de Migração](docs/migration-guide.md)** - Migração de versões anteriores

--- a/docs/ide-integration.md
+++ b/docs/ide-integration.md
@@ -468,10 +468,9 @@ npm run sync:ide:cursor
 
 ## Related Documentation
 
-- [Platform Guides](./platforms/README.md)
-- [Claude Code Guide](./platforms/claude-code.md)
-- [Cursor Guide](./platforms/cursor.md)
-- [Agent Reference Guide](./agent-reference-guide.md)
+- [Claude Code Guide](./pt/platforms/claude-code.md)
+- [Cursor Guide](./pt/platforms/cursor.md)
+- [Agent Selection Guide](./guides/agent-selection-guide.md)
 - [MCP Global Setup](./guides/mcp-global-setup.md)
 
 ---


### PR DESCRIPTION
## Summary

- Fix 6 broken documentation links across `docs/ide-integration.md`, `CONTRIBUTING.md`, and `README.md` that point to non-existent files
- All links now resolve to valid, existing files in the repository

## Changes

### `docs/ide-integration.md`
- Removed `./platforms/README.md` link (directory does not exist)
- Updated `./platforms/claude-code.md` and `./platforms/cursor.md` to `./pt/platforms/claude-code.md` and `./pt/platforms/cursor.md`
- Replaced `./agent-reference-guide.md` with `./guides/agent-selection-guide.md`

### `CONTRIBUTING.md`
- Updated both references from `CONTRIBUTING-PT.md` (non-existent) to `docs/pt/contributing.md` (actual Portuguese version)

### `README.md`
- Updated both `docs/architecture/ARCHITECTURE-INDEX.md` references to `docs/architecture/AIOS-VISUAL-OVERVIEW.md` (existing architecture overview)

## Test plan

- [x] Verify all updated links point to files that exist in the repository
- [ ] Click each link on GitHub to confirm they render correctly

Closes #204

cc @Pedrovaleriolopez


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated documentation links to point to current file locations
- Added Portuguese language documentation links to enhance accessibility across guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->