### PR TITLE
test: add unit tests for health-check core modules

### DIFF
--- a/tests/core/health-check/base-check.test.js
+++ b/tests/core/health-check/base-check.test.js
@@ -1,0 +1,351 @@
+/**
+ * Unit tests for base-check module
+ *
+ * Tests the abstract BaseCheck class and its enums:
+ * CheckSeverity, CheckStatus, CheckDomain, result helpers,
+ * metadata, and healing support.
+ */
+
+const { BaseCheck, CheckSeverity, CheckStatus, CheckDomain } = require('../../../.aios-core/core/health-check/base-check');
+
+// Concrete subclass for testing
+class TestCheck extends BaseCheck {
+  async execute(context) {
+    return this.pass('ok');
+  }
+}
+
+describe('base-check', () => {
+  // ============================================================
+  // Enums
+  // ============================================================
+  describe('CheckSeverity', () => {
+    test('has all severity levels', () => {
+      expect(CheckSeverity.CRITICAL).toBe('CRITICAL');
+      expect(CheckSeverity.HIGH).toBe('HIGH');
+      expect(CheckSeverity.MEDIUM).toBe('MEDIUM');
+      expect(CheckSeverity.LOW).toBe('LOW');
+      expect(CheckSeverity.INFO).toBe('INFO');
+    });
+
+    test('has exactly 5 levels', () => {
+      expect(Object.keys(CheckSeverity)).toHaveLength(5);
+    });
+  });
+
+  describe('CheckStatus', () => {
+    test('has all status values', () => {
+      expect(CheckStatus.PASS).toBe('pass');
+      expect(CheckStatus.FAIL).toBe('fail');
+      expect(CheckStatus.WARNING).toBe('warning');
+      expect(CheckStatus.ERROR).toBe('error');
+      expect(CheckStatus.SKIPPED).toBe('skipped');
+    });
+
+    test('has exactly 5 statuses', () => {
+      expect(Object.keys(CheckStatus)).toHaveLength(5);
+    });
+  });
+
+  describe('CheckDomain', () => {
+    test('has all domain values', () => {
+      expect(CheckDomain.PROJECT).toBe('project');
+      expect(CheckDomain.LOCAL).toBe('local');
+      expect(CheckDomain.REPOSITORY).toBe('repository');
+      expect(CheckDomain.DEPLOYMENT).toBe('deployment');
+      expect(CheckDomain.SERVICES).toBe('services');
+    });
+
+    test('has exactly 5 domains', () => {
+      expect(Object.keys(CheckDomain)).toHaveLength(5);
+    });
+  });
+
+  // ============================================================
+  // BaseCheck constructor
+  // ============================================================
+  describe('constructor', () => {
+    test('throws when instantiated directly', () => {
+      expect(() => new BaseCheck({
+        id: 'test', name: 'Test', domain: 'project', severity: 'HIGH'
+      })).toThrow('BaseCheck is abstract');
+    });
+
+    test('creates instance with required options', () => {
+      const check = new TestCheck({
+        id: 'test-check',
+        name: 'Test Check',
+        domain: 'project',
+        severity: 'HIGH',
+      });
+      expect(check.id).toBe('test-check');
+      expect(check.name).toBe('Test Check');
+      expect(check.domain).toBe('project');
+      expect(check.severity).toBe('HIGH');
+    });
+
+    test('sets default values', () => {
+      const check = new TestCheck({
+        id: 'def', name: 'Def', domain: 'local', severity: 'LOW',
+      });
+      expect(check.description).toBe('');
+      expect(check.timeout).toBe(5000);
+      expect(check.cacheable).toBe(true);
+      expect(check.healingTier).toBe(0);
+      expect(check.tags).toEqual([]);
+    });
+
+    test('accepts optional values', () => {
+      const check = new TestCheck({
+        id: 'opt', name: 'Opt', domain: 'local', severity: 'MEDIUM',
+        description: 'A description',
+        timeout: 10000,
+        cacheable: false,
+        healingTier: 2,
+        tags: ['fast', 'core'],
+      });
+      expect(check.description).toBe('A description');
+      expect(check.timeout).toBe(10000);
+      expect(check.cacheable).toBe(false);
+      expect(check.healingTier).toBe(2);
+      expect(check.tags).toEqual(['fast', 'core']);
+    });
+
+    test('throws when id is missing', () => {
+      expect(() => new TestCheck({
+        name: 'No ID', domain: 'project', severity: 'HIGH',
+      })).toThrow('Check must have an id');
+    });
+
+    test('throws when name is missing', () => {
+      expect(() => new TestCheck({
+        id: 'no-name', domain: 'project', severity: 'HIGH',
+      })).toThrow('Check must have a name');
+    });
+
+    test('throws when domain is missing', () => {
+      expect(() => new TestCheck({
+        id: 'no-dom', name: 'No Domain', severity: 'HIGH',
+      })).toThrow('Check must have a domain');
+    });
+
+    test('throws when severity is missing', () => {
+      expect(() => new TestCheck({
+        id: 'no-sev', name: 'No Severity', domain: 'project',
+      })).toThrow('Check must have a severity');
+    });
+  });
+
+  // ============================================================
+  // execute()
+  // ============================================================
+  describe('execute', () => {
+    test('abstract execute throws in base class', async () => {
+      // Use a minimal subclass that does NOT override execute
+      class NoExecute extends BaseCheck {}
+      const check = new NoExecute({
+        id: 'no-exec', name: 'No Exec', domain: 'project', severity: 'LOW',
+      });
+      await expect(check.execute({})).rejects.toThrow('execute() must be implemented');
+    });
+
+    test('subclass can implement execute', async () => {
+      const check = new TestCheck({
+        id: 'impl', name: 'Impl', domain: 'project', severity: 'LOW',
+      });
+      const result = await check.execute({});
+      expect(result.status).toBe('pass');
+    });
+  });
+
+  // ============================================================
+  // Result helpers
+  // ============================================================
+  describe('pass()', () => {
+    let check;
+    beforeEach(() => {
+      check = new TestCheck({
+        id: 'p', name: 'P', domain: 'project', severity: 'LOW',
+      });
+    });
+
+    test('creates pass result', () => {
+      const result = check.pass('All good');
+      expect(result.status).toBe('pass');
+      expect(result.message).toBe('All good');
+      expect(result.healable).toBe(false);
+      expect(result.healingTier).toBe(0);
+    });
+
+    test('includes details when provided', () => {
+      const result = check.pass('ok', { count: 5 });
+      expect(result.details).toEqual({ count: 5 });
+    });
+
+    test('details default to null', () => {
+      const result = check.pass('ok');
+      expect(result.details).toBeNull();
+    });
+  });
+
+  describe('fail()', () => {
+    let check;
+    beforeEach(() => {
+      check = new TestCheck({
+        id: 'f', name: 'F', domain: 'project', severity: 'HIGH', healingTier: 1,
+      });
+    });
+
+    test('creates fail result', () => {
+      const result = check.fail('Something broke');
+      expect(result.status).toBe('fail');
+      expect(result.message).toBe('Something broke');
+    });
+
+    test('includes options', () => {
+      const result = check.fail('error', {
+        details: { file: 'a.js' },
+        recommendation: 'Fix it',
+        healable: true,
+        healingTier: 2,
+      });
+      expect(result.details).toEqual({ file: 'a.js' });
+      expect(result.recommendation).toBe('Fix it');
+      expect(result.healable).toBe(true);
+      expect(result.healingTier).toBe(2);
+    });
+
+    test('uses instance healingTier as default', () => {
+      const result = check.fail('err');
+      expect(result.healingTier).toBe(1);
+    });
+
+    test('defaults to non-healable', () => {
+      const result = check.fail('err');
+      expect(result.healable).toBe(false);
+      expect(result.recommendation).toBeNull();
+      expect(result.details).toBeNull();
+    });
+  });
+
+  describe('warning()', () => {
+    let check;
+    beforeEach(() => {
+      check = new TestCheck({
+        id: 'w', name: 'W', domain: 'local', severity: 'MEDIUM',
+      });
+    });
+
+    test('creates warning result', () => {
+      const result = check.warning('Watch out');
+      expect(result.status).toBe('warning');
+      expect(result.message).toBe('Watch out');
+    });
+
+    test('includes options', () => {
+      const result = check.warning('warn', {
+        details: { info: true },
+        recommendation: 'Consider this',
+        healable: true,
+        healingTier: 1,
+      });
+      expect(result.details).toEqual({ info: true });
+      expect(result.recommendation).toBe('Consider this');
+      expect(result.healable).toBe(true);
+      expect(result.healingTier).toBe(1);
+    });
+
+    test('defaults to safe values', () => {
+      const result = check.warning('w');
+      expect(result.healable).toBe(false);
+      expect(result.healingTier).toBe(0);
+      expect(result.details).toBeNull();
+      expect(result.recommendation).toBeNull();
+    });
+  });
+
+  describe('error()', () => {
+    let check;
+    beforeEach(() => {
+      check = new TestCheck({
+        id: 'e', name: 'E', domain: 'local', severity: 'CRITICAL',
+      });
+    });
+
+    test('creates error result', () => {
+      const result = check.error('Crash');
+      expect(result.status).toBe('error');
+      expect(result.message).toBe('Crash');
+      expect(result.healable).toBe(false);
+      expect(result.healingTier).toBe(0);
+    });
+
+    test('includes error details', () => {
+      const err = new Error('boom');
+      const result = check.error('Crash', err);
+      expect(result.details.error).toBe('boom');
+      expect(result.details.stack).toBeDefined();
+    });
+
+    test('details null when no error provided', () => {
+      const result = check.error('No err');
+      expect(result.details).toBeNull();
+    });
+  });
+
+  // ============================================================
+  // Metadata & Healing
+  // ============================================================
+  describe('getMetadata()', () => {
+    test('returns complete metadata object', () => {
+      const check = new TestCheck({
+        id: 'meta-check',
+        name: 'Meta Check',
+        description: 'Checks metadata',
+        domain: 'repository',
+        severity: 'INFO',
+        timeout: 3000,
+        cacheable: false,
+        healingTier: 3,
+        tags: ['meta'],
+      });
+      const meta = check.getMetadata();
+      expect(meta).toEqual({
+        id: 'meta-check',
+        name: 'Meta Check',
+        description: 'Checks metadata',
+        domain: 'repository',
+        severity: 'INFO',
+        timeout: 3000,
+        cacheable: false,
+        healingTier: 3,
+        tags: ['meta'],
+      });
+    });
+  });
+
+  describe('isHealable()', () => {
+    test('returns false when healingTier is 0', () => {
+      const check = new TestCheck({
+        id: 'nh', name: 'NH', domain: 'project', severity: 'LOW',
+      });
+      expect(check.isHealable()).toBe(false);
+    });
+
+    test('returns true when healingTier > 0', () => {
+      const check = new TestCheck({
+        id: 'h', name: 'H', domain: 'project', severity: 'LOW', healingTier: 1,
+      });
+      expect(check.isHealable()).toBe(true);
+    });
+  });
+
+  describe('getHealer()', () => {
+    test('returns null by default', () => {
+      const check = new TestCheck({
+        id: 'gh', name: 'GH', domain: 'project', severity: 'LOW',
+      });
+      expect(check.getHealer()).toBeNull();
+    });
+  });
+});

