### PR TITLE
test: add unit tests for CLI and infrastructure modules

### DIFF
--- a/tests/bin/utils/install-errors.test.js
+++ b/tests/bin/utils/install-errors.test.js
@@ -1,0 +1,341 @@
+/**
+ * Tests for bin/utils/install-errors.js
+ *
+ * Covers error classification, message formatting, rollback messaging,
+ * success messaging, error sanitization, and classification logic.
+ *
+ * @see Story 1.9 - Error Handling & Rollback
+ */
+
+const {
+  ERROR_CLASSIFICATION,
+  ERROR_MESSAGES,
+  formatErrorMessage,
+  formatRollbackMessage,
+  formatSuccessMessage,
+  sanitizeErrorForUser,
+  getErrorClassification,
+} = require('../../../bin/utils/install-errors');
+
+// ---------------------------------------------------------------------------
+// ERROR_CLASSIFICATION
+// ---------------------------------------------------------------------------
+describe('ERROR_CLASSIFICATION', () => {
+  test('has exactly 3 levels: CRITICAL, RECOVERABLE, WARNING', () => {
+    const keys = Object.keys(ERROR_CLASSIFICATION);
+    expect(keys).toHaveLength(3);
+    expect(keys).toContain('CRITICAL');
+    expect(keys).toContain('RECOVERABLE');
+    expect(keys).toContain('WARNING');
+  });
+
+  test.each(['CRITICAL', 'RECOVERABLE', 'WARNING'])(
+    '%s has level, color (function), and icon properties',
+    (level) => {
+      const entry = ERROR_CLASSIFICATION[level];
+      expect(entry).toBeDefined();
+      expect(entry.level).toBe(level);
+      expect(typeof entry.color).toBe('function');
+      expect(typeof entry.icon).toBe('string');
+      expect(entry.icon.length).toBeGreaterThan(0);
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// ERROR_MESSAGES
+// ---------------------------------------------------------------------------
+describe('ERROR_MESSAGES', () => {
+  const EXPECTED_CODES = [
+    'EACCES',
+    'ENOSPC',
+    'EROFS',
+    'ENOTDIR',
+    'NETWORK_TIMEOUT',
+    'NETWORK_ERROR',
+    'DEPENDENCY_FAILED',
+    'PACKAGE_CORRUPTION',
+    'CONFIG_PARSE_ERROR',
+    'CONFIG_WRITE_ERROR',
+    'GIT_CORRUPTION',
+    'GIT_CONFLICT',
+    'UNKNOWN_ERROR',
+  ];
+
+  test('contains all expected error codes', () => {
+    for (const code of EXPECTED_CODES) {
+      expect(ERROR_MESSAGES).toHaveProperty(code);
+    }
+  });
+
+  test('has at least 12 error codes', () => {
+    expect(Object.keys(ERROR_MESSAGES).length).toBeGreaterThanOrEqual(12);
+  });
+
+  test.each(EXPECTED_CODES)(
+    '%s has title (string), description (string), and recovery (non-empty array)',
+    (code) => {
+      const entry = ERROR_MESSAGES[code];
+      expect(typeof entry.title).toBe('string');
+      expect(entry.title.length).toBeGreaterThan(0);
+      expect(typeof entry.description).toBe('string');
+      expect(entry.description.length).toBeGreaterThan(0);
+      expect(Array.isArray(entry.recovery)).toBe(true);
+      expect(entry.recovery.length).toBeGreaterThan(0);
+      entry.recovery.forEach((step) => {
+        expect(typeof step).toBe('string');
+        expect(step.length).toBeGreaterThan(0);
+      });
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// formatErrorMessage
+// ---------------------------------------------------------------------------
+describe('formatErrorMessage', () => {
+  test('formats a known error code with its template', () => {
+    const error = new Error('permission denied');
+    const output = formatErrorMessage(error, 'EACCES');
+
+    expect(output).toContain('Permission Denied');
+    expect(output).toContain('insufficient file system permissions');
+    expect(output).toContain('Recovery Steps');
+  });
+
+  test('includes recovery steps from the template', () => {
+    const error = new Error('disk full');
+    const output = formatErrorMessage(error, 'ENOSPC');
+
+    // All 3 recovery steps from ENOSPC template
+    expect(output).toContain('Free up disk space');
+    expect(output).toContain('Delete unnecessary files');
+    expect(output).toContain('Run the installer again');
+  });
+
+  test('falls back to UNKNOWN_ERROR for unrecognised codes', () => {
+    const error = new Error('something weird');
+    const output = formatErrorMessage(error, 'XYZZY_NOT_REAL');
+
+    expect(output).toContain('Unknown Installation Error');
+    expect(output).toContain('unexpected error');
+  });
+
+  test('uses error.code when errorCode is not provided', () => {
+    const error = new Error('read-only');
+    error.code = 'EROFS';
+    const output = formatErrorMessage(error);
+
+    expect(output).toContain('Read-Only File System');
+  });
+
+  test('defaults to UNKNOWN_ERROR when neither errorCode nor error.code exist', () => {
+    const error = new Error('bare error');
+    const output = formatErrorMessage(error);
+
+    expect(output).toContain('Unknown Installation Error');
+  });
+
+  test('includes error details section with the error code', () => {
+    const error = new Error('details test');
+    const output = formatErrorMessage(error, 'NETWORK_TIMEOUT');
+
+    expect(output).toContain('Error Details');
+    expect(output).toContain('NETWORK_TIMEOUT');
+  });
+
+  test('includes error.message when it differs from the title', () => {
+    const error = new Error('custom technical detail');
+    const output = formatErrorMessage(error, 'EACCES');
+
+    expect(output).toContain('custom technical detail');
+  });
+
+  test('omits error.message when it duplicates the title', () => {
+    const error = new Error('Permission Denied');
+    const output = formatErrorMessage(error, 'EACCES');
+
+    // "Message:" line should not appear because message includes the title
+    expect(output).not.toContain('Message: Permission Denied');
+  });
+
+  test('includes the installation log reference', () => {
+    const error = new Error('test');
+    const output = formatErrorMessage(error, 'EACCES');
+
+    expect(output).toContain('.aios-install.log');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatRollbackMessage
+// ---------------------------------------------------------------------------
+describe('formatRollbackMessage', () => {
+  test('success message contains positive indicators', () => {
+    const output = formatRollbackMessage(true);
+
+    expect(output).toContain('Rollback Completed Successfully');
+    expect(output).toContain('restored to its previous state');
+    expect(output).toContain('No files were modified');
+  });
+
+  test('failure message contains warning indicators', () => {
+    const output = formatRollbackMessage(false, ['config.json', 'package.json']);
+
+    expect(output).toContain('Rollback Completed with Errors');
+    expect(output).toContain('Manual Recovery Required');
+    expect(output).toContain('config.json');
+    expect(output).toContain('package.json');
+  });
+
+  test('failure message with empty failedFiles array still shows recovery steps', () => {
+    const output = formatRollbackMessage(false, []);
+
+    expect(output).toContain('Rollback Completed with Errors');
+    expect(output).toContain('Recovery Steps');
+    expect(output).toContain('.aios-backup/');
+  });
+
+  test('failure message without failedFiles argument shows recovery steps', () => {
+    const output = formatRollbackMessage(false);
+
+    expect(output).toContain('Rollback Completed with Errors');
+    expect(output).toContain('Recovery Steps');
+  });
+
+  test('returns a string', () => {
+    expect(typeof formatRollbackMessage(true)).toBe('string');
+    expect(typeof formatRollbackMessage(false)).toBe('string');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatSuccessMessage
+// ---------------------------------------------------------------------------
+describe('formatSuccessMessage', () => {
+  test('returns a non-empty string', () => {
+    const output = formatSuccessMessage();
+    expect(typeof output).toBe('string');
+    expect(output.length).toBeGreaterThan(0);
+  });
+
+  test('contains success indicators', () => {
+    const output = formatSuccessMessage();
+    expect(output).toContain('Installation Completed Successfully');
+  });
+
+  test('contains next steps section', () => {
+    const output = formatSuccessMessage();
+    expect(output).toContain('Next Steps');
+    expect(output).toContain('.aios-install.log');
+    expect(output).toContain('aios config --check');
+    expect(output).toContain('aios validate');
+  });
+
+  test('mentions AIOS has been installed', () => {
+    const output = formatSuccessMessage();
+    expect(output).toContain('AIOS has been installed and configured');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeErrorForUser
+// ---------------------------------------------------------------------------
+describe('sanitizeErrorForUser', () => {
+  test('returns fallback message for null input', () => {
+    expect(sanitizeErrorForUser(null)).toBe('An unknown error occurred');
+  });
+
+  test('returns fallback message for undefined input', () => {
+    expect(sanitizeErrorForUser(undefined)).toBe('An unknown error occurred');
+  });
+
+  test('extracts message from Error object', () => {
+    const result = sanitizeErrorForUser(new Error('something broke'));
+    expect(result).toBe('something broke');
+  });
+
+  test('removes Unix file paths with line:col references', () => {
+    const error = new Error('Error at /Users/foo/bar/baz.js:42:13 happened');
+    const result = sanitizeErrorForUser(error);
+    expect(result).not.toContain('/Users/foo/bar/baz.js');
+    expect(result).toContain('[file]');
+  });
+
+  test('removes Windows file paths with line:col references', () => {
+    const error = new Error('Error at C:\\Users\\foo\\bar.js:10:5 happened');
+    const result = sanitizeErrorForUser(error);
+    expect(result).not.toContain('C:\\Users');
+    expect(result).toContain('[file]');
+  });
+
+  test('removes stack traces (keeps only first line)', () => {
+    const error = new Error('first line');
+    error.message = 'first line\n    at Object.<anonymous> (/a/b.js:1:1)\n    at Module._compile';
+    const result = sanitizeErrorForUser(error);
+    expect(result).not.toContain('at Object');
+    expect(result).not.toContain('Module._compile');
+  });
+
+  test('handles Error-like objects with toString()', () => {
+    const obj = { toString: () => 'stringified error' };
+    const result = sanitizeErrorForUser(obj);
+    expect(result).toBe('stringified error');
+  });
+
+  test('handles Error with no message (uses toString)', () => {
+    const error = new Error();
+    error.message = '';
+    const result = sanitizeErrorForUser(error);
+    // Falls back to toString(), which returns "Error" for empty message
+    expect(typeof result).toBe('string');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getErrorClassification
+// ---------------------------------------------------------------------------
+describe('getErrorClassification', () => {
+  describe('returns CRITICAL for critical error codes', () => {
+    test.each(['EACCES', 'ENOSPC', 'EROFS', 'ENOTDIR', 'EISDIR'])(
+      'returns CRITICAL for %s (from CRITICAL_ERRORS)',
+      (code) => {
+        const result = getErrorClassification(code);
+        expect(result.level).toBe('CRITICAL');
+        expect(result).toBe(ERROR_CLASSIFICATION.CRITICAL);
+      },
+    );
+
+    test('returns CRITICAL for GIT_CORRUPTION (additional critical code)', () => {
+      const result = getErrorClassification('GIT_CORRUPTION');
+      expect(result.level).toBe('CRITICAL');
+      expect(result).toBe(ERROR_CLASSIFICATION.CRITICAL);
+    });
+  });
+
+  describe('returns RECOVERABLE for recoverable error codes', () => {
+    test.each(['NETWORK_TIMEOUT', 'NETWORK_ERROR', 'DEPENDENCY_FAILED'])(
+      'returns RECOVERABLE for %s',
+      (code) => {
+        const result = getErrorClassification(code);
+        expect(result.level).toBe('RECOVERABLE');
+        expect(result).toBe(ERROR_CLASSIFICATION.RECOVERABLE);
+      },
+    );
+  });
+
+  describe('returns WARNING for everything else', () => {
+    test.each([
+      'PACKAGE_CORRUPTION',
+      'CONFIG_PARSE_ERROR',
+      'CONFIG_WRITE_ERROR',
+      'GIT_CONFLICT',
+      'UNKNOWN_ERROR',
+      'SOMETHING_RANDOM',
+    ])('returns WARNING for %s', (code) => {
+      const result = getErrorClassification(code);
+      expect(result.level).toBe('WARNING');
+      expect(result).toBe(ERROR_CLASSIFICATION.WARNING);
+    });
+  });
+});

--- a/tests/cli/utils/score-calculator.test.js
+++ b/tests/cli/utils/score-calculator.test.js
@@ -1,0 +1,327 @@
+'use strict';
+
+const {
+  calculateScores,
+  sortByScore,
+  normalizeScores,
+  calculateRelevanceScore,
+  boostExactMatches,
+  calculateSearchAccuracy,
+} = require('../../../.aios-core/cli/utils/score-calculator');
+
+describe('score-calculator', () => {
+  // Shared fixtures
+  const makeResult = (overrides = {}) => ({
+    id: 'dev',
+    name: 'Dex',
+    tags: ['development', 'code'],
+    category: 'engineering',
+    description: 'Full stack development agent',
+    score: 0,
+    ...overrides,
+  });
+
+  describe('calculateScores', () => {
+    // Use neutral fixtures to isolate each scoring factor
+    const neutral = (overrides = {}) => ({
+      id: 'zz', name: 'ZZ', tags: [], category: '', description: '', score: 0, ...overrides,
+    });
+
+    it('should boost score for exact ID match', () => {
+      const results = [neutral({ id: 'dev' })];
+      const scored = calculateScores(results, 'dev');
+      expect(scored[0].score).toBe(100);
+    });
+
+    it('should boost score for case-insensitive ID match', () => {
+      const results = [neutral({ id: 'Dev' })];
+      const scored = calculateScores(results, 'dev');
+      expect(scored[0].score).toBeGreaterThanOrEqual(99);
+    });
+
+    it('should boost score for partial ID match', () => {
+      const results = [neutral({ id: 'devops' })];
+      const scored = calculateScores(results, 'dev');
+      expect(scored[0].score).toBeGreaterThanOrEqual(95);
+    });
+
+    it('should boost score for exact name match', () => {
+      const results = [neutral({ name: 'Dex' })];
+      const scored = calculateScores(results, 'dex');
+      expect(scored[0].score).toBeGreaterThanOrEqual(98);
+    });
+
+    it('should boost score for partial name match', () => {
+      const results = [neutral({ name: 'Developer Agent' })];
+      const scored = calculateScores(results, 'developer');
+      expect(scored[0].score).toBeGreaterThanOrEqual(90);
+    });
+
+    it('should boost score for tag matches', () => {
+      const results = [neutral({ tags: ['testing', 'qa'] })];
+      const scored = calculateScores(results, 'testing qa');
+      expect(scored[0].score).toBeGreaterThan(0);
+    });
+
+    it('should boost score for category match', () => {
+      const results = [neutral({ category: 'engineering' })];
+      const scored = calculateScores(results, 'engineering');
+      expect(scored[0].score).toBeGreaterThan(0);
+    });
+
+    it('should clamp scores to 0-100 range', () => {
+      const results = [neutral({ score: 200 })];
+      const scored = calculateScores(results, 'zzzznothing');
+      expect(scored[0].score).toBeLessThanOrEqual(100);
+    });
+
+    it('should preserve existing score when no matches', () => {
+      const results = [neutral({ score: 50 })];
+      const scored = calculateScores(results, 'zzzzz');
+      expect(scored[0].score).toBe(50);
+    });
+
+    it('should handle results without tags or category', () => {
+      const results = [{ id: 'x', name: 'y', score: 0 }];
+      expect(() => calculateScores(results, 'test')).not.toThrow();
+    });
+
+    it('should handle empty results array', () => {
+      const scored = calculateScores([], 'dev');
+      expect(scored).toEqual([]);
+    });
+  });
+
+  describe('sortByScore', () => {
+    it('should sort results by score descending', () => {
+      const results = [
+        makeResult({ id: 'low', score: 10 }),
+        makeResult({ id: 'high', score: 90 }),
+        makeResult({ id: 'mid', score: 50 }),
+      ];
+      const sorted = sortByScore(results);
+      expect(sorted[0].id).toBe('high');
+      expect(sorted[1].id).toBe('mid');
+      expect(sorted[2].id).toBe('low');
+    });
+
+    it('should use name length as tiebreaker (shorter first)', () => {
+      const results = [
+        makeResult({ id: 'a', name: 'Developer Agent', score: 80 }),
+        makeResult({ id: 'b', name: 'Dev', score: 80 }),
+      ];
+      const sorted = sortByScore(results);
+      expect(sorted[0].name).toBe('Dev');
+      expect(sorted[1].name).toBe('Developer Agent');
+    });
+
+    it('should not mutate the original array', () => {
+      const results = [
+        makeResult({ id: 'b', score: 10 }),
+        makeResult({ id: 'a', score: 90 }),
+      ];
+      const sorted = sortByScore(results);
+      expect(results[0].id).toBe('b');
+      expect(sorted[0].id).toBe('a');
+    });
+
+    it('should handle empty array', () => {
+      expect(sortByScore([])).toEqual([]);
+    });
+  });
+
+  describe('normalizeScores', () => {
+    it('should normalize scores to 0-100 range', () => {
+      const results = [
+        makeResult({ score: 10 }),
+        makeResult({ score: 50 }),
+        makeResult({ score: 90 }),
+      ];
+      const normalized = normalizeScores(results);
+      expect(normalized[0].score).toBe(0);
+      expect(normalized[2].score).toBe(100);
+    });
+
+    it('should return as-is when all scores are equal', () => {
+      const results = [
+        makeResult({ id: 'a', score: 50 }),
+        makeResult({ id: 'b', score: 50 }),
+      ];
+      const normalized = normalizeScores(results);
+      expect(normalized[0].score).toBe(50);
+      expect(normalized[1].score).toBe(50);
+    });
+
+    it('should handle empty array', () => {
+      expect(normalizeScores([])).toEqual([]);
+    });
+
+    it('should handle single result', () => {
+      const results = [makeResult({ score: 75 })];
+      const normalized = normalizeScores(results);
+      expect(normalized[0].score).toBe(75);
+    });
+  });
+
+  describe('calculateRelevanceScore', () => {
+    const makeWorker = (overrides = {}) => ({
+      id: 'dev',
+      name: 'Dex',
+      tags: ['development'],
+      description: 'Full stack developer',
+      category: 'engineering',
+      ...overrides,
+    });
+
+    it('should give highest score for exact ID match', () => {
+      const score = calculateRelevanceScore(makeWorker(), 'dev');
+      expect(score).toBeGreaterThanOrEqual(90);
+    });
+
+    it('should score partial ID match lower than exact when using low weights', () => {
+      const lowWeights = { idWeight: 0.5, nameWeight: 0, tagWeight: 0, descriptionWeight: 0, categoryWeight: 0 };
+      const exact = calculateRelevanceScore(
+        makeWorker({ id: 'dev', name: 'x', tags: [], description: '', category: '' }), 'dev', lowWeights,
+      );
+      const partial = calculateRelevanceScore(
+        makeWorker({ id: 'devops', name: 'x', tags: [], description: '', category: '' }), 'dev', lowWeights,
+      );
+      expect(exact).toBeGreaterThan(partial);
+    });
+
+    it('should boost for name match', () => {
+      const withName = calculateRelevanceScore(makeWorker({ id: 'x', name: 'development' }), 'development');
+      const noName = calculateRelevanceScore(makeWorker({ id: 'x', name: 'zzz' }), 'development');
+      expect(withName).toBeGreaterThan(noName);
+    });
+
+    it('should boost for tag match', () => {
+      const withTags = calculateRelevanceScore(makeWorker({ id: 'x', name: 'x', tags: ['testing'] }), 'testing');
+      const noTags = calculateRelevanceScore(makeWorker({ id: 'x', name: 'x', tags: [] }), 'testing');
+      expect(withTags).toBeGreaterThan(noTags);
+    });
+
+    it('should boost for description match', () => {
+      const withDesc = calculateRelevanceScore(
+        makeWorker({ id: 'x', name: 'x', tags: [], description: 'handles testing' }),
+        'testing',
+      );
+      const noDesc = calculateRelevanceScore(
+        makeWorker({ id: 'x', name: 'x', tags: [], description: '' }),
+        'testing',
+      );
+      expect(withDesc).toBeGreaterThan(noDesc);
+    });
+
+    it('should boost for category match', () => {
+      const withCat = calculateRelevanceScore(
+        makeWorker({ id: 'x', name: 'x', tags: [], description: '', category: 'testing' }),
+        'testing',
+      );
+      const noCat = calculateRelevanceScore(
+        makeWorker({ id: 'x', name: 'x', tags: [], description: '', category: '' }),
+        'testing',
+      );
+      expect(withCat).toBeGreaterThan(noCat);
+    });
+
+    it('should respect custom weights', () => {
+      const worker = makeWorker({ id: 'dev' });
+      const highWeight = calculateRelevanceScore(worker, 'dev', { idWeight: 3.0 });
+      const lowWeight = calculateRelevanceScore(worker, 'dev', { idWeight: 0.5 });
+      expect(highWeight).toBeGreaterThanOrEqual(lowWeight);
+    });
+
+    it('should cap score at 100', () => {
+      const score = calculateRelevanceScore(makeWorker(), 'dev', { idWeight: 10, nameWeight: 10 });
+      expect(score).toBeLessThanOrEqual(100);
+    });
+
+    it('should handle worker without optional fields', () => {
+      const worker = { id: 'test', name: 'Test' };
+      expect(() => calculateRelevanceScore(worker, 'test')).not.toThrow();
+    });
+  });
+
+  describe('boostExactMatches', () => {
+    it('should set exact ID match to score 100', () => {
+      const results = [makeResult({ id: 'dev', score: 50 })];
+      const boosted = boostExactMatches(results, 'dev');
+      expect(boosted[0].score).toBe(100);
+    });
+
+    it('should be case-insensitive', () => {
+      const results = [makeResult({ id: 'Dev', score: 50 })];
+      const boosted = boostExactMatches(results, 'dev');
+      expect(boosted[0].score).toBe(100);
+    });
+
+    it('should not boost non-matching results', () => {
+      const results = [makeResult({ id: 'qa', score: 50 })];
+      const boosted = boostExactMatches(results, 'dev');
+      expect(boosted[0].score).toBe(50);
+    });
+
+    it('should handle multiple results', () => {
+      const results = [
+        makeResult({ id: 'dev', score: 30 }),
+        makeResult({ id: 'qa', score: 70 }),
+      ];
+      const boosted = boostExactMatches(results, 'dev');
+      expect(boosted[0].score).toBe(100);
+      expect(boosted[1].score).toBe(70);
+    });
+
+    it('should handle empty array', () => {
+      expect(boostExactMatches([], 'dev')).toEqual([]);
+    });
+  });
+
+  describe('calculateSearchAccuracy', () => {
+    it('should return found=true and position for existing ID', () => {
+      const results = [
+        makeResult({ id: 'dev' }),
+        makeResult({ id: 'qa' }),
+      ];
+      const accuracy = calculateSearchAccuracy(results, 'qa');
+      expect(accuracy.found).toBe(true);
+      expect(accuracy.position).toBe(1);
+      expect(accuracy.isFirst).toBe(false);
+    });
+
+    it('should return isFirst=true when expected is first', () => {
+      const results = [
+        makeResult({ id: 'dev' }),
+        makeResult({ id: 'qa' }),
+      ];
+      const accuracy = calculateSearchAccuracy(results, 'dev');
+      expect(accuracy.isFirst).toBe(true);
+      expect(accuracy.accuracy).toBe(100);
+    });
+
+    it('should return found=false for missing ID', () => {
+      const results = [makeResult({ id: 'dev' })];
+      const accuracy = calculateSearchAccuracy(results, 'nonexistent');
+      expect(accuracy.found).toBe(false);
+      expect(accuracy.position).toBe(-1);
+      expect(accuracy.accuracy).toBe(0);
+    });
+
+    it('should handle empty results', () => {
+      const accuracy = calculateSearchAccuracy([], 'dev');
+      expect(accuracy.found).toBe(false);
+      expect(accuracy.accuracy).toBe(0);
+    });
+
+    it('should decrease accuracy with position', () => {
+      const results = [
+        makeResult({ id: 'a' }),
+        makeResult({ id: 'b' }),
+        makeResult({ id: 'target' }),
+      ];
+      const accuracy = calculateSearchAccuracy(results, 'target');
+      expect(accuracy.accuracy).toBeLessThan(100);
+      expect(accuracy.accuracy).toBeGreaterThan(0);
+    });
+  });
+});

--- a/tests/ide-sync/redirect-generator.test.js
+++ b/tests/ide-sync/redirect-generator.test.js
@@ -1,0 +1,221 @@
+'use strict';
+
+const fs = require('fs-extra');
+const os = require('os');
+const path = require('path');
+
+const {
+  DEFAULT_REDIRECTS,
+  generateRedirectContent,
+  generateRedirect,
+  generateAllRedirects,
+  writeRedirects,
+  getRedirectFilenames,
+} = require('../../.aios-core/infrastructure/scripts/ide-sync/redirect-generator');
+
+describe('redirect-generator', () => {
+  let tmpDir;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'redirect-gen-'));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tmpDir);
+  });
+
+  describe('DEFAULT_REDIRECTS', () => {
+    it('should contain expected deprecated agent mappings', () => {
+      expect(DEFAULT_REDIRECTS).toHaveProperty('aios-developer', 'aios-master');
+      expect(DEFAULT_REDIRECTS).toHaveProperty('aios-orchestrator', 'aios-master');
+      expect(DEFAULT_REDIRECTS).toHaveProperty('db-sage', 'data-engineer');
+      expect(DEFAULT_REDIRECTS).toHaveProperty('github-devops', 'devops');
+    });
+
+    it('should have exactly 4 entries', () => {
+      expect(Object.keys(DEFAULT_REDIRECTS)).toHaveLength(4);
+    });
+  });
+
+  describe('generateRedirectContent', () => {
+    it('should generate full-markdown-yaml format with header and table', () => {
+      const content = generateRedirectContent('db-sage', 'data-engineer', 'full-markdown-yaml');
+
+      expect(content).toContain('# Agent Redirect: db-sage → data-engineer');
+      expect(content).toContain('**DEPRECATED:**');
+      expect(content).toContain('Use `@data-engineer` instead.');
+      expect(content).toContain('| Old ID | @db-sage |');
+      expect(content).toContain('| New ID | @data-engineer |');
+      expect(content).toContain('AIOS Redirect - Synced automatically');
+    });
+
+    it('should generate xml-tagged-markdown format with redirect tags', () => {
+      const content = generateRedirectContent('aios-developer', 'aios-master', 'xml-tagged-markdown');
+
+      expect(content).toContain('<redirect>');
+      expect(content).toContain('Old: @aios-developer');
+      expect(content).toContain('New: @aios-master');
+      expect(content).toContain('</redirect>');
+      expect(content).toContain('<notice>');
+    });
+
+    it('should generate condensed-rules format', () => {
+      const content = generateRedirectContent('github-devops', 'devops', 'condensed-rules');
+
+      expect(content).toContain('# Agent Redirect: github-devops → devops');
+      expect(content).toContain('> **DEPRECATED:**');
+      expect(content).not.toContain('<redirect>');
+      expect(content).not.toContain('| Property |');
+    });
+
+    it('should generate cursor-style format (same as condensed)', () => {
+      const content = generateRedirectContent('github-devops', 'devops', 'cursor-style');
+
+      expect(content).toContain('# Agent Redirect: github-devops → devops');
+      expect(content).toContain('> **DEPRECATED:**');
+    });
+
+    it('should use condensed format as default for unknown formats', () => {
+      const content = generateRedirectContent('db-sage', 'data-engineer', 'unknown-format');
+
+      expect(content).toContain('# Agent Redirect: db-sage → data-engineer');
+      expect(content).toContain('> **DEPRECATED:**');
+      expect(content).not.toContain('<redirect>');
+    });
+  });
+
+  describe('generateRedirect', () => {
+    it('should return an object with correct properties', () => {
+      const result = generateRedirect('db-sage', 'data-engineer', tmpDir, 'full-markdown-yaml');
+
+      expect(result.oldId).toBe('db-sage');
+      expect(result.newId).toBe('data-engineer');
+      expect(result.filename).toBe('db-sage.md');
+      expect(result.path).toBe(path.join(tmpDir, 'db-sage.md'));
+      expect(result.content).toContain('Agent Redirect');
+    });
+
+    it('should generate correct filename from oldId', () => {
+      const result = generateRedirect('aios-orchestrator', 'aios-master', tmpDir, 'condensed-rules');
+
+      expect(result.filename).toBe('aios-orchestrator.md');
+    });
+  });
+
+  describe('generateAllRedirects', () => {
+    it('should generate redirects from custom config', () => {
+      const config = {
+        'old-agent': 'new-agent',
+        'legacy-bot': 'modern-bot',
+      };
+
+      const results = generateAllRedirects(config, tmpDir, 'full-markdown-yaml');
+
+      expect(results).toHaveLength(2);
+      expect(results[0].oldId).toBe('old-agent');
+      expect(results[0].newId).toBe('new-agent');
+      expect(results[1].oldId).toBe('legacy-bot');
+      expect(results[1].newId).toBe('modern-bot');
+    });
+
+    it('should use DEFAULT_REDIRECTS when config is null', () => {
+      const results = generateAllRedirects(null, tmpDir, 'full-markdown-yaml');
+
+      expect(results).toHaveLength(4);
+      const oldIds = results.map((r) => r.oldId);
+      expect(oldIds).toContain('aios-developer');
+      expect(oldIds).toContain('db-sage');
+    });
+
+    it('should apply the specified format to all redirects', () => {
+      const config = { 'test-old': 'test-new' };
+      const results = generateAllRedirects(config, tmpDir, 'xml-tagged-markdown');
+
+      expect(results[0].content).toContain('<redirect>');
+    });
+
+    it('should handle empty config', () => {
+      const results = generateAllRedirects({}, tmpDir, 'full-markdown-yaml');
+
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('writeRedirects', () => {
+    it('should write redirect files to disk', () => {
+      const redirects = generateAllRedirects({ 'old-a': 'new-a' }, tmpDir, 'full-markdown-yaml');
+      const result = writeRedirects(redirects, false);
+
+      expect(result.written).toHaveLength(1);
+      expect(result.errors).toHaveLength(0);
+      expect(fs.existsSync(path.join(tmpDir, 'old-a.md'))).toBe(true);
+
+      const content = fs.readFileSync(path.join(tmpDir, 'old-a.md'), 'utf8');
+      expect(content).toContain('Agent Redirect: old-a → new-a');
+    });
+
+    it('should not write files in dry-run mode', () => {
+      const redirects = generateAllRedirects({ 'dry-old': 'dry-new' }, tmpDir, 'full-markdown-yaml');
+      const result = writeRedirects(redirects, true);
+
+      // In dry-run, written tracks what *would* be written, but no file is created
+      expect(result.written).toHaveLength(1);
+      expect(fs.existsSync(path.join(tmpDir, 'dry-old.md'))).toBe(false);
+    });
+
+    it('should create subdirectories if needed', () => {
+      const nestedDir = path.join(tmpDir, 'nested', 'deep');
+      const redirects = generateAllRedirects({ 'nested-old': 'nested-new' }, nestedDir, 'condensed-rules');
+      const result = writeRedirects(redirects, false);
+
+      expect(result.written).toHaveLength(1);
+      expect(fs.existsSync(path.join(nestedDir, 'nested-old.md'))).toBe(true);
+    });
+
+    it('should handle write errors gracefully', () => {
+      // Use os.devNull for cross-platform compatibility
+      const impossiblePath = path.join(os.devNull, 'impossible', 'bad.md');
+      const redirects = [
+        {
+          oldId: 'bad',
+          newId: 'target',
+          filename: 'bad.md',
+          path: impossiblePath,
+          content: 'test',
+        },
+      ];
+
+      const result = writeRedirects(redirects, false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('should write multiple redirects', () => {
+      const config = {
+        'agent-a': 'target-a',
+        'agent-b': 'target-b',
+        'agent-c': 'target-c',
+      };
+      const redirects = generateAllRedirects(config, tmpDir, 'full-markdown-yaml');
+      const result = writeRedirects(redirects, false);
+
+      expect(result.written).toHaveLength(3);
+      expect(result.errors).toHaveLength(0);
+    });
+  });
+
+  describe('getRedirectFilenames', () => {
+    it('should return filenames from custom config', () => {
+      const filenames = getRedirectFilenames({ 'old-x': 'new-x', 'old-y': 'new-y' });
+
+      expect(filenames).toEqual(['old-x.md', 'old-y.md']);
+    });
+
+    it('should return filenames from DEFAULT_REDIRECTS when config is null', () => {
+      const filenames = getRedirectFilenames(null);
+
+      expect(filenames).toHaveLength(4);
+      expect(filenames).toContain('aios-developer.md');
+      expect(filenames).toContain('db-sage.md');
+    });
+  });
+});

--- a/tests/infrastructure/changelog-generator.test.js
+++ b/tests/infrastructure/changelog-generator.test.js
@@ -1,0 +1,838 @@
+/**
+ * Tests for ChangelogGenerator
+ * @see .aios-core/infrastructure/scripts/changelog-generator.js
+ */
+
+const path = require('path');
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+// Mock child_process
+jest.mock('child_process', () => ({
+  execSync: jest.fn(),
+}));
+
+// Mock fs
+jest.mock('fs', () => ({
+  existsSync: jest.fn(),
+  readFileSync: jest.fn(),
+  writeFileSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  readdirSync: jest.fn(),
+  statSync: jest.fn(),
+}));
+
+const ChangelogGenerator = require('../../.aios-core/infrastructure/scripts/changelog-generator');
+
+describe('ChangelogGenerator', () => {
+  let generator;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    generator = new ChangelogGenerator({ rootPath: '/test/root' });
+  });
+
+  // ─── Constructor ───────────────────────────────────────────────
+
+  describe('constructor', () => {
+    it('should use provided rootPath', () => {
+      const g = new ChangelogGenerator({ rootPath: '/custom/path' });
+      expect(g.rootPath).toBe('/custom/path');
+    });
+
+    it('should default rootPath to cwd', () => {
+      const g = new ChangelogGenerator();
+      expect(g.rootPath).toBe(process.cwd());
+    });
+
+    it('should set custom changelogPath', () => {
+      const g = new ChangelogGenerator({ changelogPath: '/custom/CHANGELOG.md' });
+      expect(g.changelogPath).toBe('/custom/CHANGELOG.md');
+    });
+
+    it('should set custom jsonPath', () => {
+      const g = new ChangelogGenerator({ jsonPath: '/custom/changelog.json' });
+      expect(g.jsonPath).toBe('/custom/changelog.json');
+    });
+
+    it('should set default changelogPath based on rootPath', () => {
+      expect(generator.changelogPath).toBe(path.join('/test/root', 'docs', 'CHANGELOG.md'));
+    });
+
+    it('should set default jsonPath based on rootPath', () => {
+      expect(generator.jsonPath).toBe(path.join('/test/root', '.aios', 'changelog.json'));
+    });
+
+    it('should initialize category mapping with conventional commit types', () => {
+      expect(generator.categories.feat).toBe('Added');
+      expect(generator.categories.fix).toBe('Fixed');
+      expect(generator.categories.perf).toBe('Performance');
+      expect(generator.categories.refactor).toBe('Changed');
+      expect(generator.categories.docs).toBe('Documentation');
+      expect(generator.categories.breaking).toBe('Breaking Changes');
+      expect(generator.categories.deprecated).toBe('Deprecated');
+      expect(generator.categories.removed).toBe('Removed');
+      expect(generator.categories.security).toBe('Security');
+    });
+
+    it('should exclude chores, tests, and CI from categories', () => {
+      expect(generator.categories.chore).toBeNull();
+      expect(generator.categories.test).toBeNull();
+      expect(generator.categories.ci).toBeNull();
+    });
+
+    it('should define category order', () => {
+      expect(generator.categoryOrder).toEqual([
+        'Breaking Changes',
+        'Added',
+        'Changed',
+        'Deprecated',
+        'Removed',
+        'Fixed',
+        'Security',
+        'Performance',
+        'Documentation',
+      ]);
+    });
+
+    it('should define story patterns for extraction', () => {
+      expect(generator.storyPatterns).toHaveLength(4);
+    });
+  });
+
+  // ─── extractCommitType ─────────────────────────────────────────
+
+  describe('extractCommitType', () => {
+    it('should extract type from conventional commit format', () => {
+      expect(generator.extractCommitType('feat: add new feature')).toBe('feat');
+    });
+
+    it('should extract type with scope', () => {
+      expect(generator.extractCommitType('fix(core): resolve bug')).toBe('fix');
+    });
+
+    it('should extract type with breaking change indicator', () => {
+      expect(generator.extractCommitType('feat!: breaking change')).toBe('feat');
+    });
+
+    it('should extract type with scope and breaking indicator', () => {
+      expect(generator.extractCommitType('refactor(api)!: remove endpoint')).toBe('refactor');
+    });
+
+    it('should fallback to fix for messages starting with fix', () => {
+      expect(generator.extractCommitType('fix the login bug')).toBe('fix');
+    });
+
+    it('should fallback to fix for messages containing bug', () => {
+      expect(generator.extractCommitType('resolve a nasty bug')).toBe('fix');
+    });
+
+    it('should fallback to feat for messages starting with add', () => {
+      expect(generator.extractCommitType('add new button component')).toBe('feat');
+    });
+
+    it('should parse feature as conventional commit type', () => {
+      expect(generator.extractCommitType('feature: something new')).toBe('feature');
+    });
+
+    it('should fallback to removed for messages starting with remove', () => {
+      expect(generator.extractCommitType('remove deprecated API')).toBe('removed');
+    });
+
+    it('should fallback to removed for messages starting with delete', () => {
+      expect(generator.extractCommitType('delete old files')).toBe('removed');
+    });
+
+    it('should fallback to deprecated for messages starting with deprecate', () => {
+      expect(generator.extractCommitType('deprecate old API')).toBe('deprecated');
+    });
+
+    it('should fallback to docs for messages starting with doc', () => {
+      expect(generator.extractCommitType('document the process')).toBe('docs');
+    });
+
+    it('should default to change for unrecognized messages', () => {
+      expect(generator.extractCommitType('some random message')).toBe('change');
+    });
+
+    it('should handle null message', () => {
+      expect(generator.extractCommitType(null)).toBe('change');
+    });
+
+    it('should handle undefined message', () => {
+      expect(generator.extractCommitType(undefined)).toBe('change');
+    });
+
+    it('should handle empty string', () => {
+      expect(generator.extractCommitType('')).toBe('change');
+    });
+
+    it('should be case insensitive for keyword fallbacks', () => {
+      expect(generator.extractCommitType('FIX something')).toBe('fix');
+      expect(generator.extractCommitType('Add feature')).toBe('feat');
+    });
+  });
+
+  // ─── extractStoryRef ───────────────────────────────────────────
+
+  describe('extractStoryRef', () => {
+    it('should extract [Story X.Y] pattern', () => {
+      expect(generator.extractStoryRef('feat: add thing [Story 2.1]')).toBe('Story 2.1');
+    });
+
+    it('should extract (Story X.Y) pattern', () => {
+      expect(generator.extractStoryRef('fix: bug (Story 3.5)')).toBe('Story 3.5');
+    });
+
+    it('should extract Story-X pattern', () => {
+      expect(generator.extractStoryRef('fix: resolve Story-4.2 issue')).toBe('Story 4.2');
+    });
+
+    it('should extract #N pattern', () => {
+      expect(generator.extractStoryRef('feat: implement #42')).toBe('Story 42');
+    });
+
+    it('should extract integer story ID', () => {
+      expect(generator.extractStoryRef('feat: thing [Story 5]')).toBe('Story 5');
+    });
+
+    it('should return null for no story ref', () => {
+      expect(generator.extractStoryRef('just a plain commit')).toBeNull();
+    });
+
+    it('should be case insensitive', () => {
+      expect(generator.extractStoryRef('feat: thing [STORY 2.1]')).toBe('Story 2.1');
+    });
+  });
+
+  // ─── parseStory ────────────────────────────────────────────────
+
+  describe('parseStory', () => {
+    it('should extract title from markdown heading', () => {
+      const result = generator.parseStory('# My Story Title\nSome content', 'story-1.md');
+      expect(result.title).toBe('My Story Title');
+    });
+
+    it('should extract title from yaml title field', () => {
+      const result = generator.parseStory('title: YAML Title\nstatus: done', 'story.yaml');
+      expect(result.title).toBe('YAML Title');
+    });
+
+    it('should use filename as fallback title', () => {
+      const result = generator.parseStory('no heading here', 'my-feature.md');
+      expect(result.title).toBe('my-feature');
+    });
+
+    it('should strip Story: prefix from title', () => {
+      const result = generator.parseStory('# Story: My Feature\n', 'story.md');
+      expect(result.title).toBe('My Feature');
+    });
+
+    it('should extract story ID from filename', () => {
+      const result = generator.parseStory('# Title', 'story-2.1.md');
+      expect(result.id).toBe('2.1');
+    });
+
+    it('should extract story ID from yaml content', () => {
+      const result = generator.parseStory('id: 3.5\ntitle: Test', 'file.yaml');
+      expect(result.id).toBe('3.5');
+    });
+
+    it('should detect fix type', () => {
+      const result = generator.parseStory('# Fix login bug\nfixing something', 'fix.md');
+      expect(result.type).toBe('fix');
+    });
+
+    it('should detect refactor type', () => {
+      const result = generator.parseStory('# Refactor core\nrefactor the module', 'story.md');
+      expect(result.type).toBe('refactor');
+    });
+
+    it('should detect docs type', () => {
+      const result = generator.parseStory('# Update documentation\ndocs for API', 'story.md');
+      expect(result.type).toBe('docs');
+    });
+
+    it('should default to feature type', () => {
+      const result = generator.parseStory('# New awesome thing\n', 'story.md');
+      expect(result.type).toBe('feature');
+    });
+
+    it('should extract user story if present', () => {
+      const content = '**As a** developer, **I want** better tests, **so that** code is reliable';
+      const result = generator.parseStory(content, 'story.md');
+      expect(result.userStory).not.toBeNull();
+      expect(result.userStory.role).toBe('developer');
+      expect(result.userStory.action).toBe('better tests');
+      expect(result.userStory.benefit).toBe('code is reliable');
+    });
+
+    it('should return null userStory when not present', () => {
+      const result = generator.parseStory('# Simple story', 'story.md');
+      expect(result.userStory).toBeNull();
+    });
+  });
+
+  // ─── storyToCategory ──────────────────────────────────────────
+
+  describe('storyToCategory', () => {
+    it('should map feature to Added', () => {
+      expect(generator.storyToCategory({ type: 'feature' })).toBe('Added');
+    });
+
+    it('should map feat to Added', () => {
+      expect(generator.storyToCategory({ type: 'feat' })).toBe('Added');
+    });
+
+    it('should map fix to Fixed', () => {
+      expect(generator.storyToCategory({ type: 'fix' })).toBe('Fixed');
+    });
+
+    it('should map bugfix to Fixed', () => {
+      expect(generator.storyToCategory({ type: 'bugfix' })).toBe('Fixed');
+    });
+
+    it('should map refactor to Changed', () => {
+      expect(generator.storyToCategory({ type: 'refactor' })).toBe('Changed');
+    });
+
+    it('should map docs to Documentation', () => {
+      expect(generator.storyToCategory({ type: 'docs' })).toBe('Documentation');
+    });
+
+    it('should map breaking to Breaking Changes', () => {
+      expect(generator.storyToCategory({ type: 'breaking' })).toBe('Breaking Changes');
+    });
+
+    it('should default to Added for unknown types', () => {
+      expect(generator.storyToCategory({ type: 'unknown' })).toBe('Added');
+    });
+  });
+
+  // ─── formatCommit ─────────────────────────────────────────────
+
+  describe('formatCommit', () => {
+    it('should strip conventional commit prefix', () => {
+      const result = generator.formatCommit({ message: 'feat: add new feature', hash: 'abc12345' });
+      expect(result).toBe('Add new feature');
+    });
+
+    it('should strip prefix with scope', () => {
+      const result = generator.formatCommit({ message: 'fix(core): resolve issue', hash: 'abc12345' });
+      expect(result).toBe('Resolve issue');
+    });
+
+    it('should capitalize first letter', () => {
+      const result = generator.formatCommit({ message: 'feat: something cool', hash: 'abc' });
+      expect(result).toMatch(/^S/);
+    });
+
+    it('should append story reference', () => {
+      const result = generator.formatCommit({ message: 'feat: add thing [Story 2.1]', hash: 'abc' });
+      expect(result).toContain('[Story 2.1]');
+    });
+
+    it('should handle commit with no message', () => {
+      const result = generator.formatCommit({ hash: 'abc12345' });
+      expect(result).toBe('abc12345');
+    });
+
+    it('should handle commit with undefined message', () => {
+      const result = generator.formatCommit({ message: undefined, hash: 'def' });
+      expect(result).toBe('def');
+    });
+
+    it('should return Unknown commit when no message and no hash', () => {
+      const result = generator.formatCommit({});
+      expect(result).toBe('Unknown commit');
+    });
+  });
+
+  // ─── formatStory ──────────────────────────────────────────────
+
+  describe('formatStory', () => {
+    it('should format story with ID', () => {
+      const result = generator.formatStory({ title: 'New Feature', id: '2.1' });
+      expect(result).toBe('New Feature [Story 2.1]');
+    });
+
+    it('should format story without ID', () => {
+      const result = generator.formatStory({ title: 'Another Feature', id: null });
+      expect(result).toBe('Another Feature');
+    });
+  });
+
+  // ─── categorize ───────────────────────────────────────────────
+
+  describe('categorize', () => {
+    it('should categorize feat commits as Added', () => {
+      const commits = [{ message: 'feat: add widget', hash: 'abc' }];
+      const result = generator.categorize(commits, []);
+      expect(result['Added']).toHaveLength(1);
+    });
+
+    it('should categorize fix commits as Fixed', () => {
+      const commits = [{ message: 'fix: resolve crash', hash: 'abc' }];
+      const result = generator.categorize(commits, []);
+      expect(result['Fixed']).toHaveLength(1);
+    });
+
+    it('should skip chore commits', () => {
+      const commits = [{ message: 'chore: update deps', hash: 'abc' }];
+      const result = generator.categorize(commits, []);
+      const totalEntries = Object.values(result).flat().length;
+      expect(totalEntries).toBe(0);
+    });
+
+    it('should skip test commits', () => {
+      const commits = [{ message: 'test: add tests', hash: 'abc' }];
+      const result = generator.categorize(commits, []);
+      const totalEntries = Object.values(result).flat().length;
+      expect(totalEntries).toBe(0);
+    });
+
+    it('should detect breaking changes from BREAKING keyword', () => {
+      const commits = [{ message: 'feat: BREAKING remove old API', hash: 'abc' }];
+      const result = generator.categorize(commits, []);
+      expect(result['Breaking Changes']).toHaveLength(1);
+    });
+
+    it('should detect breaking changes from !: marker', () => {
+      const commits = [{ message: 'feat!: something big', hash: 'abc' }];
+      const result = generator.categorize(commits, []);
+      expect(result['Breaking Changes']).toHaveLength(1);
+    });
+
+    it('should detect breaking changes from body', () => {
+      const commits = [{ message: 'feat: something', body: 'BREAKING: changes API', hash: 'abc' }];
+      const result = generator.categorize(commits, []);
+      expect(result['Breaking Changes']).toHaveLength(1);
+    });
+
+    it('should process stories into correct categories', () => {
+      const stories = [{ title: 'New Dashboard', type: 'feature', id: '5.1' }];
+      const result = generator.categorize([], stories);
+      expect(result['Added']).toHaveLength(1);
+    });
+
+    it('should not duplicate stories already present from commits', () => {
+      const commits = [{ message: 'feat: New Dashboard', hash: 'abc' }];
+      const stories = [{ title: 'New Dashboard', type: 'feature', id: '5.1' }];
+      const result = generator.categorize(commits, stories);
+      expect(result['Added']).toHaveLength(1);
+    });
+
+    it('should skip null/invalid commits', () => {
+      const commits = [null, { message: null }, { message: 'feat: valid', hash: 'abc' }];
+      const result = generator.categorize(commits, []);
+      expect(result['Added']).toHaveLength(1);
+    });
+
+    it('should initialize all category arrays', () => {
+      const result = generator.categorize([], []);
+      for (const category of generator.categoryOrder) {
+        expect(result[category]).toEqual([]);
+      }
+    });
+  });
+
+  // ─── format ───────────────────────────────────────────────────
+
+  describe('format', () => {
+    it('should generate markdown with version header', () => {
+      const categorized = { Added: ['Feature 1'], Fixed: [], Changed: [] };
+      // Initialize all categories
+      for (const cat of generator.categoryOrder) {
+        if (!categorized[cat]) categorized[cat] = [];
+      }
+      const result = generator.format(categorized, '1.0.0');
+      expect(result).toContain('## [1.0.0]');
+    });
+
+    it('should include date in header', () => {
+      const categorized = {};
+      for (const cat of generator.categoryOrder) categorized[cat] = [];
+      categorized['Added'] = ['Test'];
+      const result = generator.format(categorized, '1.0.0');
+      const today = new Date().toISOString().split('T')[0];
+      expect(result).toContain(today);
+    });
+
+    it('should include category headings for non-empty categories', () => {
+      const categorized = {};
+      for (const cat of generator.categoryOrder) categorized[cat] = [];
+      categorized['Added'] = ['Feature A'];
+      categorized['Fixed'] = ['Bug B'];
+      const result = generator.format(categorized, '1.0.0');
+      expect(result).toContain('### Added');
+      expect(result).toContain('### Fixed');
+    });
+
+    it('should skip empty categories', () => {
+      const categorized = {};
+      for (const cat of generator.categoryOrder) categorized[cat] = [];
+      categorized['Added'] = ['Feature A'];
+      const result = generator.format(categorized, '1.0.0');
+      expect(result).not.toContain('### Fixed');
+      expect(result).not.toContain('### Changed');
+    });
+
+    it('should format items as bullet points', () => {
+      const categorized = {};
+      for (const cat of generator.categoryOrder) categorized[cat] = [];
+      categorized['Added'] = ['Feature 1', 'Feature 2'];
+      const result = generator.format(categorized, '1.0.0');
+      expect(result).toContain('- Feature 1');
+      expect(result).toContain('- Feature 2');
+    });
+
+    it('should handle Unreleased version', () => {
+      const categorized = {};
+      for (const cat of generator.categoryOrder) categorized[cat] = [];
+      const result = generator.format(categorized, 'Unreleased');
+      expect(result).toContain('## [Unreleased]');
+    });
+  });
+
+  // ─── getLastReleaseTag ─────────────────────────────────────────
+
+  describe('getLastReleaseTag', () => {
+    it('should return latest tag when available', async () => {
+      execSync.mockReturnValueOnce('v1.2.3\n');
+      const tag = await generator.getLastReleaseTag();
+      expect(tag).toBe('v1.2.3');
+    });
+
+    it('should fallback to first commit when no tags', async () => {
+      execSync.mockImplementationOnce(() => { throw new Error('no tags'); });
+      execSync.mockReturnValueOnce('abc123\n');
+      const tag = await generator.getLastReleaseTag();
+      expect(tag).toBe('abc123');
+    });
+
+    it('should fallback to HEAD~100 when no commits found', async () => {
+      execSync.mockImplementationOnce(() => { throw new Error('no tags'); });
+      execSync.mockImplementationOnce(() => { throw new Error('no commits'); });
+      const tag = await generator.getLastReleaseTag();
+      expect(tag).toBe('HEAD~100');
+    });
+
+    it('should pass rootPath as cwd', async () => {
+      execSync.mockReturnValueOnce('v1.0.0\n');
+      await generator.getLastReleaseTag();
+      expect(execSync).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ cwd: '/test/root' })
+      );
+    });
+  });
+
+  // ─── getCommits ────────────────────────────────────────────────
+
+  describe('getCommits', () => {
+    it('should parse git log output into commit objects', async () => {
+      const sep = '|||CHANGELOG_SEP|||';
+      const log = `abc12345${sep}feat: add thing${sep}Author${sep}2026-01-01T00:00:00Z`;
+      execSync.mockReturnValueOnce(log);
+
+      const commits = await generator.getCommits('v1.0.0', 'HEAD');
+      expect(commits).toHaveLength(1);
+      expect(commits[0].hash).toBe('abc12345');
+      expect(commits[0].message).toBe('feat: add thing');
+      expect(commits[0].author).toBe('Author');
+      expect(commits[0].date).toBe('2026-01-01T00:00:00Z');
+    });
+
+    it('should handle multiple commits', async () => {
+      const sep = '|||CHANGELOG_SEP|||';
+      const log = [
+        `abc${sep}feat: one${sep}Auth1${sep}2026-01-01`,
+        `def${sep}fix: two${sep}Auth2${sep}2026-01-02`,
+      ].join('\n');
+      execSync.mockReturnValueOnce(log);
+
+      const commits = await generator.getCommits('v1.0.0', 'HEAD');
+      expect(commits).toHaveLength(2);
+    });
+
+    it('should skip malformed entries', async () => {
+      const sep = '|||CHANGELOG_SEP|||';
+      const log = `abc${sep}feat: one${sep}Auth${sep}2026-01-01\nmalformed line\n`;
+      execSync.mockReturnValueOnce(log);
+
+      const commits = await generator.getCommits('v1.0.0', 'HEAD');
+      expect(commits).toHaveLength(1);
+    });
+
+    it('should return empty array on error', async () => {
+      execSync.mockImplementationOnce(() => { throw new Error('git error'); });
+      const commits = await generator.getCommits('v1.0.0', 'HEAD');
+      expect(commits).toEqual([]);
+    });
+
+    it('should skip empty lines', async () => {
+      const sep = '|||CHANGELOG_SEP|||';
+      const log = `\nabc${sep}feat: one${sep}Auth${sep}2026-01-01\n\n`;
+      execSync.mockReturnValueOnce(log);
+
+      const commits = await generator.getCommits('v1.0.0', 'HEAD');
+      expect(commits).toHaveLength(1);
+    });
+
+    it('should truncate hash to 8 characters', async () => {
+      const sep = '|||CHANGELOG_SEP|||';
+      const log = `abcdefghijklmnop${sep}feat: test${sep}Author${sep}2026-01-01`;
+      execSync.mockReturnValueOnce(log);
+
+      const commits = await generator.getCommits('v1.0.0', 'HEAD');
+      expect(commits[0].hash).toBe('abcdefgh');
+    });
+  });
+
+  // ─── getCompletedStories ───────────────────────────────────────
+
+  describe('getCompletedStories', () => {
+    it('should return empty array when stories dir does not exist', async () => {
+      fs.existsSync.mockReturnValue(false);
+      const stories = await generator.getCompletedStories('HEAD');
+      expect(stories).toEqual([]);
+    });
+
+    it('should read and parse completed story files', async () => {
+      fs.existsSync.mockReturnValue(true);
+      execSync.mockReturnValueOnce('2026-01-01T00:00:00Z\n');
+      fs.readdirSync.mockReturnValue([
+        { name: 'story-1.md', isDirectory: () => false },
+      ]);
+      fs.readFileSync.mockReturnValue('# My Story\nStatus: Done');
+      fs.statSync.mockReturnValue({ mtime: new Date('2026-02-01') });
+
+      const stories = await generator.getCompletedStories('v1.0.0');
+      expect(stories).toHaveLength(1);
+      expect(stories[0].title).toBe('My Story');
+    });
+
+    it('should skip non-completed stories', async () => {
+      fs.existsSync.mockReturnValue(true);
+      execSync.mockReturnValueOnce('2026-01-01T00:00:00Z\n');
+      fs.readdirSync.mockReturnValue([
+        { name: 'story-1.md', isDirectory: () => false },
+      ]);
+      fs.readFileSync.mockReturnValue('# My Story\nStatus: In Progress');
+      fs.statSync.mockReturnValue({ mtime: new Date('2026-02-01') });
+
+      const stories = await generator.getCompletedStories('v1.0.0');
+      expect(stories).toHaveLength(0);
+    });
+
+    it('should walk subdirectories recursively', async () => {
+      fs.existsSync.mockReturnValue(true);
+      execSync.mockReturnValueOnce('2026-01-01T00:00:00Z\n');
+
+      // First call: root dir
+      fs.readdirSync.mockReturnValueOnce([
+        { name: 'subdir', isDirectory: () => true },
+      ]);
+      // Second call: subdir
+      fs.readdirSync.mockReturnValueOnce([
+        { name: 'story-2.md', isDirectory: () => false },
+      ]);
+      fs.readFileSync.mockReturnValue('# Sub Story\nStatus: Done');
+      fs.statSync.mockReturnValue({ mtime: new Date('2026-02-01') });
+
+      const stories = await generator.getCompletedStories('v1.0.0');
+      expect(stories).toHaveLength(1);
+    });
+
+    it('should skip files older than since date', async () => {
+      fs.existsSync.mockReturnValue(true);
+      execSync.mockReturnValueOnce('2026-02-01T00:00:00Z\n');
+      fs.readdirSync.mockReturnValue([
+        { name: 'old-story.md', isDirectory: () => false },
+      ]);
+      fs.readFileSync.mockReturnValue('# Old Story\nStatus: Done');
+      fs.statSync.mockReturnValue({ mtime: new Date('2026-01-01') });
+
+      const stories = await generator.getCompletedStories('v1.0.0');
+      expect(stories).toHaveLength(0);
+    });
+
+    it('should accept Status: Complete as completed', async () => {
+      fs.existsSync.mockReturnValue(true);
+      execSync.mockReturnValueOnce('2026-01-01T00:00:00Z\n');
+      fs.readdirSync.mockReturnValue([
+        { name: 'story-1.md', isDirectory: () => false },
+      ]);
+      fs.readFileSync.mockReturnValue('# Story\nStatus: Complete');
+      fs.statSync.mockReturnValue({ mtime: new Date('2026-02-01') });
+
+      const stories = await generator.getCompletedStories('v1.0.0');
+      expect(stories).toHaveLength(1);
+    });
+
+    it('should accept lowercase status: done', async () => {
+      fs.existsSync.mockReturnValue(true);
+      execSync.mockReturnValueOnce('2026-01-01T00:00:00Z\n');
+      fs.readdirSync.mockReturnValue([
+        { name: 'story-1.yaml', isDirectory: () => false },
+      ]);
+      fs.readFileSync.mockReturnValue('title: Story\nstatus: done');
+      fs.statSync.mockReturnValue({ mtime: new Date('2026-02-01') });
+
+      const stories = await generator.getCompletedStories('v1.0.0');
+      expect(stories).toHaveLength(1);
+    });
+
+    it('should handle git date parse failure gracefully', async () => {
+      fs.existsSync.mockReturnValue(true);
+      execSync.mockImplementationOnce(() => { throw new Error('bad ref'); });
+      fs.readdirSync.mockReturnValue([
+        { name: 'story-1.md', isDirectory: () => false },
+      ]);
+      fs.readFileSync.mockReturnValue('# Story\nStatus: Done');
+      fs.statSync.mockReturnValue({ mtime: new Date('2026-02-01') });
+
+      // Should still work, falling back to epoch date
+      const stories = await generator.getCompletedStories('invalid-ref');
+      expect(stories).toHaveLength(1);
+    });
+  });
+
+  // ─── save ─────────────────────────────────────────────────────
+
+  describe('save', () => {
+    it('should create directories if they do not exist', async () => {
+      fs.existsSync.mockReturnValue(false);
+      await generator.save('changelog content', { Added: [] }, '1.0.0');
+      expect(fs.mkdirSync).toHaveBeenCalledTimes(2);
+    });
+
+    it('should create new changelog file if none exists', async () => {
+      // Dirs exist, but changelog file and json file do not
+      const changelogPath = generator.changelogPath;
+      const jsonPath = generator.jsonPath;
+      fs.existsSync.mockImplementation((p) => {
+        if (p === changelogPath || p === jsonPath) return false;
+        return true; // dirs exist
+      });
+      await generator.save('## [1.0.0] content', {}, '1.0.0');
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        changelogPath,
+        expect.stringContaining('# Changelog')
+      );
+    });
+
+    it('should insert new version after header in existing changelog', async () => {
+      fs.existsSync.mockReturnValue(true);
+      fs.readFileSync.mockReturnValue('# Changelog\n\n## [0.9.0] - old content\n');
+      await generator.save('## [1.0.0] new content\n', {}, '1.0.0');
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        generator.changelogPath,
+        expect.stringContaining('## [1.0.0] new content')
+      );
+    });
+
+    it('should append if no existing version header found', async () => {
+      fs.existsSync.mockReturnValue(true);
+      fs.readFileSync.mockReturnValue('# Changelog\nSome intro text only');
+      await generator.save('## [1.0.0] content\n', {}, '1.0.0');
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        generator.changelogPath,
+        expect.stringContaining('## [1.0.0] content')
+      );
+    });
+
+    it('should save JSON data with metadata', async () => {
+      fs.existsSync.mockReturnValue(true);
+      fs.readFileSync.mockReturnValue('# Changelog\n\n## [0.9.0] old');
+      const categorized = { Added: ['Feature 1'] };
+      await generator.save('changelog', categorized, '1.0.0');
+      expect(fs.writeFileSync).toHaveBeenCalledWith(
+        generator.jsonPath,
+        expect.stringContaining('"version"')
+      );
+    });
+  });
+
+  // ─── generate ─────────────────────────────────────────────────
+
+  describe('generate', () => {
+    beforeEach(() => {
+      // Default mock for getLastReleaseTag
+      execSync.mockImplementation((cmd) => {
+        if (cmd.includes('describe --tags')) return 'v1.0.0\n';
+        if (cmd.includes('git log')) return '';
+        return '';
+      });
+      fs.existsSync.mockReturnValue(false);
+    });
+
+    it('should return result object with expected properties', async () => {
+      const result = await generator.generate();
+      expect(result).toHaveProperty('version');
+      expect(result).toHaveProperty('since');
+      expect(result).toHaveProperty('until');
+      expect(result).toHaveProperty('commitCount');
+      expect(result).toHaveProperty('storyCount');
+      expect(result).toHaveProperty('changelog');
+      expect(result).toHaveProperty('categorized');
+    });
+
+    it('should use Unreleased as default version', async () => {
+      const result = await generator.generate();
+      expect(result.version).toBe('Unreleased');
+    });
+
+    it('should use provided version', async () => {
+      const result = await generator.generate({ version: '2.0.0' });
+      expect(result.version).toBe('2.0.0');
+    });
+
+    it('should use provided since ref', async () => {
+      const result = await generator.generate({ since: 'v0.5.0' });
+      expect(result.since).toBe('v0.5.0');
+    });
+
+    it('should call save when save option is true', async () => {
+      fs.existsSync.mockReturnValue(false);
+      await generator.generate({ save: true });
+      expect(fs.writeFileSync).toHaveBeenCalled();
+    });
+
+    it('should not call save when save option is false', async () => {
+      await generator.generate({ save: false });
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── preview ──────────────────────────────────────────────────
+
+  describe('preview', () => {
+    it('should return changelog string without saving', async () => {
+      execSync.mockImplementation((cmd) => {
+        if (cmd.includes('describe --tags')) return 'v1.0.0\n';
+        if (cmd.includes('git log')) return '';
+        return '';
+      });
+      fs.existsSync.mockReturnValue(false);
+
+      const result = await generator.preview();
+      expect(typeof result).toBe('string');
+      expect(result).toContain('## [Unreleased]');
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Module exports ───────────────────────────────────────────
+
+  describe('module exports', () => {
+    it('should export ChangelogGenerator class as default', () => {
+      expect(ChangelogGenerator).toBeInstanceOf(Function);
+    });
+
+    it('should export ChangelogGenerator as named export', () => {
+      const mod = require('../../.aios-core/infrastructure/scripts/changelog-generator');
+      expect(mod.ChangelogGenerator).toBe(ChangelogGenerator);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add comprehensive test coverage for CLI and infrastructure utilities.

Closes #441

### Test files added

| File | Module | Key scenarios |
|------|--------|---------------|
| `redirect-generator.test.js` | ide-sync/redirect-generator | URL generation, path handling, cross-platform |
| `score-calculator.test.js` | cli/utils/score-calculator | Score computation, clamping, weighting |
| `install-errors.test.js` | bin/utils/install-errors | Error classification, message formatting |
| `changelog-generator.test.js` | infrastructure/changelog-generator | Changelog generation, commit parsing, filtering |

### How to run

```bash
npx jest tests/ide-sync/redirect-generator.test.js tests/cli/utils/score-calculator.test.js tests/bin/utils/install-errors.test.js tests/infrastructure/changelog-generator.test.js --verbose
```

All tests pass locally with Jest 30.

Related to #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test coverage for multiple core utility modules: install error handling with message formatting and sanitization, search result scoring and relevance calculations, redirect URL generation and file operations, and changelog metadata extraction and generation. These tests validate existing functionality across various scenarios and edge cases to ensure robust internal system behavior and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->