### PR TITLE
fix(security): remove shell: true from execa calls to prevent command injection

### DIFF
--- a/.aios-core/infrastructure/scripts/sandbox-tester.js
+++ b/.aios-core/infrastructure/scripts/sandbox-tester.js
@@ -441,6 +441,7 @@ class SandboxTester {
   /**
    * Execute command in sandbox with timeout
    * Refactored to use execa for cross-platform compatibility
+   * Security: shell: false to prevent shell metacharacter injection
    */
   async runCommand(cwd, command, options = {}) {
     const timeout = options.timeout || 30000;
@@ -453,7 +454,6 @@ class SandboxTester {
 
       const { stdout } = await execa(program, args, {
         cwd,
-        shell: true,
         timeout,
         encoding: 'utf8',
         env: { ...process.env, CI: 'true', NODE_ENV: 'test' },

--- a/.aios-core/infrastructure/scripts/subtask-verifier.js
+++ b/.aios-core/infrastructure/scripts/subtask-verifier.js
@@ -273,10 +273,13 @@ class SubtaskVerifier {
     this._log(`Running command: ${config.command}`, 'info');
 
     if (!execa) {
-      // Fallback to child_process
-      const { execSync } = require('child_process');
+      // Fallback to child_process (no shell for security)
+      const { execFileSync } = require('child_process');
       try {
-        const output = execSync(config.command, {
+        const parts = config.command.split(' ');
+        const program = parts[0];
+        const args = parts.slice(1);
+        const output = execFileSync(program, args, {
           cwd: this.cwd,
           timeout,
           encoding: 'utf8',
@@ -301,7 +304,6 @@ class SubtaskVerifier {
 
       const { stdout, stderr, exitCode } = await execa(program, args, {
         cwd: this.cwd,
-        shell: true,
         timeout,
         encoding: 'utf8',
         env: { ...process.env, CI: 'true' },

--- a/.aios-core/install-manifest.yaml
+++ b/.aios-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 4.2.13
-generated_at: "2026-02-20T22:30:07.846Z"
+generated_at: "2026-02-21T01:28:45.363Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1048
 files:
@@ -1045,7 +1045,7 @@ files:
     type: data
     size: 34251
   - path: data/entity-registry.yaml
-    hash: sha256:5b6223eb4b7fdc532ed707ddb573ea614ec2d824f6c6ac436c9965ac0d9bea9c
+    hash: sha256:8cb1291ecb42f9f72881b3552639d9dd5b85cf6a4c9cc7dce5e6baad8ce14118
     type: data
     size: 292792
   - path: data/learned-patterns.yaml
@@ -3065,9 +3065,9 @@ files:
     type: script
     size: 22266
   - path: infrastructure/scripts/sandbox-tester.js
-    hash: sha256:019af2e23de70d7dacb49faf031ba0c1f5553ecebe52f361bab74bfca73ba609
+    hash: sha256:99b0d340d472d8a543e66547412b47f0bba1ac9ce583d88111f87bcf7764d237
     type: script
-    size: 15702
+    size: 15750
   - path: infrastructure/scripts/security-checker.js
     hash: sha256:467c7366b60460ef1840492ebe6f9d9eb57c307da6b7e71c6dd35bdddf85f4c0
     type: script
@@ -3105,9 +3105,9 @@ files:
     type: script
     size: 39109
   - path: infrastructure/scripts/subtask-verifier.js
-    hash: sha256:ceb0450fa12fa48f0255bb4565858eb1a97b28c30b98d36cb61d52d72e08b054
+    hash: sha256:0da3348f012641f680c34cc92ebe70093b869c5e97f6ca4f03d716ed56e87a60
     type: script
-    size: 22394
+    size: 22524
   - path: infrastructure/scripts/task-skills-sync/index.js
     hash: sha256:1a48832b277eb3a1ad56f36aa12973ac3c79b3343ee91923cdb75489eaaf9459
     type: script


### PR DESCRIPTION
## Summary
- **sandbox-tester.js**: Remove redundant `shell: true` from `execa()` in `runCommand()` — args were already split into array, making shell interpretation unnecessary and a security risk
- **subtask-verifier.js**: Remove `shell: true` from `execa()` path and replace `execSync` fallback with `execFileSync` + proper argument splitting

## Context
Both scripts already split command strings into `program + args` array before passing to `execa()`, making `shell: true` completely redundant. With `shell: true`, shell metacharacters (`;`, `|`, `&&`, `$()`) in command inputs would be interpreted, enabling potential command injection.

## Risk Assessment
- `sandbox-tester.js` was flagged as the **most dangerous file** in the codebase due to `shell: true` + arbitrary command execution
- `subtask-verifier.js` combines shell execution + network access + browser automation — broad attack surface

## Changes
| File | Change |
|------|--------|
| `sandbox-tester.js:454` | Removed `shell: true` from `execa()` options |
| `subtask-verifier.js:277` | Replaced `execSync` with `execFileSync` + arg splitting |
| `subtask-verifier.js:304` | Removed `shell: true` from `execa()` options |

## Test plan
- [ ] `npm test` passes
- [ ] Sandbox tester runs `npm test` and `npm run lint` commands correctly without `shell: true`
- [ ] Subtask verifier command verification works with `execFileSync` fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)