### PR TITLE
fix(config): unref setInterval in config-cache to prevent process hang

### DIFF
--- a/.aios-core/core/config/config-cache.js
+++ b/.aios-core/core/config/config-cache.js
@@ -220,12 +220,14 @@ class ConfigCache {
 const globalConfigCache = new ConfigCache();
 
 // Auto cleanup expired entries every minute
-setInterval(() => {
+// .unref() allows Node.js to exit naturally when all other work is done
+const _cacheCleanupTimer = setInterval(() => {
   const cleared = globalConfigCache.clearExpired();
   if (cleared > 0) {
     console.log(`🗑️ Config cache: Cleared ${cleared} expired entries`);
   }
 }, 60 * 1000);
+_cacheCleanupTimer.unref();
 
 module.exports = {
   ConfigCache,


### PR DESCRIPTION
## Summary
- Added `.unref()` to the module-level `setInterval` in `config-cache.js` that runs cache cleanup every 60 seconds
- Without `.unref()`, this timer keeps the Node.js event loop alive indefinitely, preventing the process from exiting after the unified activation pipeline completes
- This caused agent activation (e.g. `@devops`) to appear to hang forever

## Test plan
- [ ] Activate any agent (e.g. `@devops`) and verify the process completes and exits normally
- [ ] Verify config cache cleanup still works during long-running sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal optimization to improve resource management during idle periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->