### PR TITLE
fix(ci): npm publish workflow — submodule + husky

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -161,6 +161,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -171,6 +173,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          HUSKY: '0'
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -253,7 +257,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: packages/aios-install
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Get aios-install version
         id: pkg-version


### PR DESCRIPTION
## Summary
- Fix `publish` job: add `submodules: recursive` to checkout so `pro/` safety gate passes
- Fix `publish` job: set `HUSKY=0` to prevent prepare script failure in CI
- Fix `publish-aios-install` job: use `--ignore-scripts` to skip husky in subdirectory

## Context
v4.3.0 tag was pushed but both publish jobs failed:
- `publish`: Publish Safety Gate (INS-4.10) blocked because `pro/` submodule was not initialized
- `publish-aios-install`: `husky: not found` during `npm ci` in `packages/aios-install/`

## Test plan
- [ ] Re-trigger npm publish workflow after merge
- [ ] Verify both publish jobs succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD build process configuration for better reliability and performance during automated deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->