### PR TITLE
fix(session-state): previne divisão por zero em getProgressSummary (#533)

### DIFF
--- a/.aios-core/core/orchestration/session-state.js
+++ b/.aios-core/core/orchestration/session-state.js
@@ -618,7 +618,9 @@ O que você quer fazer?
       progress: {
         completed: progress.stories_done.length,
         total: epic.total_stories,
-        percentage: Math.round((progress.stories_done.length / epic.total_stories) * 100),
+        percentage: epic.total_stories > 0
+          ? Math.round((progress.stories_done.length / epic.total_stories) * 100)
+          : 0,
         storiesDone: progress.stories_done,
         storiesPending: progress.stories_pending,
         currentStory: progress.current_story,

--- a/tests/core/orchestration/session-state.test.js
+++ b/tests/core/orchestration/session-state.test.js
@@ -541,6 +541,23 @@ describe('SessionState', () => {
       expect(summary.progress.storiesDone).toEqual(['11.1', '11.2']);
       expect(summary.context.branch).toBe('feature/bob');
     });
+
+    it('should return 0 percentage when totalStories is 0 (no division by zero)', async () => {
+      const epicInfo = {
+        id: 'epic-empty',
+        title: 'Empty Epic',
+        totalStories: 0,
+        storyIds: [],
+      };
+      await sessionState.createSessionState(epicInfo, 'feature/empty');
+
+      const summary = sessionState.getProgressSummary();
+
+      expect(summary.progress.percentage).toBe(0);
+      expect(Number.isNaN(summary.progress.percentage)).toBe(false);
+      expect(summary.progress.total).toBe(0);
+      expect(summary.progress.completed).toBe(0);
+    });
   });
 
   describe('discard()', () => {


### PR DESCRIPTION
## Resumo

Corrige divisão por zero em `getProgressSummary()` quando `epic.total_stories` é 0 (edge case de epic recém-criado sem stories definidas).

### Problema

`Math.round((progress.stories_done.length / epic.total_stories) * 100)` retorna `NaN` quando `epic.total_stories === 0`.

### Correção

```javascript
percentage: epic.total_stories > 0
  ? Math.round((progress.stories_done.length / epic.total_stories) * 100)
  : 0,
```

### Plano de teste

- [x] 42/42 testes passam (era 41, +1 novo)
- [x] Teste de regressão verifica que `percentage` é `0` (não `NaN`) quando `totalStories` é 0

Closes #533

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed progress percentage calculation to properly handle scenarios with zero total stories, preventing division by zero errors that resulted in undefined NaN values appearing in progress summaries.

## Tests
- Added test case to validate that progress summaries correctly return 0% instead of NaN when handling epics containing no stories, ensuring both total and completed story counts are properly set to 0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->