### PR TITLE
fix(ci): remove submodules: recursive from publish checkout

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -161,8 +161,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
Remove `submodules: recursive` from publish job checkout — private `aios-pro` submodule causes checkout failure in CI. The `validate-publish.js` already handles CI skip via `IS_CI` flag (PR #486).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the publish workflow checkout configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->