### PR TITLE
test: add unit tests for session, manifest, and pipeline collectors

### DIFF
--- a/tests/synapse/diagnostics/manifest-collector.test.js
+++ b/tests/synapse/diagnostics/manifest-collector.test.js
@@ -1,0 +1,150 @@
+/**
+ * Tests for Manifest Collector
+ * @see .aios-core/core/synapse/diagnostics/collectors/manifest-collector.js
+ */
+
+'use strict';
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+  readdirSync: jest.fn().mockReturnValue([]),
+  statSync: jest.fn().mockReturnValue({ isDirectory: () => false }),
+}));
+
+jest.mock('../../../.aios-core/core/synapse/domain/domain-loader', () => ({
+  parseManifest: jest.fn().mockReturnValue({ domains: {} }),
+}));
+
+const fs = require('fs');
+const { parseManifest } = require('../../../.aios-core/core/synapse/domain/domain-loader');
+const { collectManifestIntegrity } = require('../../../.aios-core/core/synapse/diagnostics/collectors/manifest-collector');
+
+describe('collectManifestIntegrity', () => {
+  const ROOT = '/test/project';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fs.existsSync.mockReturnValue(false);
+    fs.readdirSync.mockReturnValue([]);
+    parseManifest.mockReturnValue({ domains: {} });
+  });
+
+  it('should return entries and orphanedFiles arrays', () => {
+    const result = collectManifestIntegrity(ROOT);
+    expect(result).toHaveProperty('entries');
+    expect(result).toHaveProperty('orphanedFiles');
+    expect(Array.isArray(result.entries)).toBe(true);
+    expect(Array.isArray(result.orphanedFiles)).toBe(true);
+  });
+
+  it('should return empty entries when no domains in manifest', () => {
+    const result = collectManifestIntegrity(ROOT);
+    expect(result.entries).toHaveLength(0);
+  });
+
+  it('should PASS when domain file exists', () => {
+    parseManifest.mockReturnValue({
+      domains: {
+        constitution: { file: 'constitution.md', state: 'active' },
+      },
+    });
+    fs.existsSync.mockReturnValue(true);
+
+    const result = collectManifestIntegrity(ROOT);
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].status).toBe('PASS');
+    expect(result.entries[0].fileExists).toBe(true);
+  });
+
+  it('should FAIL when domain file is missing', () => {
+    parseManifest.mockReturnValue({
+      domains: {
+        constitution: { file: 'constitution.md', state: 'active' },
+      },
+    });
+    fs.existsSync.mockReturnValue(false);
+
+    const result = collectManifestIntegrity(ROOT);
+    expect(result.entries[0].status).toBe('FAIL');
+    expect(result.entries[0].fileExists).toBe(false);
+  });
+
+  it('should include trigger info in inManifest field', () => {
+    parseManifest.mockReturnValue({
+      domains: {
+        agent: { file: 'agent.md', state: 'active', agentTrigger: 'dev' },
+      },
+    });
+    fs.existsSync.mockReturnValue(true);
+
+    const result = collectManifestIntegrity(ROOT);
+    expect(result.entries[0].inManifest).toContain('trigger=dev');
+  });
+
+  it('should include ALWAYS_ON flag', () => {
+    parseManifest.mockReturnValue({
+      domains: {
+        global: { file: 'global.md', state: 'active', alwaysOn: true },
+      },
+    });
+    fs.existsSync.mockReturnValue(true);
+
+    const result = collectManifestIntegrity(ROOT);
+    expect(result.entries[0].inManifest).toContain('ALWAYS_ON');
+  });
+
+  it('should detect orphaned files not in manifest', () => {
+    parseManifest.mockReturnValue({ domains: {} });
+    fs.readdirSync.mockReturnValue(['orphan.md', 'manifest', '.gitignore']);
+    fs.statSync.mockReturnValue({ isDirectory: () => false });
+
+    const result = collectManifestIntegrity(ROOT);
+    expect(result.orphanedFiles).toContain('orphan.md');
+  });
+
+  it('should not flag manifest file as orphaned', () => {
+    parseManifest.mockReturnValue({ domains: {} });
+    fs.readdirSync.mockReturnValue(['manifest']);
+    fs.statSync.mockReturnValue({ isDirectory: () => false });
+
+    const result = collectManifestIntegrity(ROOT);
+    expect(result.orphanedFiles).not.toContain('manifest');
+  });
+
+  it('should not flag .gitignore as orphaned', () => {
+    parseManifest.mockReturnValue({ domains: {} });
+    fs.readdirSync.mockReturnValue(['.gitignore']);
+
+    const result = collectManifestIntegrity(ROOT);
+    expect(result.orphanedFiles).not.toContain('.gitignore');
+  });
+
+  it('should not flag directories as orphaned', () => {
+    parseManifest.mockReturnValue({ domains: {} });
+    fs.readdirSync.mockReturnValue(['sessions']);
+    fs.statSync.mockReturnValue({ isDirectory: () => true });
+
+    const result = collectManifestIntegrity(ROOT);
+    expect(result.orphanedFiles).not.toContain('sessions');
+  });
+
+  it('should handle readdir errors gracefully', () => {
+    parseManifest.mockReturnValue({ domains: {} });
+    fs.readdirSync.mockImplementation(() => { throw new Error('ENOENT'); });
+
+    const result = collectManifestIntegrity(ROOT);
+    expect(result.orphanedFiles).toEqual([]);
+  });
+
+  it('should not flag known domain files as orphaned', () => {
+    parseManifest.mockReturnValue({
+      domains: { constitution: { file: 'constitution.md', state: 'active' } },
+    });
+    fs.existsSync.mockReturnValue(true);
+    fs.readdirSync.mockReturnValue(['constitution.md']);
+    fs.statSync.mockReturnValue({ isDirectory: () => false });
+
+    const result = collectManifestIntegrity(ROOT);
+    expect(result.orphanedFiles).toEqual([]);
+  });
+});

