### PR TITLE
fix(ci): use pull_request_target so labeler works on fork PRs

### DIFF
--- a/.github/workflows/pr-labeling.yml
+++ b/.github/workflows/pr-labeling.yml
@@ -1,8 +1,10 @@
 name: PR Labeling
 # Story 6.1 - Added concurrency
+# Fix #479 - use pull_request_target so the GITHUB_TOKEN has write
+# permissions even for PRs from forks.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 concurrency:
@@ -28,12 +30,16 @@ jobs:
 
       - name: Check for squad changes
         id: check-squad
-        run: |
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "^squads/"; then
-            echo "has_squad=true" >> $GITHUB_OUTPUT
-          else
-            echo "has_squad=false" >> $GITHUB_OUTPUT
-          fi
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number,
+            });
+            const hasSquad = files.some(f => f.filename.startsWith('squads/'));
+            core.setOutput('has_squad', hasSquad ? 'true' : 'false');
 
       - name: Add needs-po-review label for squad PRs
         if: steps.check-squad.outputs.has_squad == 'true'
@@ -41,9 +47,8 @@ jobs:
         with:
           script: |
             github.rest.issues.addLabels({
-              issue_number: context.issue.number,
+              issue_number: context.payload.pull_request.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
               labels: ['needs-po-review']
             })
-

--- a/.github/workflows/pr-labeling.yml
+++ b/.github/workflows/pr-labeling.yml
@@ -2,6 +2,7 @@ name: PR Labeling
 # Story 6.1 - Added concurrency
 # Fix #479 - use pull_request_target so the GITHUB_TOKEN has write
 # permissions even for PRs from forks.
+# SECURITY: checkout uses the base ref (default), never the PR head.
 
 on:
   pull_request_target:
@@ -17,6 +18,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      issues: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -46,7 +48,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            github.rest.issues.addLabels({
+            await github.rest.issues.addLabels({
               issue_number: context.payload.pull_request.number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## Resumo
- Corrige o workflow de labeling que falhava silenciosamente em PRs de forks
- Troca trigger de `pull_request` para `pull_request_target` (o evento `pull_request` dá token read-only para forks, então `addLabels` falhava)
- Substitui `git diff` por chamada à API do GitHub para detecção de mudanças em squads (forks não têm acesso ao histórico de branches remotas)
- Adiciona permissão `issues: write` necessária para adicionar labels
- Adiciona `await` na chamada `addLabels`

Closes #479

## Nota de segurança
`pull_request_target` executa no contexto do repo base. O workflow atual apenas faz checkout de código (read-only) e adiciona labels — não executa scripts não-confiáveis. Se no futuro adicionar steps que executam código do PR, considerar `pull_request` + workflow_run pattern.

## Plano de teste
- [x] Validação manual da sintaxe YAML
- [x] Verificar que permissões estão corretas
- [x] Verificar que chamada à API substitui corretamente o `git diff`