### PR TITLE
fix: build-state-manager null guards para checkpoints/failedAttempts/notifications

### DIFF
--- a/.aios-core/core/execution/build-state-manager.js
+++ b/.aios-core/core/execution/build-state-manager.js
@@ -781,6 +781,8 @@ class BuildStateManager {
       throw new Error('No state loaded');
     }
 
+    this._state.failedAttempts ??= [];
+
     const failure = {
       subtaskId,
       attempt:
@@ -831,7 +833,7 @@ class BuildStateManager {
     }
 
     // Get attempts for this subtask
-    const attempts = this._state.failedAttempts
+    const attempts = (this._state.failedAttempts || [])
       .filter((f) => f.subtaskId === subtaskId)
       .map((f) => ({
         success: false,
@@ -895,7 +897,7 @@ class BuildStateManager {
    */
   getNotifications() {
     if (!this._state) return [];
-    return this._state.notifications.filter((n) => !n.acknowledged);
+    return (this._state.notifications || []).filter((n) => !n.acknowledged);
   }
 
   /**
@@ -904,7 +906,7 @@ class BuildStateManager {
    * @param {number} index - Notification index
    */
   acknowledgeNotification(index) {
-    if (!this._state || !this._state.notifications[index]) return;
+    if (!this._state || !this._state.notifications || !this._state.notifications[index]) return;
     this._state.notifications[index].acknowledged = true;
     this.saveState();
   }

--- a/tests/core/execution/build-state-manager-guards.test.js
+++ b/tests/core/execution/build-state-manager-guards.test.js
@@ -1,7 +1,8 @@
 /**
  * Testes para null guards em BuildStateManager
  *
- * Valida que getLastCheckpoint, getCheckpoint e getStatus
+ * Valida que getLastCheckpoint, getCheckpoint, getStatus,
+ * getNotifications, acknowledgeNotification e recordFailure
  * não falham com TypeError quando arrays são undefined.
  *
  * Closes #513
@@ -101,6 +102,138 @@ describe('BuildStateManager - null guards (#513)', () => {
     test('usa rootPath padrão se não fornecido', () => {
       const m = new BuildStateManager('s1');
       expect(m.rootPath).toBe(process.cwd());
+    });
+  });
+
+  // ============================================================
+  // getStatus - null guards para arrays opcionais
+  // ============================================================
+  describe('getStatus', () => {
+    test('retorna exists:false quando loadState retorna null', () => {
+      jest.spyOn(manager, 'loadState').mockReturnValue(null);
+      const status = manager.getStatus();
+      expect(status.exists).toBe(false);
+    });
+
+    test('calcula recentFailures com failedAttempts undefined', () => {
+      jest.spyOn(manager, 'loadState').mockReturnValue({
+        status: 'running',
+        startedAt: new Date().toISOString(),
+        currentPhase: 'build',
+        currentSubtask: null,
+        metrics: { completedSubtasks: 0, totalSubtasks: 1, totalFailures: 0, totalAttempts: 0 },
+        worktree: null,
+        lastCheckpoint: null,
+      });
+      jest.spyOn(manager, '_checkAbandoned').mockReturnValue(false);
+      const status = manager.getStatus();
+      expect(status.recentFailures).toEqual([]);
+      expect(status.checkpointCount).toBe(0);
+      expect(status.notificationCount).toBe(0);
+    });
+
+    test('calcula checkpointCount e notificationCount com arrays presentes', () => {
+      jest.spyOn(manager, 'loadState').mockReturnValue({
+        status: 'running',
+        startedAt: new Date().toISOString(),
+        currentPhase: 'build',
+        currentSubtask: null,
+        metrics: { completedSubtasks: 0, totalSubtasks: 1, totalFailures: 0, totalAttempts: 0 },
+        worktree: null,
+        lastCheckpoint: null,
+        checkpoints: [{ id: 'cp-1' }, { id: 'cp-2' }],
+        notifications: [
+          { acknowledged: false },
+          { acknowledged: true },
+          { acknowledged: false },
+        ],
+        failedAttempts: [{ subtaskId: 'a' }, { subtaskId: 'b' }],
+      });
+      jest.spyOn(manager, '_checkAbandoned').mockReturnValue(false);
+      const status = manager.getStatus();
+      expect(status.checkpointCount).toBe(2);
+      expect(status.notificationCount).toBe(2);
+      expect(status.recentFailures).toHaveLength(2);
+    });
+  });
+
+  // ============================================================
+  // getNotifications - null guard
+  // ============================================================
+  describe('getNotifications', () => {
+    test('retorna array vazio quando _state é null', () => {
+      manager._state = null;
+      expect(manager.getNotifications()).toEqual([]);
+    });
+
+    test('retorna array vazio quando notifications é undefined', () => {
+      manager._state = { status: 'running' };
+      expect(manager.getNotifications()).toEqual([]);
+    });
+
+    test('filtra apenas não-acknowledged', () => {
+      manager._state = {
+        notifications: [
+          { message: 'a', acknowledged: false },
+          { message: 'b', acknowledged: true },
+          { message: 'c', acknowledged: false },
+        ],
+      };
+      const result = manager.getNotifications();
+      expect(result).toHaveLength(2);
+      expect(result[0].message).toBe('a');
+      expect(result[1].message).toBe('c');
+    });
+  });
+
+  // ============================================================
+  // acknowledgeNotification - null guard
+  // ============================================================
+  describe('acknowledgeNotification', () => {
+    test('não falha quando _state é null', () => {
+      manager._state = null;
+      expect(() => manager.acknowledgeNotification(0)).not.toThrow();
+    });
+
+    test('não falha quando notifications é undefined', () => {
+      manager._state = { status: 'running' };
+      expect(() => manager.acknowledgeNotification(0)).not.toThrow();
+    });
+
+    test('não falha com índice inválido', () => {
+      manager._state = { notifications: [{ acknowledged: false }] };
+      jest.spyOn(manager, 'saveState').mockImplementation(() => {});
+      expect(() => manager.acknowledgeNotification(99)).not.toThrow();
+    });
+
+    test('marca notification como acknowledged', () => {
+      manager._state = {
+        notifications: [
+          { message: 'alerta', acknowledged: false },
+        ],
+      };
+      jest.spyOn(manager, 'saveState').mockImplementation(() => {});
+      manager.acknowledgeNotification(0);
+      expect(manager._state.notifications[0].acknowledged).toBe(true);
+    });
+  });
+
+  // ============================================================
+  // recordFailure - failedAttempts null guard
+  // ============================================================
+  describe('recordFailure', () => {
+    test('inicializa failedAttempts quando undefined', () => {
+      manager._state = {
+        status: 'running',
+        metrics: { totalFailures: 0, totalAttempts: 0 },
+        notifications: [],
+      };
+      jest.spyOn(manager, 'saveState').mockImplementation(() => {});
+      jest.spyOn(manager, '_logAttempt').mockImplementation(() => {});
+
+      const result = manager.recordFailure('subtask-1', { error: 'test error' });
+      expect(result.failure.subtaskId).toBe('subtask-1');
+      expect(manager._state.failedAttempts).toHaveLength(1);
     });
   });
 });


### PR DESCRIPTION
## Descrição

Corrige 3 potenciais TypeErrors em `build-state-manager.js` quando arrays opcionais (`checkpoints`, `failedAttempts`, `notifications`) são `undefined` no state carregado de JSON.

## Problema

Os campos `checkpoints`, `failedAttempts` e `notifications` são opcionais na validação de estado (`validateBuildState`), mas os métodos `getLastCheckpoint()`, `getCheckpoint()` e `getStatus()` acessam esses arrays sem verificar se existem:

```javascript
// ANTES — TypeError se checkpoints é undefined
if (!this._state || this._state.checkpoints.length === 0)
```

Isso acontece quando um `build-state.json` é salvo por uma versão mais antiga ou sem esses campos.

## Correção

```diff
 getLastCheckpoint() {
-  if (!this._state || this._state.checkpoints.length === 0) {
+  if (!this._state || !this._state.checkpoints || this._state.checkpoints.length === 0) {
     return null;
   }
```

```diff
 getCheckpoint(checkpointId) {
-  if (!this._state) {
+  if (!this._state || !this._state.checkpoints) {
     return null;
   }
```

```diff
-recentFailures: state.failedAttempts.slice(-5),
-checkpointCount: state.checkpoints.length,
-notificationCount: state.notifications.filter(...).length,
+recentFailures: (state.failedAttempts || []).slice(-5),
+checkpointCount: (state.checkpoints || []).length,
+notificationCount: (state.notifications || []).filter(...).length,
```

## Testes

12 testes unitários cobrindo todos os cenários de null/undefined:

```
PASS tests/core/execution/build-state-manager-guards.test.js
Tests: 12 passed, 12 total
```

Closes #513

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability with defensive checks and safe defaults to prevent runtime errors when state arrays are missing or undefined.

* **Tests**
  * Added comprehensive edge-case tests validating null/undefined handling, constructor behavior, and state mutation safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->