### PR TITLE
fix(security): eliminate supply chain risks from npx and shell execution

### DIFF
--- a/bin/aios-init.js
+++ b/bin/aios-init.js
@@ -36,14 +36,15 @@ const execAsync = promisify(exec);
 /**
  * Execute command with inherited stdio (for npm install -g that needs user interaction)
  * INS-2 Performance: Async version that doesn't block event loop
- * @param {string} command - Command to execute
+ * Security: Uses array args without shell interpretation
+ * @param {string} program - Program to execute
+ * @param {string[]} args - Arguments array
  * @param {object} options - Spawn options
  * @returns {Promise<void>}
  */
-function spawnAsync(command, options = {}) {
+function spawnAsync(program, args = [], options = {}) {
   return new Promise((resolve, reject) => {
-    const [cmd, ...args] = command.split(' ');
-    const child = spawn(cmd, args, { stdio: 'inherit', shell: true, ...options });
+    const child = spawn(program, args, { stdio: 'inherit', ...options });
     child.on('close', (code) => {
       if (code === 0) {
         resolve();
@@ -480,7 +481,7 @@ async function main() {
           console.log(chalk.blue(`📥 Installing ${tool.name}...`));
           try {
             // INS-2 Performance: Use async spawn instead of sync (AC7)
-            await spawnAsync(`npm install -g ${tool.npm}`);
+            await spawnAsync('npm', ['install', '-g', tool.npm]);
             console.log(chalk.green('✓') + ` ${tool.name} installed successfully`);
 
             // Show post-install instructions

--- a/bin/aios.js
+++ b/bin/aios.js
@@ -475,7 +475,8 @@ Examples:
       fixAction: async () => {
         console.log('  🔧 Installing AIOS...');
         try {
-          execSync('npx aios-core install --force --quiet', { stdio: 'inherit', timeout: 60000 });
+          // Use local wizard instead of npx to avoid supply chain risk
+          await runWizard({ force: true, quiet: true });
           console.log('  ✓ Installation complete');
         } catch (installError) {
           console.error(`  ✗ Installation failed: ${installError.message}`);


### PR DESCRIPTION
## Summary
- **aios.js**: Replace `execSync('npx aios-core install --force --quiet')` in `doctor --fix` with local `runWizard()` call — eliminates supply chain risk from resolving packages via npm registry at runtime
- **aios-init.js** (legacy): Refactor `spawnAsync()` from string-based `command.split(' ')` with `shell: true` to `program + args[]` without shell interpretation

## Context
### Supply chain via npx (aios.js)
When `aios doctor --fix` detects a missing installation, it ran `npx aios-core install` which resolves the package from the npm registry. A compromised `aios-core` package on npm would execute arbitrary code. The fix uses the local `runWizard()` function that's already available in the same file.

### Shell execution (aios-init.js)
`spawnAsync()` used `command.split(' ')` + `shell: true`, allowing shell metacharacter injection. Refactored to accept `(program, args[])` directly.

## Files Changed
| File | Change |
|------|--------|
| `bin/aios.js:478` | `execSync('npx ...')` → `await runWizard(...)` |
| `bin/aios-init.js:43` | `spawnAsync(string)` → `spawnAsync(program, args[])` |
| `bin/aios-init.js:484` | Caller updated to new signature |

## Test plan
- [ ] `aios doctor --fix` uses local wizard instead of npx
- [ ] `aios-init.js` installs CLI tools correctly with array-based spawn
- [ ] No shell metacharacters are interpreted in command arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)