--- a/tests/core/health-check/check-registry.test.js
+++ b/tests/core/health-check/check-registry.test.js
@@ -1,0 +1,273 @@
+/**
+ * Unit tests for check-registry module
+ *
+ * Tests the CheckRegistry class: registration, unregistration,
+ * lookup by id/domain/severity/tag, healable checks, stats, and clear.
+ */
+
+const { BaseCheck, CheckSeverity, CheckDomain } = require('../../../.aios-core/core/health-check/base-check');
+
+// Mock the built-in check modules to prevent loading real files
+jest.mock('../../../.aios-core/core/health-check/checks/project', () => ({}), { virtual: true });
+jest.mock('../../../.aios-core/core/health-check/checks/local', () => ({}), { virtual: true });
+jest.mock('../../../.aios-core/core/health-check/checks/repository', () => ({}), { virtual: true });
+jest.mock('../../../.aios-core/core/health-check/checks/deployment', () => ({}), { virtual: true });
+jest.mock('../../../.aios-core/core/health-check/checks/services', () => ({}), { virtual: true });
+
+const CheckRegistry = require('../../../.aios-core/core/health-check/check-registry');
+
+// Test check subclasses
+class ProjectCheck extends BaseCheck {
+  constructor(id, opts = {}) {
+    super({
+      id,
+      name: opts.name || `Check ${id}`,
+      domain: CheckDomain.PROJECT,
+      severity: opts.severity || CheckSeverity.MEDIUM,
+      healingTier: opts.healingTier || 0,
+      tags: opts.tags || [],
+    });
+  }
+  async execute() { return this.pass('ok'); }
+}
+
+class LocalCheck extends BaseCheck {
+  constructor(id, opts = {}) {
+    super({
+      id,
+      name: opts.name || `Check ${id}`,
+      domain: CheckDomain.LOCAL,
+      severity: opts.severity || CheckSeverity.LOW,
+      healingTier: opts.healingTier || 0,
+      tags: opts.tags || [],
+    });
+  }
+  async execute() { return this.pass('ok'); }
+}
+
+describe('check-registry', () => {
+  let registry;
+
+  beforeEach(() => {
+    registry = new CheckRegistry();
+  });
+
+  // ============================================================
+  // register
+  // ============================================================
+  describe('register', () => {
+    test('registers a valid check', () => {
+      const check = new ProjectCheck('pkg-json');
+      registry.register(check);
+      expect(registry.getCheck('pkg-json')).toBe(check);
+    });
+
+    test('throws for non-BaseCheck instance', () => {
+      expect(() => registry.register({ id: 'fake' })).toThrow('must be an instance of BaseCheck');
+    });
+
+    test('throws for duplicate id', () => {
+      registry.register(new ProjectCheck('dup'));
+      expect(() => registry.register(new ProjectCheck('dup'))).toThrow("already registered");
+    });
+
+    test('indexes check by domain', () => {
+      const check = new ProjectCheck('proj-1');
+      registry.register(check);
+      expect(registry.getChecksByDomain(CheckDomain.PROJECT)).toContain(check);
+    });
+
+    test('indexes check by severity', () => {
+      const check = new ProjectCheck('sev-1', { severity: CheckSeverity.CRITICAL });
+      registry.register(check);
+      expect(registry.getChecksBySeverity(CheckSeverity.CRITICAL)).toContain(check);
+    });
+  });
+
+  // ============================================================
+  // unregister
+  // ============================================================
+  describe('unregister', () => {
+    test('removes a registered check', () => {
+      registry.register(new ProjectCheck('to-remove'));
+      expect(registry.unregister('to-remove')).toBe(true);
+      expect(registry.getCheck('to-remove')).toBeUndefined();
+    });
+
+    test('returns false for non-existent check', () => {
+      expect(registry.unregister('does-not-exist')).toBe(false);
+    });
+
+    test('removes check from domain index', () => {
+      const check = new ProjectCheck('dom-rm');
+      registry.register(check);
+      registry.unregister('dom-rm');
+      expect(registry.getChecksByDomain(CheckDomain.PROJECT)).not.toContain(check);
+    });
+
+    test('removes check from severity index', () => {
+      const check = new ProjectCheck('sev-rm', { severity: CheckSeverity.HIGH });
+      registry.register(check);
+      registry.unregister('sev-rm');
+      expect(registry.getChecksBySeverity(CheckSeverity.HIGH)).not.toContain(check);
+    });
+  });
+
+  // ============================================================
+  // getCheck / getAllChecks
+  // ============================================================
+  describe('getCheck', () => {
+    test('returns check by id', () => {
+      const check = new ProjectCheck('find-me');
+      registry.register(check);
+      expect(registry.getCheck('find-me')).toBe(check);
+    });
+
+    test('returns undefined for unknown id', () => {
+      expect(registry.getCheck('nope')).toBeUndefined();
+    });
+  });
+
+  describe('getAllChecks', () => {
+    test('returns all registered checks as array', () => {
+      registry.register(new ProjectCheck('a'));
+      registry.register(new LocalCheck('b'));
+      const all = registry.getAllChecks();
+      expect(all).toHaveLength(2);
+    });
+
+    test('returns empty array when no checks', () => {
+      registry.clear();
+      expect(registry.getAllChecks()).toEqual([]);
+    });
+  });
+
+  // ============================================================
+  // getChecksByDomain
+  // ============================================================
+  describe('getChecksByDomain', () => {
+    test('returns checks for a specific domain', () => {
+      registry.register(new ProjectCheck('p1'));
+      registry.register(new ProjectCheck('p2'));
+      registry.register(new LocalCheck('l1'));
+
+      const project = registry.getChecksByDomain(CheckDomain.PROJECT);
+      expect(project).toHaveLength(2);
+    });
+
+    test('returns empty array for domain with no checks', () => {
+      expect(registry.getChecksByDomain(CheckDomain.SERVICES)).toEqual([]);
+    });
+  });
+
+  // ============================================================
+  // getChecksBySeverity
+  // ============================================================
+  describe('getChecksBySeverity', () => {
+    test('returns checks for a specific severity', () => {
+      registry.register(new ProjectCheck('c1', { severity: CheckSeverity.CRITICAL }));
+      registry.register(new ProjectCheck('c2', { severity: CheckSeverity.CRITICAL }));
+      registry.register(new LocalCheck('l1', { severity: CheckSeverity.LOW }));
+
+      expect(registry.getChecksBySeverity(CheckSeverity.CRITICAL)).toHaveLength(2);
+      expect(registry.getChecksBySeverity(CheckSeverity.LOW)).toHaveLength(1);
+    });
+
+    test('returns empty array for unused severity', () => {
+      expect(registry.getChecksBySeverity(CheckSeverity.INFO)).toEqual([]);
+    });
+  });
+
+  // ============================================================
+  // getChecksByTag
+  // ============================================================
+  describe('getChecksByTag', () => {
+    test('filters checks by tag', () => {
+      registry.register(new ProjectCheck('t1', { tags: ['fast', 'core'] }));
+      registry.register(new ProjectCheck('t2', { tags: ['slow'] }));
+      registry.register(new LocalCheck('t3', { tags: ['fast'] }));
+
+      const fast = registry.getChecksByTag('fast');
+      expect(fast).toHaveLength(2);
+    });
+
+    test('returns empty when no checks match tag', () => {
+      registry.register(new ProjectCheck('t1', { tags: ['a'] }));
+      expect(registry.getChecksByTag('nonexistent')).toEqual([]);
+    });
+  });
+
+  // ============================================================
+  // getHealableChecks
+  // ============================================================
+  describe('getHealableChecks', () => {
+    test('returns checks with healingTier > 0', () => {
+      registry.register(new ProjectCheck('h1', { healingTier: 1 }));
+      registry.register(new ProjectCheck('h2', { healingTier: 2 }));
+      registry.register(new LocalCheck('h3', { healingTier: 0 }));
+
+      const healable = registry.getHealableChecks();
+      expect(healable).toHaveLength(2);
+    });
+
+    test('filters by maxTier', () => {
+      registry.register(new ProjectCheck('t1', { healingTier: 1 }));
+      registry.register(new ProjectCheck('t2', { healingTier: 2 }));
+      registry.register(new ProjectCheck('t3', { healingTier: 3 }));
+
+      expect(registry.getHealableChecks(1)).toHaveLength(1);
+      expect(registry.getHealableChecks(2)).toHaveLength(2);
+    });
+
+    test('returns empty when no healable checks', () => {
+      registry.register(new ProjectCheck('nh', { healingTier: 0 }));
+      expect(registry.getHealableChecks()).toEqual([]);
+    });
+  });
+
+  // ============================================================
+  // getStats
+  // ============================================================
+  describe('getStats', () => {
+    test('returns complete stats object', () => {
+      registry.register(new ProjectCheck('s1', { severity: CheckSeverity.HIGH, healingTier: 1 }));
+      registry.register(new LocalCheck('s2', { severity: CheckSeverity.LOW }));
+
+      const stats = registry.getStats();
+      expect(stats.total).toBe(2);
+      expect(stats.byDomain[CheckDomain.PROJECT]).toBe(1);
+      expect(stats.byDomain[CheckDomain.LOCAL]).toBe(1);
+      expect(stats.bySeverity[CheckSeverity.HIGH]).toBe(1);
+      expect(stats.healable).toBe(1);
+    });
+
+    test('returns zeros when empty', () => {
+      registry.clear();
+      const stats = registry.getStats();
+      expect(stats.total).toBe(0);
+      expect(stats.healable).toBe(0);
+    });
+  });
+
+  // ============================================================
+  // clear
+  // ============================================================
+  describe('clear', () => {
+    test('removes all checks', () => {
+      registry.register(new ProjectCheck('cl1'));
+      registry.register(new LocalCheck('cl2'));
+      registry.clear();
+
+      expect(registry.getAllChecks()).toEqual([]);
+      expect(registry.getChecksByDomain(CheckDomain.PROJECT)).toEqual([]);
+    });
+
+    test('allows re-registration after clear', () => {
+      const check = new ProjectCheck('re-add');
+      registry.register(check);
+      registry.clear();
+      registry.register(check);
+      expect(registry.getCheck('re-add')).toBe(check);
+    });
+  });
+});