--- a/tests/synapse/diagnostics/pipeline-collector.test.js
+++ b/tests/synapse/diagnostics/pipeline-collector.test.js
@@ -1,0 +1,115 @@
+/**
+ * Tests for Pipeline Collector
+ * @see .aios-core/core/synapse/diagnostics/collectors/pipeline-collector.js
+ */
+
+'use strict';
+
+jest.mock('../../../.aios-core/core/synapse/context/context-tracker', () => ({
+  estimateContextPercent: jest.fn().mockReturnValue(90),
+  calculateBracket: jest.fn().mockReturnValue('FRESH'),
+  getActiveLayers: jest.fn().mockReturnValue({ layers: [0, 1, 2, 3, 4, 5, 6, 7] }),
+}));
+
+const { estimateContextPercent, calculateBracket, getActiveLayers } = require('../../../.aios-core/core/synapse/context/context-tracker');
+const { collectPipelineSimulation } = require('../../../.aios-core/core/synapse/diagnostics/collectors/pipeline-collector');
+
+describe('collectPipelineSimulation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    estimateContextPercent.mockReturnValue(90);
+    calculateBracket.mockReturnValue('FRESH');
+    getActiveLayers.mockReturnValue({ layers: [0, 1, 2, 3, 4, 5, 6, 7] });
+  });
+
+  it('should return bracket, contextPercent, and layers', () => {
+    const result = collectPipelineSimulation(5, 'dev', {});
+    expect(result).toHaveProperty('bracket');
+    expect(result).toHaveProperty('contextPercent');
+    expect(result).toHaveProperty('layers');
+  });
+
+  it('should pass promptCount to estimateContextPercent', () => {
+    collectPipelineSimulation(10, null, {});
+    expect(estimateContextPercent).toHaveBeenCalledWith(10);
+  });
+
+  it('should default promptCount to 0 when null', () => {
+    collectPipelineSimulation(null, null, {});
+    expect(estimateContextPercent).toHaveBeenCalledWith(0);
+  });
+
+  it('should return all 8 layers (L0-L7)', () => {
+    const result = collectPipelineSimulation(5, null, {});
+    expect(result.layers).toHaveLength(8);
+  });
+
+  it('should use LAYER_NAMES for layer labels', () => {
+    const result = collectPipelineSimulation(5, null, {});
+    expect(result.layers[0].layer).toBe('L0 Constitution');
+    expect(result.layers[1].layer).toBe('L1 Global');
+    expect(result.layers[7].layer).toBe('L7 Star-Command');
+  });
+
+  it('should mark active layers as ACTIVE', () => {
+    const result = collectPipelineSimulation(5, null, {});
+    expect(result.layers[0].expected).toContain('ACTIVE');
+  });
+
+  it('should mark inactive layers as SKIP', () => {
+    getActiveLayers.mockReturnValue({ layers: [0, 1] });
+    const result = collectPipelineSimulation(5, null, {});
+    expect(result.layers[3].expected).toContain('SKIP');
+    expect(result.layers[3].expected).toContain('FRESH');
+  });
+
+  it('should show agent info for L2 when activeAgentId has matching domain', () => {
+    const manifest = {
+      domains: { dev: { agentTrigger: 'dev' } },
+    };
+    const result = collectPipelineSimulation(5, 'dev', manifest);
+    expect(result.layers[2].expected).toContain('agent: dev');
+    expect(result.layers[2].status).toBe('PASS');
+  });
+
+  it('should WARN for L2 when activeAgentId has no matching domain', () => {
+    const manifest = { domains: {} };
+    const result = collectPipelineSimulation(5, 'unknown-agent', manifest);
+    expect(result.layers[2].expected).toContain('no domain for unknown-agent');
+    expect(result.layers[2].status).toBe('WARN');
+  });
+
+  it('should PASS for all layers by default', () => {
+    const result = collectPipelineSimulation(5, null, {});
+    for (const layer of result.layers) {
+      expect(layer.status).toBe('PASS');
+    }
+  });
+
+  it('should return correct bracket from calculateBracket', () => {
+    calculateBracket.mockReturnValue('DEPLETED');
+    const result = collectPipelineSimulation(50, null, {});
+    expect(result.bracket).toBe('DEPLETED');
+  });
+
+  it('should return contextPercent from estimateContextPercent', () => {
+    estimateContextPercent.mockReturnValue(42.5);
+    const result = collectPipelineSimulation(5, null, {});
+    expect(result.contextPercent).toBe(42.5);
+  });
+
+  it('should handle null manifest gracefully', () => {
+    const result = collectPipelineSimulation(5, 'dev', null);
+    expect(result.layers[2].status).toBe('WARN');
+  });
+
+  it('should handle null getActiveLayers return', () => {
+    getActiveLayers.mockReturnValue(null);
+    const result = collectPipelineSimulation(5, null, {});
+    expect(result.layers).toHaveLength(8);
+    // All should be SKIP since no active layers
+    for (const layer of result.layers) {
+      expect(layer.expected).toContain('SKIP');
+    }
+  });
+});

