### PR TITLE
fix(ci): npm publish — skip pro submodule in CI + non-blocking aios-install

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -161,8 +161,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -243,6 +241,7 @@ jobs:
   publish-aios-install:
     needs: [test, build]
     if: ${{ needs.build.outputs.has_aios_install == 'true' }}
+    continue-on-error: true  # Don't block main publish if @synkra org not yet configured
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- `validate-publish.js`: Skip pro/ submodule checks when `CI=true` (private repo inaccessible in GitHub Actions)
- `npm-publish.yml`: Revert `submodules: recursive` (causes checkout failure for private `aios-pro`)
- `npm-publish.yml`: Add `continue-on-error: true` to `publish-aios-install` job (npm org `@synkra` not yet configured)
- Keep `HUSKY=0` and `--ignore-scripts` fixes from PR #485

## Context
Follow-up to PR #485. v4.3.0 publish failed because:
1. `pro/` is a private submodule — CI can't clone `aios-pro` without separate PAT
2. `@synkra/aios-install` package returns 404 — npm org not created yet

## Test plan
- [ ] Re-trigger npm publish workflow after merge
- [ ] Verify `publish` job (aios-core) succeeds
- [ ] `publish-aios-install` may still fail but won't block the pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized npm publishing workflow with improved environment configuration, lifecycle script management during installation, and refined error handling for optional package components.
  * Enhanced build validation script with CI environment detection that replaces fatal errors with graceful fallbacks when optional dependencies or submodules are missing, improving build resilience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->