### PR TITLE
chore(release): bump version to v4.4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aios-core",
-  "version": "4.4.5",
+  "version": "4.4.6",
   "description": "Synkra AIOS: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aios": "bin/aios.js",


### PR DESCRIPTION
## Summary
- Bump version to v4.4.6
- Includes fix for health-check task using `npx aios-core` instead of `node bin/aios.js` (PR #510)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch version update (4.4.6). No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->