### PR TITLE
fix: correct password reset URLs [PRO-12] (v4.2.14)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aios-core",
-  "version": "4.2.10",
+  "version": "4.2.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aios-core",
-      "version": "4.2.10",
+      "version": "4.2.14",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aios-core",
-  "version": "4.2.13",
+  "version": "4.2.14",
   "description": "Synkra AIOS: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aios": "bin/aios.js",

--- a/packages/aios-pro-cli/src/recover.js
+++ b/packages/aios-pro-cli/src/recover.js
@@ -14,7 +14,7 @@
 
 const readline = require('readline');
 
-const RECOVERY_URL = 'https://pro.synkra.ai/recover';
+const RECOVERY_URL = 'https://aios-license-server.vercel.app/reset-password';
 
 const RECOVERY_MESSAGE =
   'Se este email estiver associado a uma licenca, voce recebera instrucoes de recuperacao.';

--- a/packages/installer/src/wizard/pro-setup.js
+++ b/packages/installer/src/wizard/pro-setup.js
@@ -426,11 +426,11 @@ async function loginWithRetry(client, email) {
         const remaining = MAX_RETRIES - attempt;
         if (remaining > 0) {
           spinner.fail(`Incorrect password. ${remaining} attempt${remaining > 1 ? 's' : ''} remaining.`);
-          showInfo('Forgot your password? Visit https://pro.synkra.ai/reset-password');
+          showInfo('Forgot your password? Visit https://aios-license-server.vercel.app/reset-password');
         } else {
           spinner.fail('Maximum login attempts reached.');
-          showInfo('Forgot your password? Visit https://pro.synkra.ai/reset-password');
-          showInfo('Or contact support: support@synkra.ai');
+          showInfo('Forgot your password? Visit https://aios-license-server.vercel.app/reset-password');
+          showInfo('Or open an issue: https://github.com/SynkraAI/aios-core/issues');
           return { success: false, error: 'Maximum login attempts reached.' };
         }
       } else if (loginError.code === 'AUTH_RATE_LIMITED') {

--- a/tests/pro-recover.test.js
+++ b/tests/pro-recover.test.js
@@ -15,7 +15,7 @@ const { maskEmail, openBrowser, promptEmail, recoverLicense, RECOVERY_URL, RECOV
 
 describe('Recovery Constants', () => {
   test('RECOVERY_URL is the correct portal URL', () => {
-    expect(RECOVERY_URL).toBe('https://pro.synkra.ai/recover');
+    expect(RECOVERY_URL).toBe('https://aios-license-server.vercel.app/reset-password');
   });
 
   test('RECOVERY_MESSAGE is the anti-enumeration message', () => {


### PR DESCRIPTION
## Summary

- Password reset URLs in the installer login flow and CLI recovery pointed to `https://pro.synkra.ai/reset-password` which **does not exist**
- Users who typed wrong password during Pro installation were stuck with no way to reset
- Updated all 3 references to `https://aios-license-server.vercel.app/reset-password`
- Bumped version to `4.2.14` for npm publish

## Files changed

| File | Change |
|------|--------|
| `packages/installer/src/wizard/pro-setup.js` | 2x URL fix + support link → GitHub Issues |
| `packages/aios-pro-cli/src/recover.js` | Recovery URL fix |
| `tests/pro-recover.test.js` | Test assertion updated |
| `package.json` / `package-lock.json` | 4.2.13 → 4.2.14 |

## Test plan

- [x] `pro-recover.test.js` — 17/17 passing
- [x] `pro-setup-auth.test.js` — 11/11 passing
- [ ] Manual: run `npx aios-core install` → choose Pro → enter wrong password → verify correct URL shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped version to 4.2.14
  * Updated password reset endpoint URL for the license recovery flow
  * Updated support contact information displayed in error messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->