--- a/tests/core/health-check/json-reporter.test.js
+++ b/tests/core/health-check/json-reporter.test.js
@@ -1,0 +1,356 @@
+/**
+ * Unit tests for JSON reporter module
+ *
+ * Tests the JSONReporter class: report generation, domain/issue formatting,
+ * auto-fix formatting, tech debt extraction, sanitization of secrets.
+ */
+
+const JSONReporter = require('../../../.aios-core/core/health-check/reporters/json');
+
+describe('JSONReporter', () => {
+  let reporter;
+
+  const makeCheckResult = (overrides = {}) => ({
+    checkId: 'test-check',
+    name: 'Test Check',
+    domain: 'project',
+    severity: 'MEDIUM',
+    status: 'pass',
+    message: 'All good',
+    recommendation: null,
+    duration: 50,
+    timestamp: '2026-01-01T00:00:00.000Z',
+    fromCache: false,
+    healable: false,
+    healingTier: 0,
+    details: null,
+    ...overrides,
+  });
+
+  const makeReportData = (overrides = {}) => ({
+    checkResults: [makeCheckResult()],
+    scores: {
+      overall: { score: 95, status: 'healthy', issuesCount: 0 },
+      domains: {
+        project: {
+          score: 100,
+          status: 'healthy',
+          summary: 'All project checks passed',
+          checks: [{ name: 'Test Check', status: 'pass', severity: 'MEDIUM' }],
+        },
+      },
+    },
+    healingResults: [],
+    config: { mode: 'quick' },
+    timestamp: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    reporter = new JSONReporter();
+  });
+
+  // ============================================================
+  // Constructor
+  // ============================================================
+  describe('constructor', () => {
+    test('defaults to pretty and sanitized', () => {
+      expect(reporter.pretty).toBe(true);
+      expect(reporter.sanitize).toBe(true);
+    });
+
+    test('can disable pretty printing', () => {
+      const r = new JSONReporter({ output: { pretty: false } });
+      expect(r.pretty).toBe(false);
+    });
+
+    test('can disable sanitization', () => {
+      const r = new JSONReporter({ output: { sanitize: false } });
+      expect(r.sanitize).toBe(false);
+    });
+  });
+
+  // ============================================================
+  // generate
+  // ============================================================
+  describe('generate', () => {
+    test('returns valid JSON string', async () => {
+      const result = await reporter.generate(makeReportData());
+      expect(() => JSON.parse(result)).not.toThrow();
+    });
+
+    test('includes schema and version', async () => {
+      const result = JSON.parse(await reporter.generate(makeReportData()));
+      expect(result.$schema).toBeDefined();
+      expect(result.version).toBe('1.0.0');
+    });
+
+    test('includes overall summary', async () => {
+      const result = JSON.parse(await reporter.generate(makeReportData()));
+      expect(result.overall.score).toBe(95);
+      expect(result.overall.status).toBe('healthy');
+    });
+
+    test('includes mode from config', async () => {
+      const result = JSON.parse(await reporter.generate(makeReportData()));
+      expect(result.mode).toBe('quick');
+    });
+
+    test('defaults mode to quick when not specified', async () => {
+      const data = makeReportData({ config: {} });
+      const result = JSON.parse(await reporter.generate(data));
+      expect(result.mode).toBe('quick');
+    });
+
+    test('returns compact JSON when pretty is false', async () => {
+      const r = new JSONReporter({ output: { pretty: false } });
+      const result = await r.generate(makeReportData());
+      expect(result).not.toContain('\n');
+    });
+
+    test('returns formatted JSON when pretty is true', async () => {
+      const result = await reporter.generate(makeReportData());
+      expect(result).toContain('\n');
+    });
+
+    test('counts auto-fixed items', async () => {
+      const data = makeReportData({
+        healingResults: [
+          { success: true, checkId: 'a' },
+          { success: false, checkId: 'b' },
+          { success: true, checkId: 'c' },
+        ],
+      });
+      const result = JSON.parse(await reporter.generate(data));
+      expect(result.overall.autoFixedCount).toBe(2);
+    });
+
+    test('handles null healingResults', async () => {
+      const data = makeReportData({ healingResults: null });
+      const result = JSON.parse(await reporter.generate(data));
+      expect(result.overall.autoFixedCount).toBe(0);
+    });
+  });
+
+  // ============================================================
+  // calculateDuration
+  // ============================================================
+  describe('calculateDuration', () => {
+    test('formats milliseconds', () => {
+      expect(reporter.calculateDuration([{ duration: 500 }])).toBe('500ms');
+    });
+
+    test('formats seconds', () => {
+      expect(reporter.calculateDuration([{ duration: 1500 }])).toBe('1.5s');
+    });
+
+    test('sums multiple results', () => {
+      const results = [{ duration: 300 }, { duration: 200 }];
+      expect(reporter.calculateDuration(results)).toBe('500ms');
+    });
+
+    test('handles missing duration', () => {
+      expect(reporter.calculateDuration([{}])).toBe('0ms');
+    });
+  });
+
+  // ============================================================
+  // formatDomainScores
+  // ============================================================
+  describe('formatDomainScores', () => {
+    test('formats domain data', () => {
+      const domains = {
+        project: {
+          score: 90,
+          status: 'healthy',
+          summary: 'Good',
+          checks: [{ name: 'Check A', status: 'pass', severity: 'HIGH' }],
+        },
+      };
+      const result = reporter.formatDomainScores(domains);
+      expect(result.project.score).toBe(90);
+      expect(result.project.checks[0].name).toBe('Check A');
+    });
+  });
+
+  // ============================================================
+  // formatIssues
+  // ============================================================
+  describe('formatIssues', () => {
+    test('groups issues by severity', () => {
+      const results = [
+        makeCheckResult({ status: 'fail', severity: 'CRITICAL' }),
+        makeCheckResult({ checkId: 'w1', status: 'warning', severity: 'HIGH' }),
+        makeCheckResult({ checkId: 'p1', status: 'pass', severity: 'MEDIUM' }),
+      ];
+      const issues = reporter.formatIssues(results);
+      expect(issues.critical).toHaveLength(1);
+      expect(issues.high).toHaveLength(1);
+      expect(issues.medium).toHaveLength(0);
+    });
+
+    test('includes error status in issues', () => {
+      const results = [
+        makeCheckResult({ status: 'error', severity: 'CRITICAL' }),
+      ];
+      const issues = reporter.formatIssues(results);
+      expect(issues.critical).toHaveLength(1);
+    });
+
+    test('returns empty groups when all pass', () => {
+      const results = [makeCheckResult({ status: 'pass' })];
+      const issues = reporter.formatIssues(results);
+      expect(issues.critical).toHaveLength(0);
+      expect(issues.high).toHaveLength(0);
+    });
+  });
+
+  // ============================================================
+  // formatAutoFixed
+  // ============================================================
+  describe('formatAutoFixed', () => {
+    test('returns successful healing results', () => {
+      const results = [
+        { success: true, checkId: 'a', tier: 1, action: 'fix', message: 'Fixed' },
+        { success: false, checkId: 'b', tier: 2, action: 'fix', message: 'Failed' },
+      ];
+      const fixed = reporter.formatAutoFixed(results);
+      expect(fixed).toHaveLength(1);
+      expect(fixed[0].checkId).toBe('a');
+    });
+
+    test('returns empty array for null input', () => {
+      expect(reporter.formatAutoFixed(null)).toEqual([]);
+    });
+
+    test('includes backupPath when present', () => {
+      const results = [
+        { success: true, checkId: 'a', tier: 1, action: 'fix', message: 'ok', backupPath: '/tmp/bak' },
+      ];
+      const fixed = reporter.formatAutoFixed(results);
+      expect(fixed[0].backupPath).toBe('/tmp/bak');
+    });
+  });
+
+  // ============================================================
+  // extractTechDebt
+  // ============================================================
+  describe('extractTechDebt', () => {
+    test('includes warnings as tech debt', () => {
+      const results = [
+        makeCheckResult({ status: 'warning', severity: 'MEDIUM' }),
+      ];
+      const debt = reporter.extractTechDebt(results);
+      expect(debt).toHaveLength(1);
+    });
+
+    test('includes non-passing LOW severity as tech debt', () => {
+      const results = [
+        makeCheckResult({ status: 'fail', severity: 'LOW' }),
+      ];
+      const debt = reporter.extractTechDebt(results);
+      expect(debt).toHaveLength(1);
+    });
+
+    test('excludes passing checks', () => {
+      const results = [
+        makeCheckResult({ status: 'pass', severity: 'LOW' }),
+      ];
+      const debt = reporter.extractTechDebt(results);
+      expect(debt).toHaveLength(0);
+    });
+  });
+
+  // ============================================================
+  // Sanitization
+  // ============================================================
+  describe('sanitization', () => {
+    test('redacts sensitive keys', () => {
+      const obj = { api_key: 'secret123', name: 'safe' };
+      reporter.sanitizeObject(obj);
+      expect(obj.api_key).toBe('[REDACTED]');
+      expect(obj.name).toBe('safe');
+    });
+
+    test('redacts nested sensitive keys', () => {
+      const obj = { db: { password: 'mypass', host: 'localhost' } };
+      reporter.sanitizeObject(obj);
+      expect(obj.db.password).toBe('[REDACTED]');
+      expect(obj.db.host).toBe('localhost');
+    });
+
+    test('redacts strings starting with sk-', () => {
+      const obj = { value: 'sk-abc123' };
+      reporter.sanitizeObject(obj);
+      expect(obj.value).toBe('[REDACTED]');
+    });
+
+    test('redacts long hex strings', () => {
+      const obj = { hash: 'a'.repeat(32) };
+      reporter.sanitizeObject(obj);
+      expect(obj.hash).toBe('[REDACTED]');
+    });
+
+    test('redacts long base64 strings', () => {
+      const obj = { encoded: 'A'.repeat(50) };
+      reporter.sanitizeObject(obj);
+      expect(obj.encoded).toBe('[REDACTED]');
+    });
+
+    test('does not redact short strings', () => {
+      const obj = { val: 'hello' };
+      reporter.sanitizeObject(obj);
+      expect(obj.val).toBe('hello');
+    });
+
+    test('handles null/undefined input', () => {
+      expect(() => reporter.sanitizeObject(null)).not.toThrow();
+      expect(() => reporter.sanitizeObject(undefined)).not.toThrow();
+    });
+
+    test('isSensitiveKey matches patterns', () => {
+      expect(reporter.isSensitiveKey('api_key')).toBe(true);
+      expect(reporter.isSensitiveKey('password')).toBe(true);
+      expect(reporter.isSensitiveKey('auth_token')).toBe(true);
+      expect(reporter.isSensitiveKey('name')).toBe(false);
+    });
+
+    test('sanitizeDetails returns null for null input', () => {
+      expect(reporter.sanitizeDetails(null)).toBeNull();
+    });
+
+    test('sanitizeDetails redacts sensitive fields', () => {
+      const details = { token: 'secret', info: 'ok' };
+      const result = reporter.sanitizeDetails(details);
+      expect(result.token).toBe('[REDACTED]');
+      expect(result.info).toBe('ok');
+    });
+
+    test('skips sanitization when disabled', async () => {
+      const r = new JSONReporter({ output: { sanitize: false } });
+      const data = makeReportData({
+        checkResults: [makeCheckResult({ details: { api_key: 'secret' } })],
+      });
+      const result = JSON.parse(await r.generate(data));
+      expect(result.checks[0].details.api_key).toBe('secret');
+    });
+  });
+
+  // ============================================================
+  // formatChecks
+  // ============================================================
+  describe('formatChecks', () => {
+    test('maps all check fields', () => {
+      const checks = reporter.formatChecks([makeCheckResult()]);
+      expect(checks[0].id).toBe('test-check');
+      expect(checks[0].name).toBe('Test Check');
+      expect(checks[0].domain).toBe('project');
+      expect(checks[0].fromCache).toBe(false);
+    });
+
+    test('defaults fromCache to false', () => {
+      const checks = reporter.formatChecks([makeCheckResult({ fromCache: undefined })]);
+      expect(checks[0].fromCache).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Add test coverage for health-check core modules (base-check, check-registry, json-reporter). All tests pass locally. Closes #419

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive tests for health-check base functionality covering constructor behavior, result helpers, metadata operations, and healing capabilities
  * Added comprehensive tests for the check registry system covering registration, filtering by domain/severity/tags, and statistical metrics
  * Added comprehensive tests for JSON reporting functionality including output formatting, data sanitization, and healing result processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->