### PR TITLE
chore(release): bump version to v4.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aios-core",
-  "version": "4.4.3",
+  "version": "4.4.4",
   "description": "Synkra AIOS: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aios": "bin/aios.js",


### PR DESCRIPTION
## Summary
- Patch release v4.4.4

## Changelog
- fix(installer): Pro brownfield upgrade — auto-install @aios-fullstack/pro when license module missing (#506)
- fix(ci): expand test matrix to Node 18, 20, 22, 24, 25 (#506)
- fix(test): replace rmdirSync with rmSync for Node 25 compat (#506)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version updated to 4.4.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->