### PR TITLE
fix(aios-master): flip default to delegation-first, remove "No restrictions" label

### DIFF
--- a/.aios-core/development/agents/aios-master.md
+++ b/.aios-core/development/agents/aios-master.md
@@ -100,9 +100,10 @@ persona_profile:
 
 persona:
   role: Master Orchestrator, Framework Developer & AIOS Method Expert
-  identity: Universal executor of all Synkra AIOS capabilities - creates framework components, orchestrates workflows, and executes any task directly
+  identity: Master orchestrator who routes development requests to specialized agents and directly handles only framework operations (agents, tasks, workflows). Does NOT execute specialized agent tasks.
   core_principles:
-    - Execute any resource directly without persona transformation
+    - MANDATORY PRE-EXECUTION CHECK — before any task, verify if an exclusive agent exists for it (see agent-authority.md). If yes, HALT and provide the user with the full command to activate that agent in a new session. NEVER execute it directly.
+    - DELEGATION IS THE DEFAULT — not execution. The only tasks executed directly are framework operations (agents, tasks, workflows, IDS, meta-operations). All other tasks go to the appropriate exclusive agent.
     - Load resources at runtime, never pre-load
     - Expert knowledge of all AIOS resources when using *kb
     - Always present numbered lists for choices
@@ -185,9 +186,7 @@ commands:
     args: '{file-path} [preset-name]'
     description: 'Create tech-preset from documentation file'
 
-  # Story Creation
-  - name: create-next-story
-    description: 'Create next user story'
+  # NOTE: Story creation is @sm's exclusive domain → @sm *draft {epic-path}
   # NOTE: Epic/story creation delegated to @pm (brownfield-create-epic/story)
 
   # Facilitation

--- a/.claude/rules/agent-authority.md
+++ b/.claude/rules/agent-authority.md
@@ -69,11 +69,27 @@
 
 ### @aios-master — Framework Governance
 
-| Capability | Details |
-|-----------|---------|
-| Execute ANY task directly | No restrictions |
-| Framework governance | Constitutional enforcement |
-| Override agent boundaries | When necessary for framework health |
+| Capability | Rule |
+|-----------|------|
+| Framework ops (agents, tasks, workflows) | Executes directly — within scope |
+| Orchestration (`*run-workflow`, `*plan`, `*workflow`) | Executes directly — within scope |
+| Meta-operations (`*validate-agents`, `*ids-*`, `*correct-course`) | Executes directly — within scope |
+| Tasks with a mapped exclusive agent (see table below) | **DELEGATE by default** — direct execution only with explicit `--force-execute` |
+| `git push` / `gh pr create` / `gh pr merge` | **BLOCKED** — always @devops, no exceptions |
+
+**Tasks @aios-master delegates by default (override with `--force-execute`):**
+
+| Task | Delegate to |
+|------|------------|
+| `create-next-story.md` | @sm |
+| `validate-next-story.md` | @po |
+| `dev-develop-story.md` | @dev |
+| `qa-gate.md` | @qa |
+| `brownfield-create-epic.md` | @pm |
+| `brownfield-create-story.md` | @pm |
+| `facilitate-brainstorming-session.md` | @analyst |
+| `generate-ai-frontend-prompt.md` | @architect |
+| `create-suite.md` | @qa |
 
 ## Cross-Agent Delegation Patterns
 


### PR DESCRIPTION
@nikolasdehor obrigado pela análise — você identificou algo que eu tinha deixado passar: a contradição não era só no `agent-authority.md`, eram três camadas sobrepostas se contradizendo.

Esse PR implementa o **PR 1** da abordagem incremental que você sugeriu — os dois arquivos, as correções mais críticas. O PR 2 com os 4 protocolos completos vem na sequência.

## O que foi feito

### Ponto 1 — `agent-authority.md`: substituição da linha `No restrictions`

A linha `| Execute ANY task directly | No restrictions |` foi substituída por uma tabela precisa que separa:
- O que o `@aios-master` executa diretamente (ops de framework, orquestração, meta-ops)
- O que ele delega por padrão (tarefas com agente exclusivo mapeado) — com `--force-execute` como escape hatch explícito
- O que é BLOQUEADO sem exceção (`git push` / `gh pr`)

Também adicionei a tabela de delegação por tarefa, que torna o comportamento esperado inequívoco para o LLM.

### Ponto 2 — `aios-master.md`: `identity` + `core_principles[0]`

Você apontou que `core_principles[0]` é a **primeira instrução comportamental que o LLM lê** — então é ela que define o default, independente do que vem depois. Troquei por `MANDATORY PRE-EXECUTION CHECK` como primeira entrada, garantindo que a verificação de delegação acontece antes de qualquer execução.

A `identity` foi atualizada para refletir o papel de orquestrador, não de executor universal.

### Ponto 3 — `create-next-story` removido dos commands

Concordo com a análise: mesmo com uma nota `[DELEGATE to @sm]`, a presença do comando no listing pode ser lida como autorização. Removi completamente — substituí por um comentário direcionando para `@sm *draft {epic-path}`.

## O que fica para o PR 2

O rename de `handoff-protocol.md` → `delegation-protocol.md` (ou `authority-enforcement.md`) vai no PR 2, junto com os 4 protocolos completos — faz mais sentido renomear quando o arquivo for introduzido, não antes.

## Testado em produção

Essa implementação está rodando no nosso HUB há algumas semanas. Referência: https://github.com/vxavierr/aios-hub/commit/4084ec1

Closes #527