### PR TITLE
ci: add missing permissions blocks to 4 workflow files

### DIFF
--- a/.github/workflows/macos-testing.yml
+++ b/.github/workflows/macos-testing.yml
@@ -32,6 +32,9 @@ concurrency:
   group: macos-testing-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   # Job 1: Intel Mac Testing
   test-intel-mac:
@@ -213,6 +216,9 @@ jobs:
     runs-on: macos-latest
     needs: [test-intel-mac, test-apple-silicon, test-error-recovery]
     if: always()
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,6 +33,9 @@ concurrency:
   group: npm-publish-${{ github.ref }}
   cancel-in-progress: false  # Never cancel publishing in progress
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: '20'
   NPM_REGISTRY: 'https://registry.npmjs.org/'
@@ -342,6 +345,8 @@ jobs:
     needs: [build, publish, publish-aios-install]
     if: github.event_name == 'release' && (needs.publish.result == 'success' || needs.publish-aios-install.result == 'success')
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/publish-pro.yml
+++ b/.github/workflows/publish-pro.yml
@@ -26,6 +26,9 @@ on:
     tags:
       - 'pro-v*'
 
+permissions:
+  contents: read
+
 jobs:
   # ─────────────────────────────────────────────────────────────────────────────
   # Quality Gates - Must pass before publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,9 @@ concurrency:
   group: test-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: '20'
 


### PR DESCRIPTION
## Summary

- Add explicit `permissions` blocks to 4 workflow files that were missing them, following [GitHub's security hardening recommendations](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-the-permissions-key)
- Apply the principle of least privilege: `contents: read` at the top level, with job-level escalations only where needed
- Complements PR #192 which addresses the `quarterly-gap-audit.yml` workflow

## Changes

| Workflow | Top-Level Permission | Job-Level Escalation |
|----------|---------------------|----------------------|
| `test.yml` | `contents: read` | None needed |
| `npm-publish.yml` | `contents: read` | `contents: write` on `create-release-notes` (updates GitHub releases via `github-script`) |
| `macos-testing.yml` | `contents: read` | `contents: read` + `pull-requests: write` on `generate-report` (posts PR comments via `github-script`) |
| `publish-pro.yml` | `contents: read` | `publish` job already had `contents: write` |

### Why This Matters

Without explicit `permissions`, workflows inherit the default token permissions configured in the repository settings. By explicitly declaring the minimum required permissions:

1. **Defense in depth** - Even if a dependency is compromised, the token has limited scope
2. **Transparency** - Reviewers can see exactly what permissions each workflow needs
3. **Consistency** - Aligns these 4 files with the 9 other workflows that already declare permissions

## Test plan

- [ ] Verify YAML syntax is valid (no indentation errors)
- [ ] Confirm `test.yml` jobs still pass with `contents: read`
- [ ] Confirm `npm-publish.yml` jobs function correctly (publish uses `NPM_TOKEN` secret, not `GITHUB_TOKEN`)
- [ ] Confirm `macos-testing.yml` PR comment creation still works with job-level `pull-requests: write`
- [ ] Confirm `publish-pro.yml` publish job still works with existing job-level `contents: write`

Closes #210
cc @Pedrovaleriolopez