### PR TITLE
fix(qa-gate): add mandatory story status update after gate verdict

### DIFF
--- a/.aios-core/development/tasks/qa-gate.md
+++ b/.aios-core/development/tasks/qa-gate.md
@@ -394,6 +394,23 @@ If blast radius returned HIGH risk:
 3. Keep status_reason to 1-2 sentences maximum
 4. Use severity values exactly: `low`, `medium`, or `high`
 
+## MANDATORY FINAL STEP — Update Story Status
+
+After creating the gate file, **ALWAYS** update the story's `| **Status** |` row in the metadata table and append to the Change Log. This step is non-negotiable — a gate file without a corresponding story Status update is an incomplete task execution.
+
+| Gate verdict | Story Status →  |
+|--------------|-----------------|
+| PASS         | Done            |
+| CONCERNS     | Done            |
+| FAIL         | InProgress      |
+| WAIVED       | Done            |
+
+**Change Log entry (append, do not replace):**
+
+```
+| {YYYY-MM-DD} | @qa (Quinn) | Gate: {verdict} — Status: {old} → {new} |
+```
+
 ## Example Story Update
 
 After creating gate file, append to story's QA Results section:

--- a/.claude/rules/story-lifecycle.md
+++ b/.claude/rules/story-lifecycle.md
@@ -18,9 +18,12 @@ Draft → Ready → InProgress → InReview → Done
 | Ready | @po validates (GO) | @po | **MUST update status field in story file from Draft → Ready** |
 | InProgress | @dev starts implementation | @dev | Update status field |
 | InReview | @dev completes, @qa reviews | @qa | Update status field |
-| Done | @qa PASS, @devops pushes | @devops | Update status field |
+| Done | @qa PASS / CONCERNS / WAIVED | **@qa** | **MUST update status field InReview → Done** |
+| InProgress (return) | @qa FAIL | **@qa** | **MUST update status field InReview → InProgress** |
 
 **CRITICAL:** The `Draft → Ready` transition is the responsibility of @po during `*validate-story-draft`. When verdict is GO (including conditional GO after fixes are applied), @po MUST update the story's Status field to `Ready` and log the transition in the Change Log. A story left in `Draft` after a GO verdict is a process violation.
+
+**CRITICAL:** The `InReview → Done` and `InReview → InProgress` transitions are the responsibility of @qa during `*qa-gate`. @qa MUST update the story's Status field immediately after creating the gate file (see `qa-gate.md` — MANDATORY FINAL STEP). A story left in `InReview` after a gate verdict is a process violation. @devops does NOT own this transition — @devops only executes `git push` after the story is already `Done`.
 
 ## Phase 1: Create (@sm)
 


### PR DESCRIPTION
## Problema

O `@qa` cria o gate file mas não atualiza o campo `Status` da story — que fica preso em `InReview` (ou `Ready for Review`). Qualquer agente ou pessoa que consulte a story lê um estado incorreto: o gate file e o campo da story estão dessincronizados.

**Raiz dupla:**
1. `qa-gate.md` não tinha nenhuma instrução explícita para atualizar o `Status` da story após emitir o veredicto
2. `story-lifecycle.md` atribuía a transição para `Done` ao `@devops`, o que está incorreto — o `@devops` executa o `git push`, não atualiza o campo de status

## Mudanças

### `qa-gate.md`
Adiciona a seção `## MANDATORY FINAL STEP — Update Story Status` com:
- Tabela de mapeamento veredicto → Status (PASS/CONCERNS/WAIVED → Done, FAIL → InProgress)
- Formato obrigatório de entrada no Change Log
- Definição explícita: gate file sem atualização de status = execução incompleta da task

### `story-lifecycle.md`
- Substitui a linha `Done` (incorretamente atribuída ao `@devops`) por duas linhas explícitas de responsabilidade do `@qa`:
  - `PASS/CONCERNS/WAIVED → Done` — **@qa MUST update**
  - `FAIL → InProgress` — **@qa MUST update**
- Adiciona bloco `CRITICAL` (espelhando o que já existe para a transição `Draft → Ready`) tornando a responsabilidade do `@qa` inequívoca
- Esclarece que o `@devops` só executa o `git push` **depois** que a story já está `Done`

## Por que isso importa

Sem esse fix, qualquer consulta de status — incluindo `@aios-master *list-stories` — lê dado stale. Uma story pode ter um gate PASS e continuar aparecendo como `InReview`, fazendo agentes tratarem trabalho concluído como pendente.