### PR TITLE
fix: Cursor IDE integration not generating rules on install

### DIFF
--- a/.aios-core/product/templates/ide-rules/cursor-rules.md
+++ b/.aios-core/product/templates/ide-rules/cursor-rules.md
@@ -1,115 +1,84 @@
-# Synkra AIOS Development Rules for Cursor
+---
+description: Synkra AIOS Global Rules - Loaded on every conversation
+globs:
+alwaysApply: true
+---
+
+# Synkra AIOS Development Rules
 
 You are working with Synkra AIOS, an AI-Orchestrated System for Full Stack Development.
 
-## Core Development Rules
+## Core Principles (Constitution)
 
-### Agent Integration
-- Recognize AIOS agent activations: @dev, @qa, @architect, @pm, @po, @sm, @analyst
-- Agent commands use * prefix: *help, *create-story, *task, *exit
-- Follow agent-specific workflows and patterns
+1. **CLI First** → Toda funcionalidade CLI antes de qualquer UI
+2. **Story-Driven** → Nenhum código sem uma story associada em `docs/stories/`
+3. **No Invention** → Não inventar requisitos fora dos artefatos existentes
+4. **Quality First** → `npm run lint`, `npm run typecheck`, `npm test` devem passar
+5. **Agent Authority** → Respeitar autoridades exclusivas de cada agente
 
-### Story-Driven Development
-1. **Always work from a story file** in docs/stories/
-2. **Update story checkboxes** as you complete tasks: [ ] → [x]
+## Agent Activation
+
+Reconheça os seguintes atalhos para ativar agentes AIOS. Ao receber um atalho, carregue o arquivo correspondente em `.aios-core/development/agents/` e assuma a persona completa:
+
+| Atalho | Arquivo |
+|--------|---------|
+| `@dev` | `.aios-core/development/agents/dev.md` |
+| `@qa` | `.aios-core/development/agents/qa.md` |
+| `@architect` | `.aios-core/development/agents/architect.md` |
+| `@sm` | `.aios-core/development/agents/sm.md` |
+| `@po` | `.aios-core/development/agents/po.md` |
+| `@pm` | `.aios-core/development/agents/pm.md` |
+| `@analyst` | `.aios-core/development/agents/analyst.md` |
+| `@devops` | `.aios-core/development/agents/devops.md` |
+| `@data-engineer` | `.aios-core/development/agents/data-engineer.md` |
+| `@ux-design-expert` | `.aios-core/development/agents/ux-design-expert.md` |
+| `@squad-creator` | `.aios-core/development/agents/squad-creator.md` |
+| `@aios-master` | `.aios-core/development/agents/aios-master.md` |
+
+### Activation Rules
+
+- Read the FULL agent file (including YAML block) and adopt the persona
+- Display the greeting as specified in the agent definition
+- Agent commands use `*` prefix: `*help`, `*create-story`, `*task`, `*exit`
+- Stay in character until `*exit` is called
+- Only load dependency files when user requests a specific command execution
+
+## Story-Driven Development
+
+1. **Always work from a story file** in `docs/stories/`
+2. **Update story checkboxes** as you complete tasks: `[ ]` → `[x]`
 3. **Maintain the File List** section with all created/modified files
 4. **Follow acceptance criteria** exactly as written
 
-### Code Quality Standards
+## Code Quality Standards
+
 - Write clean, maintainable code following project conventions
 - Include comprehensive error handling
 - Add unit tests for all new functionality
 - Follow existing patterns in the codebase
+- Run all quality gates before marking tasks complete
 
-### Testing Protocol
-- Run all tests before marking tasks complete
-- Ensure linting passes: `npm run lint`
-- Verify type checking: `npm run typecheck`
-- Add tests for new features
-
-## AIOS Framework Structure
+## Project Structure
 
 ```
-aios-core/
-├── agents/       # Agent persona definitions
-├── tasks/        # Executable task workflows
-├── workflows/    # Multi-step workflows
-├── templates/    # Document templates
-└── checklists/   # Validation checklists
+.aios-core/                    # Framework core
+├── development/agents/        # Agent persona definitions (source of truth)
+├── development/tasks/         # Executable task workflows
+├── development/workflows/     # Multi-step workflows
+├── development/templates/     # Document templates
+└── core-config.yaml           # Project configuration
 
 docs/
-├── stories/      # Development stories
-├── prd/          # Sharded PRD sections
-└── architecture/ # Sharded architecture
+├── stories/                   # Development stories
+├── prd/                       # Product Requirements
+└── architecture/              # Architecture docs
 ```
 
