### PR TITLE
test: add unit tests for manifest modules

### DIFF
--- a/tests/core/manifest/manifest-generator.test.js
+++ b/tests/core/manifest/manifest-generator.test.js
@@ -1,0 +1,746 @@
+/**
+ * Manifest Generator Tests
+ *
+ * Story: 2.13 - Manifest System
+ *
+ * Tests for the manifest generator module which produces
+ * CSV manifest files for agents, workers, and tasks.
+ *
+ * @author @dev (Dex)
+ * @version 1.0.0
+ */
+
+const path = require('path');
+
+jest.mock('fs', () => ({
+  promises: {
+    readdir: jest.fn(),
+    readFile: jest.fn(),
+    writeFile: jest.fn(),
+    mkdir: jest.fn(),
+  },
+}));
+
+jest.mock('js-yaml', () => ({
+  load: jest.fn(),
+}));
+
+const fs = require('fs').promises;
+const yaml = require('js-yaml');
+
+const {
+  ManifestGenerator,
+  createManifestGenerator,
+  escapeCSV,
+  parseYAMLFromMarkdown,
+  extractAgentSection,
+} = require('../../../.aios-core/core/manifest/manifest-generator');
+
+describe('Manifest Generator (Story 2.13)', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // ─── escapeCSV ───────────────────────────────────────────────
+
+  describe('escapeCSV', () => {
+    it('should return empty string for null', () => {
+      expect(escapeCSV(null)).toBe('');
+    });
+
+    it('should return empty string for undefined', () => {
+      expect(escapeCSV(undefined)).toBe('');
+    });
+
+    it('should return plain string when no special characters', () => {
+      expect(escapeCSV('hello')).toBe('hello');
+    });
+
+    it('should wrap value in quotes when it contains a comma', () => {
+      expect(escapeCSV('hello, world')).toBe('"hello, world"');
+    });
+
+    it('should wrap value in quotes when it contains double quotes and escape them', () => {
+      expect(escapeCSV('say "hi"')).toBe('"say ""hi"""');
+    });
+
+    it('should wrap value in quotes when it contains a newline', () => {
+      expect(escapeCSV('line1\nline2')).toBe('"line1\nline2"');
+    });
+
+    it('should handle value with commas, quotes, and newlines together', () => {
+      expect(escapeCSV('a "b", c\nd')).toBe('"a ""b"", c\nd"');
+    });
+
+    it('should convert numeric values to string', () => {
+      expect(escapeCSV(42)).toBe('42');
+    });
+
+    it('should convert boolean values to string', () => {
+      expect(escapeCSV(true)).toBe('true');
+    });
+
+    it('should return empty string as-is', () => {
+      expect(escapeCSV('')).toBe('');
+    });
+  });
+
+  // ─── extractAgentSection ─────────────────────────────────────
+
+  describe('extractAgentSection', () => {
+    it('should extract agent fields from YAML content', () => {
+      const yamlContent = [
+        'agent:',
+        '  name: TestAgent',
+        '  id: test-agent',
+        '  title: Test Title',
+        '  icon: 🧪',
+        '  whenToUse: For testing',
+      ].join('\n') + '\n';
+
+      const result = extractAgentSection(yamlContent);
+
+      expect(result).not.toBeNull();
+      expect(result.agent.name).toBe('TestAgent');
+      expect(result.agent.id).toBe('test-agent');
+      expect(result.agent.title).toBe('Test Title');
+      expect(result.agent.icon).toBe('🧪');
+      expect(result.agent.whenToUse).toBe('For testing');
+    });
+
+    it('should extract persona_profile archetype when present', () => {
+      const yamlContent = [
+        'agent:',
+        '  name: TestAgent',
+        '  id: test-agent',
+        'persona_profile:',
+        '  archetype: Builder',
+      ].join('\n') + '\n';
+
+      const result = extractAgentSection(yamlContent);
+
+      expect(result).not.toBeNull();
+      expect(result.persona_profile).toEqual({ archetype: 'Builder' });
+    });
+
+    it('should return null persona_profile when archetype is missing', () => {
+      const yamlContent = [
+        'agent:',
+        '  name: TestAgent',
+        '  id: test-agent',
+      ].join('\n') + '\n';
+
+      const result = extractAgentSection(yamlContent);
+
+      expect(result).not.toBeNull();
+      expect(result.persona_profile).toBeNull();
+    });
+
+    it('should return null when no agent block is found', () => {
+      const yamlContent = 'some_other_key: value\n';
+      const result = extractAgentSection(yamlContent);
+      expect(result).toBeNull();
+    });
+
+    it('should return null when agent block has no id or name', () => {
+      const yamlContent = [
+        'agent:',
+        '  title: Only Title',
+      ].join('\n') + '\n';
+
+      const result = extractAgentSection(yamlContent);
+      expect(result).toBeNull();
+    });
+
+    it('should handle partial agent data (only id, no name)', () => {
+      const yamlContent = [
+        'agent:',
+        '  id: partial-agent',
+      ].join('\n') + '\n';
+
+      const result = extractAgentSection(yamlContent);
+
+      expect(result).not.toBeNull();
+      expect(result.agent.id).toBe('partial-agent');
+      expect(result.agent.name).toBeNull();
+    });
+
+    it('should handle partial agent data (only name, no id)', () => {
+      const yamlContent = [
+        'agent:',
+        '  name: PartialAgent',
+      ].join('\n') + '\n';
+
+      const result = extractAgentSection(yamlContent);
+
+      expect(result).not.toBeNull();
+      expect(result.agent.name).toBe('PartialAgent');
+      expect(result.agent.id).toBeNull();
+    });
+  });
+
+  // ─── parseYAMLFromMarkdown ───────────────────────────────────
+
+  describe('parseYAMLFromMarkdown', () => {
+    it('should parse YAML from ```yaml code block', () => {
+      const content = '# Title\n\n```yaml\nkey: value\n```\n';
+      yaml.load.mockReturnValue({ key: 'value' });
+
+      const result = parseYAMLFromMarkdown(content);
+
+      expect(yaml.load).toHaveBeenCalledWith('key: value\n');
+      expect(result).toEqual({ key: 'value' });
+    });
+
+    it('should parse YAML from --- front matter', () => {
+      const content = '---\ntitle: test\n---\n\n# Content\n';
+      yaml.load.mockReturnValue({ title: 'test' });
+
+      const result = parseYAMLFromMarkdown(content);
+
+      expect(yaml.load).toHaveBeenCalledWith('title: test');
+      expect(result).toEqual({ title: 'test' });
+    });
+
+    it('should return null when no YAML is found', () => {
+      const content = '# Just a title\n\nSome text.\n';
+      const result = parseYAMLFromMarkdown(content);
+      expect(result).toBeNull();
+    });
+
+    it('should fall back to extractAgentSection when yaml code block parse fails', () => {
+      const yamlBlock = 'agent:\n  name: FallbackAgent\n  id: fallback\n';
+      const content = '```yaml\n' + yamlBlock + '```\n';
+      yaml.load.mockImplementation(() => {
+        throw new Error('parse error');
+      });
+
+      const result = parseYAMLFromMarkdown(content);
+
+      expect(result).not.toBeNull();
+      expect(result.agent.name).toBe('FallbackAgent');
+      expect(result.agent.id).toBe('fallback');
+    });
+
+    it('should fall back to extractAgentSection when front matter parse fails', () => {
+      const yamlContent = 'agent:\n  name: FrontAgent\n  id: front\n';
+      const content = '---\n' + yamlContent + '\n---\n';
+      yaml.load.mockImplementation(() => {
+        throw new Error('parse error');
+      });
+
+      const result = parseYAMLFromMarkdown(content);
+
+      expect(result).not.toBeNull();
+      expect(result.agent.name).toBe('FrontAgent');
+      expect(result.agent.id).toBe('front');
+    });
+
+    it('should prefer yaml code block over front matter', () => {
+      const content = '---\nfm: data\n---\n\n```yaml\nblock: data\n```\n';
+      yaml.load.mockReturnValue({ block: 'data' });
+
+      const result = parseYAMLFromMarkdown(content);
+
+      expect(yaml.load).toHaveBeenCalledWith('block: data\n');
+      expect(result).toEqual({ block: 'data' });
+    });
+  });
+
+  // ─── ManifestGenerator constructor ──────────────────────────
+
+  describe('ManifestGenerator constructor', () => {
+    it('should set defaults when no options provided', () => {
+      const gen = new ManifestGenerator();
+
+      expect(gen.basePath).toBe(process.cwd());
+      expect(gen.aiosCoreDir).toBe(path.join(process.cwd(), '.aios-core'));
+      expect(gen.manifestDir).toBe(path.join(process.cwd(), '.aios-core', 'manifests'));
+      expect(gen.version).toBe('2.1.0');
+    });
+
+    it('should use provided basePath', () => {
+      const gen = new ManifestGenerator({ basePath: '/custom/path' });
+
+      expect(gen.basePath).toBe('/custom/path');
+      expect(gen.aiosCoreDir).toBe(path.join('/custom/path', '.aios-core'));
+      expect(gen.manifestDir).toBe(path.join('/custom/path', '.aios-core', 'manifests'));
+    });
+  });
+
+  // ─── generateAll ─────────────────────────────────────────────
+
+  describe('generateAll', () => {
+    let gen;
+
+    beforeEach(() => {
+      gen = new ManifestGenerator({ basePath: '/test' });
+      fs.mkdir.mockResolvedValue(undefined);
+    });
+
+    it('should create manifest directory and run all generators', async () => {
+      fs.readdir.mockResolvedValue([]);
+      fs.readFile.mockResolvedValueOnce(JSON.stringify({ workers: [] }));
+      fs.writeFile.mockResolvedValue(undefined);
+
+      const results = await gen.generateAll();
+
+      expect(fs.mkdir).toHaveBeenCalledWith(gen.manifestDir, { recursive: true });
+      expect(results.agents).toBeDefined();
+      expect(results.workers).toBeDefined();
+      expect(results.tasks).toBeDefined();
+      expect(results.errors).toEqual([]);
+      expect(typeof results.duration).toBe('number');
+    });
+
+    it('should capture errors when mkdir fails', async () => {
+      fs.mkdir.mockRejectedValue(new Error('mkdir failed'));
+
+      const results = await gen.generateAll();
+
+      expect(results.errors).toContain('mkdir failed');
+    });
+  });
+
+  // ─── generateAgentsManifest ──────────────────────────────────
+
+  describe('generateAgentsManifest', () => {
+    let gen;
+
+    beforeEach(() => {
+      gen = new ManifestGenerator({ basePath: '/test' });
+      fs.writeFile.mockResolvedValue(undefined);
+    });
+
+    it('should generate agents CSV from markdown files with YAML', async () => {
+      fs.readdir.mockResolvedValue(['agent-one.md', 'agent-two.md', 'readme.txt']);
+      fs.readFile
+        .mockResolvedValueOnce('```yaml\nagent:\n  id: agent-one\n  name: Agent One\n```\n')
+        .mockResolvedValueOnce('```yaml\nagent:\n  id: agent-two\n  name: Agent Two\n```\n');
+
+      yaml.load
+        .mockReturnValueOnce({
+          agent: { id: 'agent-one', name: 'Agent One', title: 'Builder', icon: '🔨', whenToUse: 'building' },
+          persona_profile: { archetype: 'Engineer' },
+        })
+        .mockReturnValueOnce({
+          agent: { id: 'agent-two', name: 'Agent Two', title: 'Tester', icon: '🧪', whenToUse: 'testing' },
+        });
+
+      const result = await gen.generateAgentsManifest();
+
+      expect(result.success).toBe(true);
+      expect(result.count).toBe(2);
+      expect(result.errors).toEqual([]);
+
+      const csvCall = fs.writeFile.mock.calls[0];
+      expect(csvCall[0]).toContain('agents.csv');
+      expect(csvCall[1]).toContain('id,name,archetype,icon,version,status,file_path,when_to_use');
+      expect(csvCall[1]).toContain('agent-one');
+      expect(csvCall[1]).toContain('agent-two');
+    });
+
+    it('should use file name as id when agent has no id', async () => {
+      fs.readdir.mockResolvedValue(['my-agent.md']);
+      fs.readFile.mockResolvedValueOnce('```yaml\nagent:\n  name: My Agent\n```\n');
+      yaml.load.mockReturnValueOnce({
+        agent: { name: 'My Agent' },
+      });
+
+      const result = await gen.generateAgentsManifest();
+
+      expect(result.success).toBe(true);
+      const csv = fs.writeFile.mock.calls[0][1];
+      expect(csv).toContain('my-agent');
+    });
+
+    it('should use defaults for missing agent fields', async () => {
+      fs.readdir.mockResolvedValue(['minimal.md']);
+      fs.readFile.mockResolvedValueOnce('```yaml\nagent:\n  id: minimal\n```\n');
+      yaml.load.mockReturnValueOnce({
+        agent: { id: 'minimal' },
+      });
+
+      const result = await gen.generateAgentsManifest();
+
+      expect(result.success).toBe(true);
+      const csv = fs.writeFile.mock.calls[0][1];
+      // Default name: 'Unknown', default icon: '🤖', default archetype: 'Agent'
+      expect(csv).toContain('Unknown');
+    });
+
+    it('should skip files that fail to parse without failing the whole manifest', async () => {
+      fs.readdir.mockResolvedValue(['good.md', 'bad.md']);
+      fs.readFile
+        .mockResolvedValueOnce('```yaml\nagent:\n  id: good\n  name: Good\n```\n')
+        .mockRejectedValueOnce(new Error('read error'));
+
+      yaml.load.mockReturnValueOnce({
+        agent: { id: 'good', name: 'Good' },
+      });
+
+      const result = await gen.generateAgentsManifest();
+
+      expect(result.success).toBe(true);
+      expect(result.count).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('bad.md');
+    });
+
+    it('should return failure when readdir fails', async () => {
+      fs.readdir.mockRejectedValue(new Error('ENOENT'));
+
+      const result = await gen.generateAgentsManifest();
+
+      expect(result.success).toBe(false);
+      expect(result.count).toBe(0);
+      expect(result.errors).toContain('ENOENT');
+    });
+
+    it('should skip markdown files with no parsed agent data', async () => {
+      fs.readdir.mockResolvedValue(['no-yaml.md']);
+      fs.readFile.mockResolvedValueOnce('# Just markdown\n\nNo YAML here.\n');
+
+      const result = await gen.generateAgentsManifest();
+
+      expect(result.success).toBe(true);
+      expect(result.count).toBe(0);
+    });
+
+    it('should use persona.archetype for archetype, then agent.title as fallback', async () => {
+      fs.readdir.mockResolvedValue(['with-persona.md', 'with-title.md']);
+      fs.readFile
+        .mockResolvedValueOnce('```yaml\ndata\n```\n')
+        .mockResolvedValueOnce('```yaml\ndata\n```\n');
+
+      yaml.load
+        .mockReturnValueOnce({
+          agent: { id: 'a1', name: 'A1', title: 'ShouldNotUse' },
+          persona_profile: { archetype: 'Strategist' },
+        })
+        .mockReturnValueOnce({
+          agent: { id: 'a2', name: 'A2', title: 'Analyst' },
+        });
+
+      const result = await gen.generateAgentsManifest();
+      const csv = fs.writeFile.mock.calls[0][1];
+
+      expect(csv).toContain('Strategist');
+      expect(csv).toContain('Analyst');
+      expect(csv).not.toContain('ShouldNotUse');
+    });
+  });
+
+  // ─── generateWorkersManifest ─────────────────────────────────
+
+  describe('generateWorkersManifest', () => {
+    let gen;
+
+    beforeEach(() => {
+      gen = new ManifestGenerator({ basePath: '/test' });
+      fs.writeFile.mockResolvedValue(undefined);
+    });
+
+    it('should generate workers CSV from service registry', async () => {
+      const registry = {
+        workers: [
+          {
+            id: 'w1',
+            name: 'Worker One',
+            category: 'compute',
+            subcategory: 'gpu',
+            executorTypes: ['docker', 'local'],
+            tags: ['fast', 'reliable'],
+            path: 'workers/w1.js',
+          },
+          {
+            id: 'w2',
+            name: 'Worker Two',
+            category: 'storage',
+            executorTypes: [],
+            tags: [],
+            path: 'workers/w2.js',
+          },
+        ],
+      };
+
+      fs.readFile.mockResolvedValue(JSON.stringify(registry));
+
+      const result = await gen.generateWorkersManifest();
+
+      expect(result.success).toBe(true);
+      expect(result.count).toBe(2);
+      expect(result.errors).toEqual([]);
+
+      const csvCall = fs.writeFile.mock.calls[0];
+      expect(csvCall[0]).toContain('workers.csv');
+      expect(csvCall[1]).toContain('id,name,category,subcategory,executor_types,tags,file_path,status');
+      expect(csvCall[1]).toContain('docker;local');
+      expect(csvCall[1]).toContain('fast;reliable');
+    });
+
+    it('should handle missing subcategory, executorTypes, and tags', async () => {
+      const registry = {
+        workers: [
+          {
+            id: 'w3',
+            name: 'Minimal Worker',
+            category: 'general',
+            path: 'workers/w3.js',
+          },
+        ],
+      };
+
+      fs.readFile.mockResolvedValue(JSON.stringify(registry));
+
+      const result = await gen.generateWorkersManifest();
+
+      expect(result.success).toBe(true);
+      expect(result.count).toBe(1);
+    });
+
+    it('should return failure when registry file cannot be read', async () => {
+      fs.readFile.mockRejectedValue(new Error('ENOENT'));
+
+      const result = await gen.generateWorkersManifest();
+
+      expect(result.success).toBe(false);
+      expect(result.count).toBe(0);
+      expect(result.errors).toContain('ENOENT');
+    });
+
+    it('should return failure when registry has invalid JSON', async () => {
+      fs.readFile.mockResolvedValue('not json');
+
+      const result = await gen.generateWorkersManifest();
+
+      expect(result.success).toBe(false);
+      expect(result.count).toBe(0);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+  });
+
+  // ─── generateTasksManifest ───────────────────────────────────
+
+  describe('generateTasksManifest', () => {
+    let gen;
+
+    beforeEach(() => {
+      gen = new ManifestGenerator({ basePath: '/test' });
+      fs.writeFile.mockResolvedValue(undefined);
+    });
+
+    it('should generate tasks CSV from markdown files', async () => {
+      fs.readdir.mockResolvedValue(['build-app.md']);
+      fs.readFile.mockResolvedValueOnce('```yaml\ntask:\n  name: Build App\n  category: dev\n```\n');
+      yaml.load.mockReturnValueOnce({
+        task: { name: 'Build App', category: 'dev' },
+      });
+
+      const result = await gen.generateTasksManifest();
+
+      expect(result.success).toBe(true);
+      expect(result.count).toBe(1);
+      const csv = fs.writeFile.mock.calls[0][1];
+      expect(csv).toContain('id,name,category,format,has_elicitation,file_path,status');
+      expect(csv).toContain('build-app');
+      expect(csv).toContain('Build App');
+    });
+
+    it('should detect category from filename prefix: db-', async () => {
+      fs.readdir.mockResolvedValue(['db-migrate.md']);
+      fs.readFile.mockResolvedValueOnce('# DB Migrate\n');
+
+      const result = await gen.generateTasksManifest();
+      const csv = fs.writeFile.mock.calls[0][1];
+
+      expect(csv).toContain('database');
+    });
+
+    it('should detect category from filename prefix: qa-', async () => {
+      fs.readdir.mockResolvedValue(['qa-check.md']);
+      fs.readFile.mockResolvedValueOnce('# QA Check\n');
+
+      const result = await gen.generateTasksManifest();
+      const csv = fs.writeFile.mock.calls[0][1];
+
+      expect(csv).toContain('quality');
+    });
+
+    it('should detect category from filename prefix: dev-', async () => {
+      fs.readdir.mockResolvedValue(['dev-setup.md']);
+      fs.readFile.mockResolvedValueOnce('# Dev Setup\n');
+
+      const result = await gen.generateTasksManifest();
+      const csv = fs.writeFile.mock.calls[0][1];
+
+      expect(csv).toContain('development');
+    });
+
+    it('should detect category from filename prefix: po-', async () => {
+      fs.readdir.mockResolvedValue(['po-backlog.md']);
+      fs.readFile.mockResolvedValueOnce('# PO Backlog\n');
+
+      const result = await gen.generateTasksManifest();
+      const csv = fs.writeFile.mock.calls[0][1];
+
+      expect(csv).toContain('product');
+    });
+
+    it('should detect category from filename prefix: github-', async () => {
+      fs.readdir.mockResolvedValue(['github-deploy.md']);
+      fs.readFile.mockResolvedValueOnce('# GitHub Deploy\n');
+
+      const result = await gen.generateTasksManifest();
+      const csv = fs.writeFile.mock.calls[0][1];
+
+      expect(csv).toContain('devops');
+    });
+
+    it('should generate task name from filename when YAML has no name', async () => {
+      fs.readdir.mockResolvedValue(['my-cool-task.md']);
+      fs.readFile.mockResolvedValueOnce('# No yaml here\n');
+
+      const result = await gen.generateTasksManifest();
+      const csv = fs.writeFile.mock.calls[0][1];
+
+      // my-cool-task -> My Cool Task
+      expect(csv).toContain('My Cool Task');
+    });
+
+    it('should detect elicitation from task.elicit in YAML', async () => {
+      fs.readdir.mockResolvedValue(['elicit-task.md']);
+      fs.readFile.mockResolvedValueOnce('```yaml\ntask:\n  name: Elicit\n  elicit: true\n```\n');
+      yaml.load.mockReturnValueOnce({
+        task: { name: 'Elicit', elicit: true },
+      });
+
+      const result = await gen.generateTasksManifest();
+      const csv = fs.writeFile.mock.calls[0][1];
+
+      expect(csv).toContain('true');
+    });
+
+    it('should detect elicitation from content string "elicit: true"', async () => {
+      fs.readdir.mockResolvedValue(['content-elicit.md']);
+      fs.readFile.mockResolvedValueOnce('# Task\n\nelicit: true\n');
+
+      const result = await gen.generateTasksManifest();
+      const csv = fs.writeFile.mock.calls[0][1];
+
+      expect(csv).toContain('true');
+    });
+
+    it('should detect elicitation from content string "elicit=true"', async () => {
+      fs.readdir.mockResolvedValue(['content-elicit2.md']);
+      fs.readFile.mockResolvedValueOnce('# Task\n\nelicit=true\n');
+
+      const result = await gen.generateTasksManifest();
+      const csv = fs.writeFile.mock.calls[0][1];
+
+      expect(csv).toContain('true');
+    });
+
+    it('should use top-level parsed fields as fallback (name, category, format)', async () => {
+      fs.readdir.mockResolvedValue(['top-level.md']);
+      fs.readFile.mockResolvedValueOnce('```yaml\nname: TopName\ncategory: topcat\nformat: TOP-V2\n```\n');
+      yaml.load.mockReturnValueOnce({
+        name: 'TopName',
+        category: 'topcat',
+        format: 'TOP-V2',
+      });
+
+      const result = await gen.generateTasksManifest();
+      const csv = fs.writeFile.mock.calls[0][1];
+
+      // Filename prefix override: top-level doesn't match any prefix, so category stays topcat
+      // But wait -- prefix detection runs AFTER yaml extraction and overwrites.
+      // Actually looking at the code: prefix detection always runs and overwrites.
+      // "top-level" doesn't start with db-, qa-, dev-, po-, github- so category stays 'topcat'
+      expect(csv).toContain('TopName');
+      expect(csv).toContain('topcat');
+      expect(csv).toContain('TOP-V2');
+    });
+
+    it('should override YAML category with filename prefix category', async () => {
+      fs.readdir.mockResolvedValue(['db-custom.md']);
+      fs.readFile.mockResolvedValueOnce('```yaml\ntask:\n  name: Custom\n  category: custom-cat\n```\n');
+      yaml.load.mockReturnValueOnce({
+        task: { name: 'Custom', category: 'custom-cat' },
+      });
+
+      const result = await gen.generateTasksManifest();
+      const csv = fs.writeFile.mock.calls[0][1];
+
+      // db- prefix should override custom-cat with 'database'
+      expect(csv).toContain('database');
+    });
+
+    it('should skip files that fail to parse without failing', async () => {
+      fs.readdir.mockResolvedValue(['good.md', 'bad.md']);
+      fs.readFile
+        .mockResolvedValueOnce('# Good\n')
+        .mockRejectedValueOnce(new Error('read error'));
+
+      const result = await gen.generateTasksManifest();
+
+      expect(result.success).toBe(true);
+      expect(result.count).toBe(1);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('bad.md');
+    });
+
+    it('should return failure when readdir fails', async () => {
+      fs.readdir.mockRejectedValue(new Error('ENOENT'));
+
+      const result = await gen.generateTasksManifest();
+
+      expect(result.success).toBe(false);
+      expect(result.count).toBe(0);
+      expect(result.errors).toContain('ENOENT');
+    });
+
+    it('should use elicit from top-level parsed data', async () => {
+      fs.readdir.mockResolvedValue(['elicit-top.md']);
+      fs.readFile.mockResolvedValueOnce('```yaml\nelicit: true\n```\n');
+      yaml.load.mockReturnValueOnce({
+        elicit: true,
+      });
+
+      const result = await gen.generateTasksManifest();
+      const csv = fs.writeFile.mock.calls[0][1];
+
+      expect(csv).toContain('true');
+    });
+
+    it('should default to general category and TASK-FORMAT-V1', async () => {
+      fs.readdir.mockResolvedValue(['plain.md']);
+      fs.readFile.mockResolvedValueOnce('# Plain task\n');
+
+      const result = await gen.generateTasksManifest();
+      const csv = fs.writeFile.mock.calls[0][1];
+
+      expect(csv).toContain('general');
+      expect(csv).toContain('TASK-FORMAT-V1');
+    });
+  });
+
+  // ─── createManifestGenerator ─────────────────────────────────
+
+  describe('createManifestGenerator', () => {
+    it('should return a ManifestGenerator instance', () => {
+      const gen = createManifestGenerator();
+      expect(gen).toBeInstanceOf(ManifestGenerator);
+    });
+
+    it('should pass options to the constructor', () => {
+      const gen = createManifestGenerator({ basePath: '/custom' });
+      expect(gen.basePath).toBe('/custom');
+    });
+
+    it('should work with empty options', () => {
+      const gen = createManifestGenerator({});
+      expect(gen.basePath).toBe(process.cwd());
+    });
+  });
+});

--- a/tests/core/manifest/manifest-validator.test.js
+++ b/tests/core/manifest/manifest-validator.test.js
@@ -1,0 +1,251 @@
+/**
+ * Unit tests for manifest-validator
+ *
+ * Tests CSV parsing, header validation, row validation, file checks,
+ * schema definitions, and result formatting.
+ */
+
+jest.mock('fs', () => ({
+  promises: {
+    access: jest.fn(),
+    readFile: jest.fn(),
+    readdir: jest.fn(),
+  },
+}));
+
+const fs = require('fs').promises;
+
+const {
+  ManifestValidator,
+  createManifestValidator,
+  parseCSV,
+  parseCSVLine,
+  parseCSVContent,
+} = require('../../../.aios-core/core/manifest/manifest-validator');
+
+describe('manifest-validator', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('parseCSVLine', () => {
+    test('parses simple CSV line', () => {
+      expect(parseCSVLine('a,b,c')).toEqual(['a', 'b', 'c']);
+    });
+
+    test('handles quoted values', () => {
+      expect(parseCSVLine('"hello","world"')).toEqual(['hello', 'world']);
+    });
+
+    test('handles escaped quotes', () => {
+      expect(parseCSVLine('"he said ""hi"""')).toEqual(['he said "hi"']);
+    });
+
+    test('handles commas inside quotes', () => {
+      expect(parseCSVLine('"a,b",c')).toEqual(['a,b', 'c']);
+    });
+
+    test('handles empty fields', () => {
+      expect(parseCSVLine('a,,c')).toEqual(['a', '', 'c']);
+    });
+  });
+
+  describe('parseCSVContent', () => {
+    test('parses multi-line CSV content', () => {
+      const content = 'a,b\n1,2\n3,4';
+      const records = parseCSVContent(content);
+      expect(records).toEqual([['a', 'b'], ['1', '2'], ['3', '4']]);
+    });
+
+    test('handles multi-line quoted values', () => {
+      const content = 'a,b\n"line1\nline2",val';
+      const records = parseCSVContent(content);
+      expect(records).toHaveLength(2);
+      expect(records[1][0]).toBe('line1\nline2');
+    });
+
+    test('handles Windows line endings', () => {
+      const content = 'a,b\r\n1,2\r\n';
+      const records = parseCSVContent(content);
+      expect(records).toEqual([['a', 'b'], ['1', '2']]);
+    });
+
+    test('returns empty array for empty content', () => {
+      expect(parseCSVContent('')).toEqual([]);
+    });
+  });
+
+  describe('parseCSV', () => {
+    test('returns header and rows', () => {
+      const content = 'id,name\n1,foo\n2,bar';
+      const result = parseCSV(content);
+      expect(result.header).toEqual(['id', 'name']);
+      expect(result.rows).toHaveLength(2);
+      expect(result.rows[0].id).toBe('1');
+      expect(result.rows[0].name).toBe('foo');
+    });
+
+    test('adds _lineNumber to rows', () => {
+      const content = 'id\n1\n2';
+      const result = parseCSV(content);
+      expect(result.rows[0]._lineNumber).toBe(2);
+      expect(result.rows[1]._lineNumber).toBe(3);
+    });
+
+    test('returns empty for empty content', () => {
+      const result = parseCSV('');
+      expect(result.header).toEqual([]);
+      expect(result.rows).toEqual([]);
+    });
+  });
+
+  describe('ManifestValidator', () => {
+    let validator;
+
+    beforeEach(() => {
+      validator = new ManifestValidator({ basePath: '/project' });
+    });
+
+    describe('constructor', () => {
+      test('uses process.cwd() as default basePath', () => {
+        const v = new ManifestValidator();
+        expect(v.basePath).toBe(process.cwd());
+      });
+
+      test('sets verbose option', () => {
+        const v = new ManifestValidator({ verbose: true });
+        expect(v.verbose).toBe(true);
+      });
+    });
+
+    describe('schemas', () => {
+      test('getAgentsSchema has required fields', () => {
+        const schema = validator.getAgentsSchema();
+        expect(schema.required).toContain('id');
+        expect(schema.required).toContain('name');
+        expect(schema.required).toContain('file_path');
+      });
+
+      test('getWorkersSchema has required fields', () => {
+        const schema = validator.getWorkersSchema();
+        expect(schema.required).toContain('id');
+        expect(schema.required).toContain('category');
+      });
+
+      test('getTasksSchema has required fields', () => {
+        const schema = validator.getTasksSchema();
+        expect(schema.required).toContain('id');
+        expect(schema.required).toContain('file_path');
+      });
+    });
+
+    describe('validateHeader', () => {
+      test('returns no errors for valid header', () => {
+        const schema = { required: ['id', 'name'] };
+        expect(validator.validateHeader(['id', 'name', 'extra'], schema)).toEqual([]);
+      });
+
+      test('reports missing required columns', () => {
+        const schema = { required: ['id', 'name'] };
+        const errors = validator.validateHeader(['id'], schema);
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toContain('name');
+      });
+    });
+
+    describe('validateManifest', () => {
+      test('returns error when file not found', async () => {
+        fs.access.mockRejectedValue(new Error('ENOENT'));
+        const result = await validator.validateManifest('agents.csv', { required: ['id'] });
+        expect(result.valid).toBe(false);
+        expect(result.errors[0]).toContain('not found');
+      });
+
+      test('validates valid manifest', async () => {
+        const csvContent = 'id,name,version,status,file_path\ndev,Dev,1.0,active,.aios-core/agents/dev.md';
+        fs.access.mockResolvedValue(undefined);
+        fs.readFile.mockResolvedValue(csvContent);
+        fs.readdir.mockResolvedValue(['dev.md']);
+        const schema = validator.getAgentsSchema();
+        const result = await validator.validateManifest('agents.csv', schema);
+        expect(result.valid).toBe(true);
+        expect(result.rowCount).toBe(1);
+      });
+
+      test('detects duplicate IDs', async () => {
+        const csvContent = 'id,name\nfoo,Foo\nfoo,Bar';
+        fs.access.mockResolvedValue(undefined);
+        fs.readFile.mockResolvedValue(csvContent);
+        const result = await validator.validateManifest('test.csv', { required: ['id', 'name'] });
+        expect(result.valid).toBe(false);
+        expect(result.errors.some(e => e.includes('Duplicate'))).toBe(true);
+      });
+
+      test('detects missing required fields', async () => {
+        const csvContent = 'id,name\nfoo,';
+        fs.access.mockResolvedValue(undefined);
+        fs.readFile.mockResolvedValue(csvContent);
+        const result = await validator.validateManifest('test.csv', { required: ['id', 'name'] });
+        expect(result.valid).toBe(false);
+        expect(result.errors.some(e => e.includes("Missing required field 'name'"))).toBe(true);
+      });
+
+      test('warns about invalid status', async () => {
+        const csvContent = 'id,status\nfoo,invalid-status';
+        fs.access.mockResolvedValue(undefined);
+        fs.readFile.mockResolvedValue(csvContent);
+        const result = await validator.validateManifest('test.csv', { required: ['id'] });
+        expect(result.warnings.some(w => w.includes('Invalid status'))).toBe(true);
+      });
+    });
+
+    describe('formatResults', () => {
+      test('formats valid results', () => {
+        const results = {
+          agents: { valid: true, filename: 'agents.csv', rowCount: 5, errors: [], warnings: [], missingFiles: [], orphanFiles: [] },
+          summary: { valid: 1, invalid: 0, missing: [], orphan: [] },
+        };
+        const output = validator.formatResults(results);
+        expect(output).toContain('✓');
+        expect(output).toContain('agents.csv');
+        expect(output).toContain('All manifests valid');
+      });
+
+      test('formats invalid results', () => {
+        const results = {
+          agents: { valid: false, filename: 'agents.csv', rowCount: 3, errors: ['Missing ID'], warnings: [], missingFiles: [], orphanFiles: [] },
+          summary: { valid: 0, invalid: 1, missing: [{ id: '1', path: 'x' }], orphan: [] },
+        };
+        const output = validator.formatResults(results);
+        expect(output).toContain('✗');
+        expect(output).toContain('Validation failed');
+        expect(output).toContain('missing file');
+      });
+
+      test('verbose mode includes error details', () => {
+        const v = new ManifestValidator({ verbose: true });
+        const results = {
+          agents: { valid: false, filename: 'agents.csv', rowCount: 1, errors: ['Bad field'], warnings: ['Low prio'], missingFiles: [{ id: 'x', path: 'y' }], orphanFiles: [{ path: 'z' }] },
+          summary: { valid: 0, invalid: 1, missing: [], orphan: [{ path: 'z' }] },
+        };
+        const output = v.formatResults(results);
+        expect(output).toContain('Bad field');
+        expect(output).toContain('Low prio');
+        expect(output).toContain('Missing file');
+        expect(output).toContain('Orphan file');
+      });
+    });
+  });
+
+  describe('createManifestValidator', () => {
+    test('returns ManifestValidator instance', () => {
+      const v = createManifestValidator();
+      expect(v).toBeInstanceOf(ManifestValidator);
+    });
+
+    test('passes options to constructor', () => {
+      const v = createManifestValidator({ verbose: true });
+      expect(v.verbose).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive test coverage for the manifest subsystem.

Closes #437

### Test files added

| File | Module | Key scenarios |
|------|--------|---------------|
| `manifest-validator.test.js` | manifest-validator | CSV parsing, field validation, schema checks, error handling |
| `manifest-generator.test.js` | manifest-generator | CSV generation, template handling, output formatting |

### How to run

```bash
npx jest tests/core/manifest/ --verbose
```

All tests pass locally with Jest 30.

Related to #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the Manifest Generator module, validating CSV handling, YAML extraction, agent/worker/task generation workflows, and error scenarios.
  * Added extensive test suite for the Manifest Validator module, covering CSV parsing, schema validation, manifest integrity checks, and error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->