--- a/tests/synapse/diagnostics/session-collector.test.js
+++ b/tests/synapse/diagnostics/session-collector.test.js
@@ -1,0 +1,136 @@
+/**
+ * Tests for Session Collector
+ * @see .aios-core/core/synapse/diagnostics/collectors/session-collector.js
+ */
+
+'use strict';
+
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+  readFileSync: jest.fn(),
+}));
+
+const fs = require('fs');
+const { collectSessionStatus } = require('../../../.aios-core/core/synapse/diagnostics/collectors/session-collector');
+
+describe('collectSessionStatus', () => {
+  const ROOT = '/test/project';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fs.existsSync.mockReturnValue(false);
+  });
+
+  it('should return fields array and raw object', () => {
+    const result = collectSessionStatus(ROOT);
+    expect(result).toHaveProperty('fields');
+    expect(result).toHaveProperty('raw');
+    expect(Array.isArray(result.fields)).toBe(true);
+  });
+
+  it('should have 5 field checks', () => {
+    const result = collectSessionStatus(ROOT);
+    expect(result.fields).toHaveLength(5);
+  });
+
+  it('should check active_agent.id', () => {
+    const result = collectSessionStatus(ROOT);
+    const field = result.fields.find(f => f.field === 'active_agent.id');
+    expect(field).toBeDefined();
+    expect(field.status).toBe('WARN');
+    expect(field.actual).toBe('(none)');
+  });
+
+  it('should check activation_quality', () => {
+    const result = collectSessionStatus(ROOT);
+    const field = result.fields.find(f => f.field === 'activation_quality');
+    expect(field).toBeDefined();
+    expect(field.status).toBe('WARN');
+  });
+
+  it('should check prompt_count', () => {
+    const result = collectSessionStatus(ROOT);
+    const field = result.fields.find(f => f.field === 'prompt_count');
+    expect(field).toBeDefined();
+    expect(field.status).toBe('INFO');
+  });
+
+  it('should check bracket', () => {
+    const result = collectSessionStatus(ROOT);
+    const field = result.fields.find(f => f.field === 'bracket');
+    expect(field).toBeDefined();
+    expect(field.status).toBe('INFO');
+  });
+
+  it('should check _active-agent.json existence', () => {
+    const result = collectSessionStatus(ROOT);
+    const field = result.fields.find(f => f.field === '_active-agent.json');
+    expect(field).toBeDefined();
+    expect(field.status).toBe('WARN');
+    expect(field.actual).toBe('missing');
+  });
+
+  it('should load session by sessionId when provided', () => {
+    fs.existsSync.mockImplementation((p) => p.includes('test-session'));
+    fs.readFileSync.mockReturnValue(JSON.stringify({
+      active_agent: { id: 'dev', activation_quality: 'full' },
+      prompt_count: 5,
+      context: { last_bracket: 'FRESH' },
+    }));
+
+    const result = collectSessionStatus(ROOT, 'test-session');
+    const agentField = result.fields.find(f => f.field === 'active_agent.id');
+    expect(agentField.actual).toBe('dev');
+    expect(agentField.status).toBe('PASS');
+  });
+
+  it('should read bridge data from _active-agent.json', () => {
+    fs.existsSync.mockImplementation((p) => p.includes('_active-agent.json'));
+    fs.readFileSync.mockReturnValue(JSON.stringify({
+      id: 'qa',
+      activation_quality: 'partial',
+    }));
+
+    const result = collectSessionStatus(ROOT);
+    const agentField = result.fields.find(f => f.field === 'active_agent.id');
+    expect(agentField.actual).toBe('qa');
+    expect(agentField.status).toBe('PASS');
+  });
+
+  it('should PASS activation_quality when present', () => {
+    fs.existsSync.mockImplementation((p) => p.includes('_active-agent.json'));
+    fs.readFileSync.mockReturnValue(JSON.stringify({
+      id: 'dev',
+      activation_quality: 'full',
+    }));
+
+    const result = collectSessionStatus(ROOT);
+    const field = result.fields.find(f => f.field === 'activation_quality');
+    expect(field.status).toBe('PASS');
+    expect(field.actual).toBe('full');
+  });
+
+  it('should PASS _active-agent.json when bridge file exists', () => {
+    fs.existsSync.mockImplementation((p) => p.includes('_active-agent.json'));
+    fs.readFileSync.mockReturnValue(JSON.stringify({ id: 'dev' }));
+
+    const result = collectSessionStatus(ROOT);
+    const field = result.fields.find(f => f.field === '_active-agent.json');
+    expect(field.status).toBe('PASS');
+    expect(field.actual).toBe('exists');
+  });
+
+  it('should include raw session and bridgeData', () => {
+    const result = collectSessionStatus(ROOT);
+    expect(result.raw).toHaveProperty('session');
+    expect(result.raw).toHaveProperty('bridgeData');
+  });
+
+  it('should handle malformed JSON gracefully', () => {
+    fs.existsSync.mockReturnValue(true);
+    fs.readFileSync.mockReturnValue('not json');
+
+    const result = collectSessionStatus(ROOT);
+    expect(result.fields).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
## Summary

- Add 39 unit tests for 3 SYNAPSE diagnostic collectors with zero prior coverage
- **session-collector.js** (102 lines): 14 tests covering session loading, bridge file reading, field validation
- **manifest-collector.js** (82 lines): 12 tests covering domain file validation, orphan detection, trigger info
- **pipeline-collector.js** (75 lines): 13 tests covering layer simulation, bracket calculation, agent domain matching

## Test Coverage Highlights

| Collector | Tests | Key Areas |
|-----------|-------|-----------|
| session-collector | 14 | 5 field checks, session ID loading, bridge file, malformed JSON |
| manifest-collector | 12 | PASS/FAIL status, triggers, ALWAYS_ON, orphaned files, readdir errors |
| pipeline-collector | 13 | 8 layers, ACTIVE/SKIP states, L2 agent domain WARN, null handling |

Closes #227

## Test plan

- [x] All 39 tests pass across 3 test files
- [x] All I/O mocked (fs, domain-loader, context-tracker)
- [x] Tests run in < 1s

cc @Pedrovaleriolopez

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for diagnostic modules, including manifest integrity validation, pipeline simulation analysis, and session status collection. Tests cover standard operations, edge cases, and error handling scenarios to ensure diagnostic reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->