### PR TITLE
fix(installer): registra hooks no evento correto do Claude Code (#528)

### DIFF
--- a/packages/installer/tests/unit/artifact-copy-pipeline/artifact-copy-pipeline.test.js
+++ b/packages/installer/tests/unit/artifact-copy-pipeline/artifact-copy-pipeline.test.js
@@ -185,17 +185,23 @@ describe('artifact-copy-pipeline (Story INS-4.3)', () => {
         const settingsContent = fs.readFileSync(path.join(tmpDir, '.claude', 'settings.local.json'), 'utf8');
         const settings = JSON.parse(settingsContent);
 
-        // Should have hooks.UserPromptSubmit with 2 entries
+        // synapse-engine → UserPromptSubmit, precompact → PreCompact
         expect(settings.hooks).toBeDefined();
         expect(settings.hooks.UserPromptSubmit).toBeDefined();
-        expect(settings.hooks.UserPromptSubmit.length).toBe(2);
+        expect(settings.hooks.UserPromptSubmit.length).toBe(1);
+        expect(settings.hooks.PreCompact).toBeDefined();
+        expect(settings.hooks.PreCompact.length).toBe(1);
 
-        // Both hooks registered
-        const commands = settings.hooks.UserPromptSubmit.flatMap(entry =>
+        // Each hook registered under its correct event
+        const upsCommands = settings.hooks.UserPromptSubmit.flatMap(entry =>
           entry.hooks.map(h => h.command)
         );
-        expect(commands.some(c => c.includes('synapse-engine'))).toBe(true);
-        expect(commands.some(c => c.includes('precompact-session-digest'))).toBe(true);
+        expect(upsCommands.some(c => c.includes('synapse-engine'))).toBe(true);
+
+        const pcCommands = settings.hooks.PreCompact.flatMap(entry =>
+          entry.hooks.map(h => h.command)
+        );
+        expect(pcCommands.some(c => c.includes('precompact-session-digest'))).toBe(true);
       } finally {
         cleanup(tmpDir);
       }


### PR DESCRIPTION
## Problema

`createClaudeSettingsLocal()` registra **todos** os hooks `.cjs` sob o evento `UserPromptSubmit`, ignorando o evento real de cada hook. Isso faz com que `precompact-session-digest.cjs` — que deveria rodar no `PreCompact` — seja executado em **cada input do usuário**, gerando erro porque o runner (`precompact-runner.js`) não está disponível no contexto de `UserPromptSubmit`.

**Impacto:** Erro `UserPromptSubmit hook error` em toda interação com o Claude Code após instalação.

## Root Cause

A função `createClaudeSettingsLocal` em `ide-config-generator.js` (linha 743-781) hardcoda `settings.hooks.UserPromptSubmit` para todos os hooks descobertos no diretório `.claude/hooks/`, sem considerar o evento correto.

O próprio hook define seu evento esperado na documentação e no runner:
```js
// precompact-session-digest.cjs → "PreCompact" event
// precompact-runner.js → getHookConfig().event = 'PreCompact'
```

## Fix

Adicionado mapeamento de prefixo do nome do hook para o evento correto do Claude Code:

```js
const HOOK_EVENT_PREFIX_MAP = {
  precompact: 'PreCompact',
  pretooluse: 'PreToolUse',
  posttooluse: 'PostToolUse',
  // ...
};
```

Cada hook agora é registrado sob seu evento correto:
- `synapse-engine.cjs` → `UserPromptSubmit` (default)
- `precompact-session-digest.cjs` → `PreCompact`

Hooks sem prefixo reconhecido continuam em `UserPromptSubmit` (backward-compatible).

## Arquivos alterados

- `packages/installer/src/wizard/ide-config-generator.js` — lógica de registro por evento
- `packages/installer/tests/.../artifact-copy-pipeline.test.js` — testes atualizados para validar separação de eventos

## Testes

```
9/9 passing (artifact-copy-pipeline.test.js)
```

Closes #528

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected hook registration to properly organize hooks by event type, ensuring each hook is assigned to its corresponding event handler instead of defaulting to a single event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->