-## Development Workflow
-
-1. **Read the story** - Understand requirements fully
-2. **Implement sequentially** - Follow task order
-3. **Test thoroughly** - Validate each step
-4. **Update story** - Mark completed items
-5. **Document changes** - Update File List
-
-## Best Practices
-
-### When implementing:
-- Check existing patterns first
-- Reuse components and utilities
-- Follow naming conventions
-- Keep functions focused and small
-
-### When testing:
-- Write tests alongside implementation
-- Test edge cases
-- Verify error handling
-- Run full test suite
-
-### When documenting:
-- Update README for new features
-- Document API changes
-- Add inline comments for complex logic
-- Keep story File List current
-
-## Git & GitHub
+## Git Conventions
 
 - Use conventional commits: `feat:`, `fix:`, `docs:`, etc.
-- Reference story ID in commits: `feat: implement IDE detection [Story 2.1]`
-- Ensure GitHub CLI is configured: `gh auth status`
-- Push regularly to avoid conflicts
-
-## Common Patterns
-
-### Error Handling
-```javascript
-try {
-  // Operation
-} catch (error) {
-  console.error(`Error in ${operation}:`, error);
-  throw new Error(`Failed to ${operation}: ${error.message}`);
-}
-```
-
-### File Operations
-```javascript
-const fs = require('fs-extra');
-const path = require('path');
-
-// Always use absolute paths
-const filePath = path.join(__dirname, 'relative/path');
-```
-
-### Async/Await
-```javascript
-async function operation() {
-  try {
-    const result = await asyncOperation();
-    return result;
-  } catch (error) {
-    // Handle error appropriately
-  }
-}
-```
+- Reference story ID in commits: `feat: implement feature [Story 1.1]`
+- Only `@devops` agent can push to remote repositories
 
 ---
-*Synkra AIOS Cursor Configuration v1.0* 
+*Synkra AIOS Cursor Rules v2.0 - Auto-configured*

