### PR TITLE
fix: add mandatory post-verdict status update steps to task workflows

### DIFF
--- a/.aiox-core/development/tasks/dev-develop-story.md
+++ b/.aiox-core/development/tasks/dev-develop-story.md
@@ -514,7 +514,7 @@ const {
 - Missing configuration
 - Failing regression tests
 
-### Ready for Review Criteria (All Modes)
+### InReview Criteria (All Modes)
 
 - Code matches all requirements
 - All validations pass
@@ -530,7 +530,7 @@ const {
 5. File List is complete
 6. **Execute CodeRabbit Self-Healing Loop** (see below)
 7. Execute `.aiox-core/product/checklists/story-dod-checklist.md`
-8. Set story status: "Ready for Review"
+8. Set story status: "InReview" (see Status Transitions section)
 9. HALT (do not proceed further)
 
 ---
@@ -924,9 +924,10 @@ Found 5 technical decisions needed.
 ### On Development Start (before first task):
 
 0. **Pre-check (blocking):**
-   - If current Status is not `**Ready**`, HALT and log: "Cannot start development: expected Ready, found {current status}."
+   - If current Status is `**InProgress**`, skip to first uncompleted task (resume scenario — no status change needed).
+   - If current Status is not `**Ready**` and not `**InProgress**`, HALT and log: "Cannot start development: expected Ready or InProgress, found {current status}."
    - If Change Log section is missing, HALT and request user to restore template structure.
-1. **Update story Status field:** change `**Ready**` to `**InProgress**`
+1. **Update story Status field:** change `**Ready**` to `**InProgress**` (skip if already InProgress)
 2. **Add Change Log entry:**
    ```text
    | {today's date} | {next version} | Development started ({mode} mode) — Status: Ready → InProgress | @dev |

--- a/.aiox-core/development/tasks/dev-develop-story.md
+++ b/.aiox-core/development/tasks/dev-develop-story.md
@@ -370,7 +370,7 @@ const {
    - All tasks complete
    - All tests pass
    - Execute story-dod-checklist
-   - Set status: "Ready for Review"
+   - Set status: "InReview" (see Status Transitions section)
    - **Generate decision log**:
      ```javascript
      const logPath = await completeDecisionLogging(storyId, 'completed');
@@ -416,7 +416,7 @@ const {
    - All tests pass
    - Execute story-dod-checklist
    - Present completion summary to user
-   - Set status: "Ready for Review"
+   - Set status: "InReview" (see Status Transitions section)
 
 **User Prompts**: 5-10 (balanced for control and speed)
 
@@ -467,7 +467,7 @@ const {
    - All tests pass
    - Execute story-dod-checklist
    - Present execution summary vs. plan
-   - Set status: "Ready for Review"
+   - Set status: "InReview" (see Status Transitions section)
 
 **User Prompts**: All upfront (questionnaire phase), then 0 during execution
 
@@ -501,7 +501,7 @@ const {
 - Completion Notes List
 - File List
 - Change Log (add entry on completion)
-- Status (set to "Ready for Review" when complete)
+- Status (set to "InReview" when complete — see Status Transitions section)
 
 **DO NOT modify**: Story, Acceptance Criteria, Dev Notes, Testing sections
 
@@ -915,10 +915,46 @@ Found 5 technical decisions needed.
 - **Educational Value**: Interactive mode explanations help developers learn framework patterns
 - **Scope Drift Prevention**: Pre-flight mode eliminates mid-development ambiguity
 
+## Status Transitions (MANDATORY — All Modes)
+
+**Reference:** `.claude/rules/story-lifecycle.md` — @dev owns Ready → InProgress and InProgress → InReview transitions.
+
+**These steps MUST be executed at the specified points, regardless of execution mode.**
+
+### On Development Start (before first task):
+
+0. **Pre-check (blocking):**
+   - If current Status is not `**Ready**`, HALT and log: "Cannot start development: expected Ready, found {current status}."
+   - If Change Log section is missing, HALT and request user to restore template structure.
+1. **Update story Status field:** change `**Ready**` to `**InProgress**`
+2. **Add Change Log entry:**
+   ```text
+   | {today's date} | {next version} | Development started ({mode} mode) — Status: Ready → InProgress | @dev |
+   ```
+3. **Log:** "🚀 Story status updated: Ready → InProgress"
+
+### On Development Complete (after DOD checklist, before HALT):
+
+0. **Pre-check (blocking):**
+   - If current Status is not `**InProgress**`, HALT and log: "Cannot mark for review: expected InProgress, found {current status}."
+   - If Change Log section is missing, HALT and request user to restore template structure.
+1. **Update story Status field:** change `**InProgress**` to `**InReview**`
+2. **Add Change Log entry:**
+   ```text
+   | {today's date} | {next version} | Development complete — Status: InProgress → InReview | @dev |
+   ```
+3. **Log:** "✅ Story status updated: InProgress → InReview"
+
+### Rationale
+
+Status transitions defined in `story-lifecycle.md` are advisory (contextual rules). These steps make them imperative (procedural), ensuring agents always execute the transitions as part of the workflow rather than relying on contextual rule awareness.
+
+---
+
 ## Handoff
 next_agent: @qa
 next_command: *review {story-id}
-condition: Story status is Ready for Review
+condition: Story status is InReview (updated in Status Transitions above)
 alternatives:
   - agent: @qa, command: *gate {story-id}, condition: Quick gate decision needed
   - agent: @dev, command: *apply-qa-fixes, condition: Self-identified issues during dev

--- a/.aiox-core/development/tasks/qa-gate.md
+++ b/.aiox-core/development/tasks/qa-gate.md
@@ -420,11 +420,50 @@ Gate: CONCERNS → qa.qaLocation/gates/{epic}.{story}-{slug}.yml
 - Always update story with gate reference
 - Clear, actionable findings
 
+## Post-Gate Status Update (MANDATORY)
+
+**Reference:** `.claude/rules/story-lifecycle.md` — Status transitions are @qa responsibility during QA gate.
+
+**This step MUST be executed before presenting results to user.**
+
+### IF verdict is PASS or CONCERNS:
+
+1. **Update story Status field** in the story file: change `**InReview**` to `**Done**`
+2. **Add Change Log entry:**
+   ```
+   | {today's date} | {next version} | QA Gate {PASS|CONCERNS} — Status: InReview → Done | @qa |
+   ```
+3. **Log:** "✅ Story status updated: InReview → Done"
+
+### IF verdict is FAIL:
+
+1. **Update story Status field** in the story file: change `**InReview**` to `**InProgress**`
+2. **Add Change Log entry:**
+   ```
+   | {today's date} | {next version} | QA Gate FAIL — Status: InReview → InProgress — {reason} | @qa |
+   ```
+3. **Log:** "❌ Story returned to InProgress — fixes required"
+
+### IF verdict is WAIVED:
+
+1. **Update story Status field** in the story file: change `**InReview**` to `**Done**`
+2. **Add Change Log entry:**
+   ```
+   | {today's date} | {next version} | QA Gate WAIVED — Status: InReview → Done — {waiver reason} | @qa |
+   ```
+3. **Log:** "⚠️ Story status updated: InReview → Done (waived)"
+
+### Rationale
+
+Status transitions defined in `story-lifecycle.md` are advisory (contextual rules). This step makes them imperative (procedural), ensuring agents always execute the transition as part of the workflow rather than relying on contextual rule awareness.
+
+---
+
 ## Handoff
 next_agent: @devops
 next_command: *push
-condition: QA gate verdict is PASS
+condition: QA gate verdict is PASS (status updated to Done)
 alternatives:
-  - agent: @dev, command: *apply-qa-fixes, condition: QA gate verdict is FAIL or CONCERNS
-  - agent: @po, command: *close-story {story-id}, condition: QA gate verdict is WAIVED
+  - agent: @dev, command: *apply-qa-fixes, condition: QA gate verdict is FAIL (status updated to InProgress)
+  - agent: @po, command: *close-story {story-id}, condition: QA gate verdict is WAIVED (status updated to Done)
  

--- a/.aiox-core/development/tasks/qa-gate.md
+++ b/.aiox-core/development/tasks/qa-gate.md
@@ -471,9 +471,8 @@ Status transitions defined in `story-lifecycle.md` are advisory (contextual rule
 ## Handoff
 next_agent: @devops
 next_command: *push
-condition: QA gate verdict is PASS (status updated to Done)
+condition: QA gate verdict is PASS or CONCERNS (status updated to Done)
 alternatives:
-  - agent: @po, command: *review-concerns {story-id}, condition: QA gate verdict is CONCERNS (status updated to Done)
+  - agent: @po, command: *review-concerns {story-id}, condition: QA gate verdict is CONCERNS (status updated to Done, has non-blocking issues)
   - agent: @dev, command: *apply-qa-fixes, condition: QA gate verdict is FAIL (status updated to InProgress)
   - agent: @po, command: *close-story {story-id}, condition: QA gate verdict is WAIVED (status updated to Done)
- 

--- a/.aiox-core/development/tasks/qa-gate.md
+++ b/.aiox-core/development/tasks/qa-gate.md
@@ -428,27 +428,36 @@ Gate: CONCERNS → qa.qaLocation/gates/{epic}.{story}-{slug}.yml
 
 ### IF verdict is PASS or CONCERNS:
 
+0. **Pre-check (blocking):**
+   - If current Status is not `**InReview**`, HALT and log: "Cannot apply PASS/CONCERNS transition: expected InReview, found {current status}."
+   - If Change Log section is missing, HALT and request user to restore template structure.
 1. **Update story Status field** in the story file: change `**InReview**` to `**Done**`
 2. **Add Change Log entry:**
-   ```
+   ```text
    | {today's date} | {next version} | QA Gate {PASS|CONCERNS} — Status: InReview → Done | @qa |
    ```
 3. **Log:** "✅ Story status updated: InReview → Done"
 
 ### IF verdict is FAIL:
 
+0. **Pre-check (blocking):**
+   - If current Status is not `**InReview**`, HALT and log: "Cannot apply FAIL transition: expected InReview, found {current status}."
+   - If Change Log section is missing, HALT and request user to restore template structure.
 1. **Update story Status field** in the story file: change `**InReview**` to `**InProgress**`
 2. **Add Change Log entry:**
-   ```
+   ```text
    | {today's date} | {next version} | QA Gate FAIL — Status: InReview → InProgress — {reason} | @qa |
    ```
 3. **Log:** "❌ Story returned to InProgress — fixes required"
 
 ### IF verdict is WAIVED:
 
+0. **Pre-check (blocking):**
+   - If current Status is not `**InReview**`, HALT and log: "Cannot apply WAIVED transition: expected InReview, found {current status}."
+   - If Change Log section is missing, HALT and request user to restore template structure.
 1. **Update story Status field** in the story file: change `**InReview**` to `**Done**`
 2. **Add Change Log entry:**
-   ```
+   ```text
    | {today's date} | {next version} | QA Gate WAIVED — Status: InReview → Done — {waiver reason} | @qa |
    ```
 3. **Log:** "⚠️ Story status updated: InReview → Done (waived)"
@@ -464,6 +473,7 @@ next_agent: @devops
 next_command: *push
 condition: QA gate verdict is PASS (status updated to Done)
 alternatives:
+  - agent: @po, command: *review-concerns {story-id}, condition: QA gate verdict is CONCERNS (status updated to Done)
   - agent: @dev, command: *apply-qa-fixes, condition: QA gate verdict is FAIL (status updated to InProgress)
   - agent: @po, command: *close-story {story-id}, condition: QA gate verdict is WAIVED (status updated to Done)
  

--- a/.aiox-core/development/tasks/validate-next-story.md
+++ b/.aiox-core/development/tasks/validate-next-story.md
@@ -463,10 +463,40 @@ Provide a structured validation report including:
 - **Implementation Readiness Score**: 1-10 scale
 - **Confidence Level**: High/Medium/Low for successful implementation
 
+### 12. Post-Validation Status Update (MANDATORY)
+
+**Reference:** `.claude/rules/story-lifecycle.md` — Draft → Ready transition is @po responsibility.
+
+**This step MUST be executed before presenting results to user.**
+
+#### IF verdict is GO (score >= 7):
+
+1. **Update story Status field** in the story file: change `**Draft**` to `**Ready**`
+2. **Add Change Log entry:**
+   ```
+   | {today's date} | {next version} | Validated GO ({score}/10) — Status: Draft → Ready | @po |
+   ```
+3. **Log:** "✅ Story status updated: Draft → Ready"
+
+#### IF verdict is NO-GO (score < 7):
+
+1. **Keep** story Status as `**Draft**`
+2. **Add Change Log entry:**
+   ```
+   | {today's date} | {next version} | Validation NO-GO — {reason summary} | @po |
+   ```
+3. **Log:** "❌ Story remains Draft — fixes required before re-validation"
+
+#### Rationale
+
+Status transitions defined in `story-lifecycle.md` are advisory (contextual rules). This step makes them imperative (procedural), ensuring agents always execute the transition as part of the workflow rather than relying on contextual rule awareness.
+
+---
+
 ## Handoff
 next_agent: @dev
 next_command: *develop {story-id}
-condition: Story status is Approved (GO decision)
+condition: Story status is Ready (GO decision, status updated in Step 12)
 alternatives:
   - agent: @sm, command: *draft, condition: Story rejected (NO-GO), needs rework
  

--- a/.aiox-core/development/tasks/validate-next-story.md
+++ b/.aiox-core/development/tasks/validate-next-story.md
@@ -505,4 +505,3 @@ next_command: *develop {story-id}
 condition: Story status is Ready (GO decision, status updated in Step 12)
 alternatives:
   - agent: @sm, command: *draft, condition: Story rejected (NO-GO), needs rework
- 

--- a/.aiox-core/development/tasks/validate-next-story.md
+++ b/.aiox-core/development/tasks/validate-next-story.md
@@ -471,18 +471,24 @@ Provide a structured validation report including:
 
 #### IF verdict is GO (score >= 7):
 
+0. **Pre-check (blocking):**
+   - If current Status is not `**Draft**`, HALT and log: "Cannot apply GO transition: expected Draft, found {current status}."
+   - If Change Log section is missing, HALT and request user to restore template structure.
 1. **Update story Status field** in the story file: change `**Draft**` to `**Ready**`
 2. **Add Change Log entry:**
-   ```
+   ```text
    | {today's date} | {next version} | Validated GO ({score}/10) — Status: Draft → Ready | @po |
    ```
 3. **Log:** "✅ Story status updated: Draft → Ready"
 
 #### IF verdict is NO-GO (score < 7):
 
+0. **Pre-check (blocking):**
+   - If current Status is not `**Draft**`, HALT and log: "Cannot apply NO-GO outcome: expected Draft, found {current status}."
+   - If Change Log section is missing, HALT and request user to restore template structure.
 1. **Keep** story Status as `**Draft**`
 2. **Add Change Log entry:**
-   ```
+   ```text
    | {today's date} | {next version} | Validation NO-GO — {reason summary} | @po |
    ```
 3. **Log:** "❌ Story remains Draft — fixes required before re-validation"


### PR DESCRIPTION
## Summary

- Task workflows (`validate-next-story.md`, `qa-gate.md`) lack imperative steps to update story status after verdict
- Status transitions are defined in `story-lifecycle.md` (advisory/contextual rules) but agents follow task files procedurally and skip rules not embedded in the workflow
- Added mandatory post-verdict status update steps to both task files, closing the gap between advisory rules and imperative execution

## Changes

### `validate-next-story.md` — New Step 12: Post-Validation Status Update
- GO verdict (score >= 7): Updates story status `Draft → Ready` + Change Log entry
- NO-GO verdict (score < 7): Keeps `Draft` + Change Log entry

### `qa-gate.md` — New section: Post-Gate Status Update
- PASS/CONCERNS: Updates story status `InReview → Done` + Change Log entry
- FAIL: Updates story status `InReview → InProgress` + Change Log entry
- WAIVED: Updates story status `InReview → Done` + Change Log entry

## Root Cause

Rules in `.claude/rules/story-lifecycle.md` are **advisory** — loaded contextually when editing files matching `paths:` patterns. Tasks in `.aios-core/development/tasks/` are **imperative** — executed step-by-step by agents as recipes. Since status transitions only existed in advisory rules, agents consistently skipped them during workflow execution.

## Test plan

- [ ] Run `*validate-story-draft` on a Draft story → verify status changes to Ready on GO
- [ ] Run `*qa-gate` on an InReview story → verify status changes to Done on PASS
- [ ] Run `*qa-gate` on an InReview story → verify status changes to InProgress on FAIL
- [ ] Verify Change Log entries are added in all cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added mandatory post-gate status update procedures requiring explicit status transitions, Change Log entries, and outcome-specific log messages for PASS, CONCERNS, FAIL, and WAIVED.
  * Introduced a mandatory post-validation status update enforcing GO/NO-GO transitions, Change Log tracking, and outcome-specific logging/remediation.
  * Added mandatory Status Transitions across development workflows (Ready→InProgress→InReview), and updated handoff conditions to reflect these enforced transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->