### PR TITLE
fix(ideation): corrigir import de GotchasMemory como named export

### DIFF
--- a/.aios-core/core/ideation/ideation-engine.js
+++ b/.aios-core/core/ideation/ideation-engine.js
@@ -13,7 +13,7 @@ const { execSync } = require('child_process');
 // Import dependencies with fallbacks
 let GotchasMemory;
 try {
-  GotchasMemory = require('../memory/gotchas-memory');
+  ({ GotchasMemory } = require('../memory/gotchas-memory'));
 } catch {
   GotchasMemory = null;
 }


### PR DESCRIPTION
## Problema

`gotchas-memory.js` exporta usando named exports:
```javascript
module.exports = { GotchasMemory, GotchaCategory, Severity, Events, CONFIG };
```

Mas `ideation-engine.js` importa sem destructuring:
```javascript
GotchasMemory = require('../memory/gotchas-memory');
```

Isso faz com que `GotchasMemory` receba o **objeto do módulo inteiro** em vez da classe. Na linha 30, `new GotchasMemory()` tenta instanciar o objeto do módulo → **TypeError**.

## Correção

Aplicar destructuring no require:
```javascript
({ GotchasMemory } = require('../memory/gotchas-memory'));
```

## Testes

Rodei os 54 testes do ideation-engine (PR #518) com este fix aplicado — todos passam.

Closes #517

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

No user-visible changes in this release. This update includes internal code organization improvements to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->