--- a/bin/aios-init.js
+++ b/bin/aios-init.js
@@ -556,7 +556,7 @@ async function main() {
 
     const ideRulesMap = {
       claude: { source: 'claude-rules.md', target: '.claude/CLAUDE.md' },
-      cursor: { source: 'cursor-rules.md', target: '.cursor/rules.md' },
+      cursor: { source: 'cursor-rules.md', target: '.cursor/rules/aios-global.mdc' },
       gemini: { source: 'gemini-rules.md', target: '.gemini/rules.md' },
       'github-copilot': { source: 'copilot-rules.md', target: '.github/chatmodes/aios-agent.md' },
       antigravity: { source: 'antigravity-rules.md', target: '.antigravity/rules.md' },

--- a/bin/modules/env-config.js
+++ b/bin/modules/env-config.js
@@ -352,7 +352,7 @@ async function generateCoreConfigYAML(projectPath, wizardState) {
  */
 function getIDEConfigFile(ideKey) {
   const ideConfigMap = {
-    cursor: '.cursorrules',
+    cursor: '.cursor/rules/aios-global.mdc',
     zed: '.zed/settings.json',
     antigravity: '.antigravity.yaml',
     continue: '.continue/config.json',

--- a/packages/installer/src/config/ide-configs.js
+++ b/packages/installer/src/config/ide-configs.js
@@ -66,11 +66,11 @@ const IDE_CONFIGS = {
   cursor: {
     name: 'Cursor',
     description: '',
-    configFile: path.join('.cursor', 'rules.md'),
+    configFile: path.join('.cursor', 'rules', 'aios-global.mdc'),
     template: 'ide-rules/cursor-rules.md',
     requiresDirectory: true,
     format: 'text',
-    agentFolder: path.join('.cursor', 'rules'),
+    agentFolder: path.join('.cursor', 'rules', 'agents'),
   },
   'github-copilot': {
     name: 'GitHub Copilot',


### PR DESCRIPTION
## Problema

Ao selecionar **Cursor** durante a instalação do AIOS (`npx @synkra/aios-core@latest install`), o instalador **não gera os arquivos de configuração** específicos do Cursor. O usuário seleciona "Cursor" no wizard, o `core-config.yaml` registra `cursor: true`, mas nenhum arquivo é criado em `.cursor/`. Isso acontece por três causas raiz:

1. **`agentFolder` com caminho incorreto**: Em `ide-configs.js`, o `agentFolder` apontava para `.cursor/rules` — o mesmo diretório do config file principal — causando conflito e impedindo a estrutura correta de pastas.

2. **Ausência de tratamento pós-instalação para Cursor**: Em `ide-config-generator.js`, Claude Code e Gemini possuem blocos dedicados que copiam rules, hooks e settings após a instalação. O Cursor **não possuía nenhum**. Os arquivos de agente eram copiados como markdown bruto, sem passar pelo transformer de regras condensadas que já existia no projeto (`ide-sync/transformers/cursor.js`).

3. **Referências legacy**: O config file apontava para `.cursor/rules.md` (texto simples) e `.cursorrules` (formato deprecated), em vez do formato nativo `.mdc` com front matter que o Cursor utiliza atualmente.

---

## Solução

Corrigir o pipeline de instalação do Cursor para:
- Gerar o arquivo de regras globais no formato `.mdc` com `alwaysApply: true`
- Utilizar o transformer de Cursor já existente (`ide-sync/transformers/cursor.js`) para gerar regras condensadas dos agentes
- Criar a estrutura correta de pastas `.cursor/rules/agents/`
- Gerar redirect files para nomes de agentes deprecated
- Atualizar todas as referências legacy para o novo caminho

---

## Como foi ajustado

### 1. `packages/installer/src/config/ide-configs.js`
- `configFile`: `.cursor/rules.md` → `.cursor/rules/aios-global.mdc`
- `agentFolder`: `.cursor/rules` → `.cursor/rules/agents`

### 2. `packages/installer/src/wizard/ide-config-generator.js`
- Adicionada função `generateCursorAgentRules()` que:
  - Carrega os agentes via `agent-parser.js`
  - Transforma cada agente usando o transformer existente `transformers/cursor.js` (formato condensado)
  - Gera redirect files para agentes deprecated (`aios-developer → aios-master`, `aios-orchestrator → aios-master`, `db-sage → data-engineer`, `github-devops → devops`)
  - Faz fallback gracioso se o transformer não estiver disponível (mantém os arquivos raw copiados pelo `copyAgentFiles`)
- Adicionado bloco de tratamento Cursor em `generateIDEConfigs()`, paralelo ao que já existia para Claude Code e Gemini

### 3. `.aios-core/product/templates/ide-rules/cursor-rules.md`
- Atualizado para formato MDC com front matter (`alwaysApply: true`)
- Adicionados princípios da Constitution, tabela de ativação de agentes e estrutura do projeto
- Atualizado paths do framework para arquitetura modular v4

### 4. `bin/aios-init.js`
- Target do cursor atualizado de `.cursor/rules.md` → `.cursor/rules/aios-global.mdc`

### 5. `bin/modules/env-config.js`
- Referência legacy `.cursorrules` → `.cursor/rules/aios-global.mdc`

### Resultado esperado após a instalação:

```
.cursor/
├── rules/
│   ├── aios-global.mdc          # Regras globais AIOS (alwaysApply: true)
│   └── agents/
│       ├── dev.md               # Regras condensadas (via cursor transformer)
│       ├── qa.md
│       ├── architect.md
│       ├── sm.md
│       ├── ...                  # 12 agentes + 4 redirects
```

---

## Preocupações futuras com essa alteração

1. **Paridade com `aios-init.js`**: O `aios-init.js` (usado por `aios init <name>`) tem sua própria lógica de cópia de agentes para Cursor (linhas ~656-681) que copia arquivos como `.mdc`. Esta PR corrige apenas o fluxo do `packages/installer` (usado por `npx @synkra/aios-core install`). Idealmente, ambos os fluxos deveriam compartilhar a mesma função `generateCursorAgentRules()` para evitar divergência.

2. **Dependência do transformer path**: A função `generateCursorAgentRules()` resolve o caminho do transformer via `path.join(__dirname, '..', '..', '..', '..', '.aios-core', 'infrastructure', ...)`. Se a estrutura de pastas do repositório mudar, esse caminho quebrará silenciosamente (o fallback gracioso mascara o erro).

3. **Formato `.mdc` vs `.md`**: Os agentes transformados são salvos como `.md` (definido pelo transformer). O `aios-init.js` salva como `.mdc`. Essa inconsistência pode causar confusão — seria bom padronizar a extensão em um único lugar.

4. **Testes unitários**: Os testes existentes em `tests/unit/wizard/ide-config-generator.test.js` e `tests/unit/config/ide-configs.test.js` podem precisar de atualização para refletir o novo `configFile` e `agentFolder` do Cursor.

5. **Versionamento do template**: O template `cursor-rules.md` agora inclui front matter YAML específico do Cursor. Se o formato `.mdc` do Cursor mudar em versões futuras, o template precisará ser atualizado. Considerar adicionar validação do formato na CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Agent Activation framework for Cursor IDE integration with formal activation rules and agent persona mapping.

* **Documentation**
  * Updated Cursor IDE rules with new Constitution structure and formalized guidelines.
  * Reorganized project structure documentation and Git conventions.

* **Chores**
  * Updated IDE configuration paths and agent rule generation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->