### PR TITLE
fix(security): register PreToolUse hooks and fix sql-governance dead code

### DIFF
--- a/.claude/hooks/sql-governance.py
+++ b/.claude/hooks/sql-governance.py
@@ -106,6 +106,12 @@ def is_safe_context(command: str) -> bool:
         if re.search(allowed, command_lower):
             return True
 
+    # Check if SQL content matches safe context patterns (read-only, metadata, etc.)
+    sql = extract_sql_from_command(command)
+    for safe_pattern in SAFE_CONTEXTS:
+        if re.search(safe_pattern, sql, re.IGNORECASE):
+            return True
+
     return False
 
 def detect_dangerous_sql(command: str) -> list[tuple[str, str]]:

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,52 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/read-protection.py",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/enforce-architecture-first.py",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/write-path-validation.py",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/mind-clone-governance.py",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/sql-governance.py",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/slug-validation.py",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "startup",


### PR DESCRIPTION
## Summary
- Register all 6 PreToolUse security hooks in `settings.json` — these hooks existed as files but were **not wired**, meaning governance rules were not being enforced
- Fix `sql-governance.py`: integrate `SAFE_CONTEXTS` patterns into `is_safe_context()` — was previously defined but never referenced (dead code)

## Context
The security hooks in `.claude/hooks/` implement the governance architecture documented in the hooks README, but `settings.json` only had `SessionStart`, `UserPromptSubmit`, `PreCompact`, and `Stop` hooks registered. The `PreToolUse` hooks that enforce security (blocking dangerous SQL, protecting critical files, validating paths) were completely absent.

## Hooks Registered

| Matcher | Hook | Behavior |
|---------|------|----------|
| `Read` | `read-protection.py` | BLOCK partial reads of critical files |
| `Write\|Edit` | `enforce-architecture-first.py` | BLOCK code without prior documentation |
| `Write\|Edit` | `write-path-validation.py` | WARN on misplaced documents |
| `Write\|Edit` | `mind-clone-governance.py` | BLOCK mind clones without DNA |
| `Bash` | `sql-governance.py` | BLOCK dangerous DDL/DML |
| `Bash` | `slug-validation.py` | BLOCK invalid slug formats |

## sql-governance.py fix
```python
# Before: SAFE_CONTEXTS defined but never used
SAFE_CONTEXTS = [r"SELECT\s+.*\bFROM\b", ...]  # dead code

# After: integrated into is_safe_context()
for safe_pattern in SAFE_CONTEXTS:
    if re.search(safe_pattern, sql, re.IGNORECASE):
        return True
```

## Test plan
- [ ] PreToolUse hooks fire on matching tool calls
- [ ] `read-protection.py` blocks partial reads of `.claude/CLAUDE.md`
- [ ] `sql-governance.py` blocks `CREATE TABLE` but allows `SELECT` queries
- [ ] `sql-governance.py` allows `supabase migration` commands
- [ ] Existing `SessionStart`, `PreCompact`, `Stop` hooks unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)