### PR TITLE
docs: adiciona seção de contribuidores da comunidade no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,13 +742,14 @@ This project was originally derived from the [BMad Method](https://github.com/bm
 
 ### 🌟 Contribuidores da Comunidade
 
-<!-- ALL-CONTRIBUTORS-LIST:START -->
+<!-- prettier-ignore-start -->
+<!-- Manually maintained — add new community contributors here -->
 <table>
   <tr>
     <td align="center"><a href="https://github.com/nikolasdehor"><img src="https://github.com/nikolasdehor.png?size=100" width="100px;" alt="Nikolas de Hor"/><br /><sub><b>Nikolas de Hor</b></sub></a><br />💻🐛⚠️👀</td>
   </tr>
 </table>
-<!-- ALL-CONTRIBUTORS-LIST:END -->
+<!-- prettier-ignore-end -->
 
 <sub>Construído com ❤️ para a comunidade de desenvolvimento assistido por IA</sub>
 


### PR DESCRIPTION
## Resumo

Adiciona uma subseção **Contribuidores da Comunidade** dentro de "Reconhecimentos" no README, usando o formato [all-contributors](https://allcontributors.org/) para destacar membros ativos da comunidade.

### Motivação

A seção atual de contribuidores usa `contrib.rocks`, que só mostra o gráfico automático do GitHub baseado em commits mergeados. Contribuições importantes como **reviews de PRs**, **triagem de issues** e **reports de bugs** não aparecem nesse gráfico. A nova subseção permite reconhecer essas contribuições de forma explícita.

### Mudanças

- Adicionada subseção "Contribuidores da Comunidade" com tabela all-contributors
- Delimitadores `<!-- ALL-CONTRIBUTORS-LIST:START/END -->` para compatibilidade futura com o bot all-contributors
- Primeiro contribuidor adicionado: [@nikolasdehor](https://github.com/nikolasdehor) (código, bugs, testes, reviews)

### Plano de teste

- [x] Renderização do markdown verificada localmente
- [x] Avatar do GitHub carrega corretamente via `github.com/nikolasdehor.png`
- [x] Links apontam para o perfil correto

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Appended a new "🌟 Contribuidores da Comunidade" section to the README to recognize contributors. Includes an ALL-CONTRIBUTORS style block listing a community member and is added as static content at the end of the document. No functional or behavioral changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->