### PR TITLE
fix: add division-by-zero guard and enforce agent delegation protocol

### DIFF
--- a/.aiox-core/core/orchestration/master-orchestrator.js
+++ b/.aiox-core/core/orchestration/master-orchestrator.js
@@ -1355,6 +1355,7 @@ class MasterOrchestrator extends EventEmitter {
     if (!state.epics) return 0;
 
     const totalEpics = Object.keys(EPIC_CONFIG).filter((num) => !EPIC_CONFIG[num].onDemand).length;
+    if (totalEpics === 0) return 0;
 
     const completedEpics = Object.values(state.epics).filter(
       (epic) => epic.status === EpicStatus.COMPLETED,
@@ -1411,6 +1412,7 @@ class MasterOrchestrator extends EventEmitter {
    */
   getProgressPercentage() {
     const totalEpics = Object.keys(EPIC_CONFIG).filter((num) => !EPIC_CONFIG[num].onDemand).length;
+    if (totalEpics === 0) return 0;
 
     const completedEpics = Object.values(this.executionState.epics).filter(
       (epic) => epic.status === EpicStatus.COMPLETED,

--- a/.aiox-core/data/entity-registry.yaml
+++ b/.aiox-core/data/entity-registry.yaml
@@ -1,6 +1,6 @@
 metadata:
   version: 1.0.0
-  lastUpdated: '2026-03-06T11:53:37.887Z'
+  lastUpdated: '2026-03-11T02:01:00.104Z'
   entityCount: 745
   checksumAlgorithm: sha256
   resolutionRate: 100
@@ -28,7 +28,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:badc8a9859cb313e908d4ea0f4c4d7bc1be723214e38f26d55c366689fe5e3f0
-      lastVerified: '2026-03-06T11:53:37.066Z'
+      lastVerified: '2026-03-11T02:00:27.493Z'
     advanced-elicitation:
       path: .aiox-core/development/tasks/advanced-elicitation.md
       layer: L2
@@ -53,7 +53,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:897f36c94fc1e4e40c9e5728f3c7780515b40742d6a99366a5fdb5df109f6636
-      lastVerified: '2026-03-06T11:53:37.068Z'
+      lastVerified: '2026-03-11T02:00:27.495Z'
     analyst-facilitate-brainstorming:
       path: .aiox-core/development/tasks/analyst-facilitate-brainstorming.md
       layer: L2
@@ -80,7 +80,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:85bef3ab05f3e3422ff450e7d39f04f49e59fa981df2f126eeb0f8395e4a1625
-      lastVerified: '2026-03-06T11:53:37.069Z'
+      lastVerified: '2026-03-11T02:00:27.496Z'
     analyze-brownfield:
       path: .aiox-core/development/tasks/analyze-brownfield.md
       layer: L2
@@ -108,7 +108,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0d1c35b32db5ae058ee29c125b1a7ce6d39bfd37d82711aad3abe780ef99cef3
-      lastVerified: '2026-03-06T11:53:37.070Z'
+      lastVerified: '2026-03-11T02:00:27.496Z'
     analyze-cross-artifact:
       path: .aiox-core/development/tasks/analyze-cross-artifact.md
       layer: L2
@@ -134,7 +134,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ce335d997ddd6438c298b18386ab72414959f24e6176736f12ee26ea5764432b
-      lastVerified: '2026-03-06T11:53:37.071Z'
+      lastVerified: '2026-03-11T02:00:27.496Z'
     analyze-framework:
       path: .aiox-core/development/tasks/analyze-framework.md
       layer: L2
@@ -163,7 +163,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6f3bb2f12ad42600cb38d6a1677608772bf8cb63a1e5971c987400ebf3e1d685
-      lastVerified: '2026-03-06T11:53:37.072Z'
+      lastVerified: '2026-03-11T02:00:27.497Z'
     analyze-performance:
       path: .aiox-core/development/tasks/analyze-performance.md
       layer: L2
@@ -187,7 +187,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c3a78a8794d2edfbf44525e1bbe286bb957dcc0fbbee5d9b8a7876a8d0cdce4
-      lastVerified: '2026-03-06T11:53:37.072Z'
+      lastVerified: '2026-03-11T02:00:27.497Z'
     analyze-project-structure:
       path: .aiox-core/development/tasks/analyze-project-structure.md
       layer: L2
@@ -219,7 +219,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0f6acf877e5fa93796418576c239ea300226c4fb6fe28639239da8cc8225a57e
-      lastVerified: '2026-03-06T11:53:37.072Z'
+      lastVerified: '2026-03-11T02:00:27.497Z'
     apply-qa-fixes:
       path: .aiox-core/development/tasks/apply-qa-fixes.md
       layer: L2
@@ -245,7 +245,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:614731439a27c15ecc02d84abf3d320c2cf18f016075c222ca1d7bfda12d6625
-      lastVerified: '2026-03-06T11:53:37.073Z'
+      lastVerified: '2026-03-11T02:00:27.497Z'
     architect-analyze-impact:
       path: .aiox-core/development/tasks/architect-analyze-impact.md
       layer: L2
@@ -276,7 +276,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:251d2c073b917f0285672568f074ec0c77372e110e234b42f043c605e438d9ee
-      lastVerified: '2026-03-06T11:53:37.074Z'
+      lastVerified: '2026-03-11T02:00:27.498Z'
     audit-codebase:
       path: .aiox-core/development/tasks/audit-codebase.md
       layer: L2
@@ -301,7 +301,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:11a136d6e7cd6d5238a06a9298eff28d381799667612aa7668d923cc40c74ff7
-      lastVerified: '2026-03-06T11:53:37.074Z'
+      lastVerified: '2026-03-11T02:00:27.498Z'
     audit-tailwind-config:
       path: .aiox-core/development/tasks/audit-tailwind-config.md
       layer: L2
@@ -326,7 +326,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6a555a7b86f2b447b0393b9ac1a7f2be84f5705c293259c83c082b25ec849fbb
-      lastVerified: '2026-03-06T11:53:37.075Z'
+      lastVerified: '2026-03-11T02:00:27.498Z'
     audit-utilities:
       path: .aiox-core/development/tasks/audit-utilities.md
       layer: L2
@@ -351,7 +351,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1a1e4cb6be031f144d223321c6977a88108843b05b933143784ce8340198acd3
-      lastVerified: '2026-03-06T11:53:37.075Z'
+      lastVerified: '2026-03-11T02:00:27.498Z'
     bootstrap-shadcn-library:
       path: .aiox-core/development/tasks/bootstrap-shadcn-library.md
       layer: L2
@@ -377,7 +377,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3fe06f13e2ff550bab6b74cf2105f5902800e568fd7afc982dd3987c5579e769
-      lastVerified: '2026-03-06T11:53:37.075Z'
+      lastVerified: '2026-03-11T02:00:27.498Z'
     brownfield-create-epic:
       path: .aiox-core/development/tasks/brownfield-create-epic.md
       layer: L2
@@ -416,7 +416,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:554a403bdd14fdc0aa6236818d47b273e275f73b39971c3918e74978e28d9b68
-      lastVerified: '2026-03-06T11:53:37.076Z'
+      lastVerified: '2026-03-11T02:00:27.498Z'
     brownfield-create-story:
       path: .aiox-core/development/tasks/brownfield-create-story.md
       layer: L2
@@ -446,7 +446,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:29ba1fe81cda46bdece3e698cc797370c63df56903e38ca71523352b98e08dd2
-      lastVerified: '2026-03-06T11:53:37.076Z'
+      lastVerified: '2026-03-11T02:00:27.499Z'
     build-autonomous:
       path: .aiox-core/development/tasks/build-autonomous.md
       layer: L2
@@ -472,7 +472,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:90ea4c17a6a131082df1546fbe1f30817b951bba7a8b9a41a371578ce8034b39
-      lastVerified: '2026-03-06T11:53:37.077Z'
+      lastVerified: '2026-03-11T02:00:27.499Z'
     build-component:
       path: .aiox-core/development/tasks/build-component.md
       layer: L2
@@ -497,7 +497,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:026adaf174a29692f4eef293a94f5909de9c79d25d7ed226740db1708cde4389
-      lastVerified: '2026-03-06T11:53:37.077Z'
+      lastVerified: '2026-03-11T02:00:27.499Z'
     build-resume:
       path: .aiox-core/development/tasks/build-resume.md
       layer: L2
@@ -520,7 +520,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:920b1faa39d021fd7c0013b5d2ac4f66ac6de844723821b65dfaceba41d37885
-      lastVerified: '2026-03-06T11:53:37.078Z'
+      lastVerified: '2026-03-11T02:00:27.499Z'
     build-status:
       path: .aiox-core/development/tasks/build-status.md
       layer: L2
@@ -542,7 +542,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:47a5f95ab59ff99532adf442700f4b949e32bd5bd2131998d8f271327108e4e1
-      lastVerified: '2026-03-06T11:53:37.079Z'
+      lastVerified: '2026-03-11T02:00:27.499Z'
     build:
       path: .aiox-core/development/tasks/build.md
       layer: L2
@@ -564,7 +564,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2f09d24cc0e5f9e4cf527fcb5341461a7ac30fcadf82e4f78f98be161e0ea4ec
-      lastVerified: '2026-03-06T11:53:37.079Z'
+      lastVerified: '2026-03-11T02:00:27.499Z'
     calculate-roi:
       path: .aiox-core/development/tasks/calculate-roi.md
       layer: L2
@@ -590,7 +590,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa8c2073ee845a42b30eea44e2452898ebb8e5d4fceb207c9b42984f817732cc
-      lastVerified: '2026-03-06T11:53:37.080Z'
+      lastVerified: '2026-03-11T02:00:27.499Z'
     check-docs-links:
       path: .aiox-core/development/tasks/check-docs-links.md
       layer: L2
@@ -612,7 +612,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a7e1400d894777caa607486ff78b77ea454e4ace1c16d54308533ecc7f2c015
-      lastVerified: '2026-03-06T11:53:37.080Z'
+      lastVerified: '2026-03-11T02:00:27.499Z'
     ci-cd-configuration:
       path: .aiox-core/development/tasks/ci-cd-configuration.md
       layer: L2
@@ -640,7 +640,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:115634392c1838eac80c7a5b760f43f96c92ad69c7a88d9932debed64e5ad23a
-      lastVerified: '2026-03-06T11:53:37.080Z'
+      lastVerified: '2026-03-11T02:00:27.500Z'
     cleanup-utilities:
       path: .aiox-core/development/tasks/cleanup-utilities.md
       layer: L2
@@ -668,7 +668,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8945dee3b0ea9afcab4aba1f4651be00d79ae236710a36821cf04238bee3890f
-      lastVerified: '2026-03-06T11:53:37.081Z'
+      lastVerified: '2026-03-11T02:00:27.500Z'
     cleanup-worktrees:
       path: .aiox-core/development/tasks/cleanup-worktrees.md
       layer: L2
@@ -691,7 +691,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:10d9fab42ba133a03f76094829ab467d2ef53b80bcc3de39245805679cedfbbd
-      lastVerified: '2026-03-06T11:53:37.081Z'
+      lastVerified: '2026-03-11T02:00:27.500Z'
     collaborative-edit:
       path: .aiox-core/development/tasks/collaborative-edit.md
       layer: L2
@@ -719,7 +719,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9295eae7a7c8731ff06131f76dcd695d30641d714a64c164989b98d8631532d8
-      lastVerified: '2026-03-06T11:53:37.082Z'
+      lastVerified: '2026-03-11T02:00:27.500Z'
     compose-molecule:
       path: .aiox-core/development/tasks/compose-molecule.md
       layer: L2
@@ -746,7 +746,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:596b8a8e1a6068e02aceeb9d1164d64fe8686b492ff39d25ec8dcd67ad1f9c09
-      lastVerified: '2026-03-06T11:53:37.082Z'
+      lastVerified: '2026-03-11T02:00:27.500Z'
     consolidate-patterns:
       path: .aiox-core/development/tasks/consolidate-patterns.md
       layer: L2
@@ -772,7 +772,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c45d9337c0aac9fcea56e216e172234a4f09a09f45db311f013973f9d5efc05a
-      lastVerified: '2026-03-06T11:53:37.083Z'
+      lastVerified: '2026-03-11T02:00:27.500Z'
     correct-course:
       path: .aiox-core/development/tasks/correct-course.md
       layer: L2
@@ -800,7 +800,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec55430908fb25c99bd0ae0bbf8aad6b1aff36306488abb07cf6e8f2e03306cc
-      lastVerified: '2026-03-06T11:53:37.083Z'
+      lastVerified: '2026-03-11T02:00:27.500Z'
     create-agent:
       path: .aiox-core/development/tasks/create-agent.md
       layer: L2
@@ -824,7 +824,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:538954ecee93c0b4467d4dc00ce4315b2fac838ad298a11c6bc4e45366430e17
-      lastVerified: '2026-03-06T11:53:37.085Z'
+      lastVerified: '2026-03-11T02:00:27.501Z'
     create-brownfield-story:
       path: .aiox-core/development/tasks/create-brownfield-story.md
       layer: L2
@@ -854,7 +854,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:88dc7949dbfde53773135650a6864c2b7a36cbfe93239cee8edf8a9c082b0fcf
-      lastVerified: '2026-03-06T11:53:37.085Z'
+      lastVerified: '2026-03-11T02:00:27.501Z'
     create-deep-research-prompt:
       path: .aiox-core/development/tasks/create-deep-research-prompt.md
       layer: L2
@@ -889,7 +889,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c432fad72d00722db2525b3b68555ab02bb38e80f85e55b7354b389771ed943b
-      lastVerified: '2026-03-06T11:53:37.086Z'
+      lastVerified: '2026-03-11T02:00:27.502Z'
     create-doc:
       path: .aiox-core/development/tasks/create-doc.md
       layer: L2
@@ -924,7 +924,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:078b2e5ac900f5d48fc82792198e59108a32891c77ed18aa062d87db442d155e
-      lastVerified: '2026-03-06T11:53:37.087Z'
+      lastVerified: '2026-03-11T02:00:27.502Z'
     create-next-story:
       path: .aiox-core/development/tasks/create-next-story.md
       layer: L2
@@ -967,7 +967,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0705fe3750d229b47fe194109d3ec398cb90adfdfe1a6d7cf80ca8bdf73b6ad0
-      lastVerified: '2026-03-06T11:53:37.088Z'
+      lastVerified: '2026-03-11T02:00:27.502Z'
     create-service:
       path: .aiox-core/development/tasks/create-service.md
       layer: L2
@@ -992,7 +992,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dd9467f3e646ca4058f0cc524f99ae102c91750fa70f412f41f50f89d8f4b4e9
-      lastVerified: '2026-03-06T11:53:37.088Z'
+      lastVerified: '2026-03-11T02:00:27.502Z'
     create-suite:
       path: .aiox-core/development/tasks/create-suite.md
       layer: L2
@@ -1022,7 +1022,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0c5e7fa10bcb37d571ae3003f79fb6f98f46ed26c35234912b23b13d47091cb1
-      lastVerified: '2026-03-06T11:53:37.088Z'
+      lastVerified: '2026-03-11T02:00:27.502Z'
     create-task:
       path: .aiox-core/development/tasks/create-task.md
       layer: L2
@@ -1051,7 +1051,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2adfe4c3c8b73fbe3998444e24af796542342265b102ce52d3fc85d69d5e12af
-      lastVerified: '2026-03-06T11:53:37.089Z'
+      lastVerified: '2026-03-11T02:00:27.502Z'
     create-workflow:
       path: .aiox-core/development/tasks/create-workflow.md
       layer: L2
@@ -1079,8 +1079,8 @@ entities:
         score: 0.8
         constraints: []
         extensionPoints: []
-      checksum: sha256:64abe2114fc3ab6b0494375c6401aa6a8213c63b1dc18ffac729d2acf1161a2c
-      lastVerified: '2026-03-06T11:53:37.089Z'
+      checksum: sha256:76f47a9fa54b9690a10ddf4544c96f8d732c658550fd8487f9defd2339b8e222
+      lastVerified: '2026-03-11T02:00:27.503Z'
     create-worktree:
       path: .aiox-core/development/tasks/create-worktree.md
       layer: L2
@@ -1111,7 +1111,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:143b9bdf87a4eed0faac612e137965483dec1224a7579399a68b68b6bc0689b7
-      lastVerified: '2026-03-06T11:53:37.089Z'
+      lastVerified: '2026-03-11T02:00:27.503Z'
     db-analyze-hotpaths:
       path: .aiox-core/development/tasks/db-analyze-hotpaths.md
       layer: L2
@@ -1137,7 +1137,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0993cb6e5d0c4fb22f081060e47f303c3c745889cf7b583ea2a29ab0f3b0ac6e
-      lastVerified: '2026-03-06T11:53:37.090Z'
+      lastVerified: '2026-03-11T02:00:27.503Z'
     db-apply-migration:
       path: .aiox-core/development/tasks/db-apply-migration.md
       layer: L2
@@ -1163,7 +1163,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73ca77d0858dde76a1979d6c0dce1cd6760666ea67fdc60283da0d027d73eaa2
-      lastVerified: '2026-03-06T11:53:37.090Z'
+      lastVerified: '2026-03-11T02:00:27.503Z'
     db-bootstrap:
       path: .aiox-core/development/tasks/db-bootstrap.md
       layer: L2
@@ -1188,7 +1188,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b50effd8d5d63bcbb7f42a02223678306c4b10a3d7cdbd94b024e0dc716d1e69
-      lastVerified: '2026-03-06T11:53:37.090Z'
+      lastVerified: '2026-03-11T02:00:27.503Z'
     db-domain-modeling:
       path: .aiox-core/development/tasks/db-domain-modeling.md
       layer: L2
@@ -1213,7 +1213,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:afd2911ebdb4d4164885efb6d71cb2578da1e60ca3c37397f19261a99e5bb22b
-      lastVerified: '2026-03-06T11:53:37.091Z'
+      lastVerified: '2026-03-11T02:00:27.503Z'
     db-dry-run:
       path: .aiox-core/development/tasks/db-dry-run.md
       layer: L2
@@ -1239,7 +1239,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ce848fdf956175b5dd96d6864376011972d2a7512ce37519592589eca442ec2b
-      lastVerified: '2026-03-06T11:53:37.091Z'
+      lastVerified: '2026-03-11T02:00:27.503Z'
     db-env-check:
       path: .aiox-core/development/tasks/db-env-check.md
       layer: L2
@@ -1263,7 +1263,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8a4674f5858ee709186690b45dd51fe5cbb28097a641f178e0e624e2a5331a44
-      lastVerified: '2026-03-06T11:53:37.091Z'
+      lastVerified: '2026-03-11T02:00:27.503Z'
     db-explain:
       path: .aiox-core/development/tasks/db-explain.md
       layer: L2
@@ -1287,7 +1287,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b96391756f45fc99b5cbd129921541060dc9ced1d1c269b820109d36fcd53530
-      lastVerified: '2026-03-06T11:53:37.092Z'
+      lastVerified: '2026-03-11T02:00:27.504Z'
     db-impersonate:
       path: .aiox-core/development/tasks/db-impersonate.md
       layer: L2
@@ -1312,7 +1312,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:31891339b082706882c3529d5fbae5a77e566dbe94dfb2cc011a70aef6721abd
-      lastVerified: '2026-03-06T11:53:37.092Z'
+      lastVerified: '2026-03-11T02:00:27.504Z'
     db-load-csv:
       path: .aiox-core/development/tasks/db-load-csv.md
       layer: L2
@@ -1338,7 +1338,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a4cf24a705ad7669aef945a71dcc95b7e156e2c41ee20be9d63819818422bd23
-      lastVerified: '2026-03-06T11:53:37.093Z'
+      lastVerified: '2026-03-11T02:00:27.504Z'
     db-policy-apply:
       path: .aiox-core/development/tasks/db-policy-apply.md
       layer: L2
@@ -1364,7 +1364,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5069a7786ac2f5c032f9b4aeedaa90808bccb0ecc01456d72b11d111281c8497
-      lastVerified: '2026-03-06T11:53:37.094Z'
+      lastVerified: '2026-03-11T02:00:27.504Z'
     db-rls-audit:
       path: .aiox-core/development/tasks/db-rls-audit.md
       layer: L2
@@ -1387,7 +1387,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b25183564fe08abdb5c563a19eac526ebbe14c10397cfb27e9b2f2c53f1c189b
-      lastVerified: '2026-03-06T11:53:37.095Z'
+      lastVerified: '2026-03-11T02:00:27.504Z'
     db-rollback:
       path: .aiox-core/development/tasks/db-rollback.md
       layer: L2
@@ -1411,7 +1411,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cc8b5ccbfb8184724452bd4fbaf93a5e43b137428f7cd1c6562b8bc7c10887e2
-      lastVerified: '2026-03-06T11:53:37.095Z'
+      lastVerified: '2026-03-11T02:00:27.504Z'
     db-run-sql:
       path: .aiox-core/development/tasks/db-run-sql.md
       layer: L2
@@ -1435,7 +1435,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:90b771db8d68c2cc3236aa371d24c2553175c4d39931fe3eb690cdd2ebaded1e
-      lastVerified: '2026-03-06T11:53:37.095Z'
+      lastVerified: '2026-03-11T02:00:27.504Z'
     db-schema-audit:
       path: .aiox-core/development/tasks/db-schema-audit.md
       layer: L2
@@ -1458,7 +1458,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4a70508b9d6bbe2b2e62265231682df371dc3a9295e285ef2e4356f81ed941e9
-      lastVerified: '2026-03-06T11:53:37.096Z'
+      lastVerified: '2026-03-11T02:00:27.505Z'
     db-seed:
       path: .aiox-core/development/tasks/db-seed.md
       layer: L2
@@ -1483,7 +1483,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e3553aff9781731e75c2017a7038cbb843a6945d69fb26365300aae3fd68d97e
-      lastVerified: '2026-03-06T11:53:37.096Z'
+      lastVerified: '2026-03-11T02:00:27.505Z'
     db-smoke-test:
       path: .aiox-core/development/tasks/db-smoke-test.md
       layer: L2
@@ -1507,7 +1507,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7f0672e95bedf5d5ac83f34acdd07f32d88bab743a2f210a49b6bea9bcdd04c7
-      lastVerified: '2026-03-06T11:53:37.097Z'
+      lastVerified: '2026-03-11T02:00:27.505Z'
     db-snapshot:
       path: .aiox-core/development/tasks/db-snapshot.md
       layer: L2
@@ -1532,7 +1532,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:60955c4ec4894233ef891424900d134ff4ac987ccf6fa2521f704e476865ef79
-      lastVerified: '2026-03-06T11:53:37.099Z'
+      lastVerified: '2026-03-11T02:00:27.505Z'
     db-squad-integration:
       path: .aiox-core/development/tasks/db-squad-integration.md
       layer: L2
@@ -1556,7 +1556,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:13ce5e3226dadffad490752064169e124e2c989514e2e7b3c249445b9ad3485c
-      lastVerified: '2026-03-06T11:53:37.099Z'
+      lastVerified: '2026-03-11T02:00:27.505Z'
     db-supabase-setup:
       path: .aiox-core/development/tasks/db-supabase-setup.md
       layer: L2
@@ -1581,7 +1581,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:64e02b6c69bb87d0082590484fadc0510cb88e4a6dc01b3c7015e5e6e6bcb585
-      lastVerified: '2026-03-06T11:53:37.100Z'
+      lastVerified: '2026-03-11T02:00:27.505Z'
     db-verify-order:
       path: .aiox-core/development/tasks/db-verify-order.md
       layer: L2
@@ -1607,7 +1607,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:478a1f94e0e4d9da5488ce5df41538308454a64e534d587d5d8361dbd9cff701
-      lastVerified: '2026-03-06T11:53:37.100Z'
+      lastVerified: '2026-03-11T02:00:27.505Z'
     deprecate-component:
       path: .aiox-core/development/tasks/deprecate-component.md
       layer: L2
@@ -1638,7 +1638,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:72dfca4d222b990ed868e5fd4c0d5793848cd1a9fda6d48fb7caec93e02c59ed
-      lastVerified: '2026-03-06T11:53:37.100Z'
+      lastVerified: '2026-03-11T02:00:27.506Z'
     dev-apply-qa-fixes:
       path: .aiox-core/development/tasks/dev-apply-qa-fixes.md
       layer: L2
@@ -1663,7 +1663,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a5b993cbc89e46f3669748da0f33e5cae28af4e6552d7f492b7f640f735736ba
-      lastVerified: '2026-03-06T11:53:37.101Z'
+      lastVerified: '2026-03-11T02:00:27.506Z'
     dev-backlog-debt:
       path: .aiox-core/development/tasks/dev-backlog-debt.md
       layer: L2
@@ -1692,7 +1692,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e5aa74b0fb90697be71cb5c1914d8b632d7edac0b9e42d87539a4ea1519c7ed3
-      lastVerified: '2026-03-06T11:53:37.101Z'
+      lastVerified: '2026-03-11T02:00:27.506Z'
     dev-develop-story:
       path: .aiox-core/development/tasks/dev-develop-story.md
       layer: L2
@@ -1722,7 +1722,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:24ef3f76f37f82c8caa0bfaec4ac1ccf14ebd1cd60c6f0fe5c355d63b113784c
-      lastVerified: '2026-03-06T11:53:37.101Z'
+      lastVerified: '2026-03-11T02:00:27.506Z'
     dev-improve-code-quality:
       path: .aiox-core/development/tasks/dev-improve-code-quality.md
       layer: L2
@@ -1755,7 +1755,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6cf78aed6cca48bf13cc1f677f2cde86aea591785f428f9f56733de478107e2f
-      lastVerified: '2026-03-06T11:53:37.102Z'
+      lastVerified: '2026-03-11T02:00:27.506Z'
     dev-optimize-performance:
       path: .aiox-core/development/tasks/dev-optimize-performance.md
       layer: L2
@@ -1786,7 +1786,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:acd5a1b14732f4d2526ebee2571897eb5ccb4c106d2388eb3560298ed85ce20d
-      lastVerified: '2026-03-06T11:53:37.102Z'
+      lastVerified: '2026-03-11T02:00:27.507Z'
     dev-suggest-refactoring:
       path: .aiox-core/development/tasks/dev-suggest-refactoring.md
       layer: L2
@@ -1817,7 +1817,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:51eebcbb72786df561ee0f25176ee4534166d71f2cfd4db1ea6eae7e8f3f6188
-      lastVerified: '2026-03-06T11:53:37.103Z'
+      lastVerified: '2026-03-11T02:00:27.507Z'
     dev-validate-next-story:
       path: .aiox-core/development/tasks/dev-validate-next-story.md
       layer: L2
@@ -1845,7 +1845,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6dda51884ce7a5dd814d026aab3f2125d399e89b468b2125673c19ade9091ace
-      lastVerified: '2026-03-06T11:53:37.103Z'
+      lastVerified: '2026-03-11T02:00:27.507Z'
     document-gotchas:
       path: .aiox-core/development/tasks/document-gotchas.md
       layer: L2
@@ -1871,7 +1871,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:84858f6252bc2a85beda75971fed74e087edee3bdd537eb29f43132f0141fbf5
-      lastVerified: '2026-03-06T11:53:37.103Z'
+      lastVerified: '2026-03-11T02:00:27.507Z'
     document-project:
       path: .aiox-core/development/tasks/document-project.md
       layer: L2
@@ -1903,7 +1903,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8123a2c9105391b46857cfb3e236a912f47bfb598fb21df1cea0a12eabbf7337
-      lastVerified: '2026-03-06T11:53:37.104Z'
+      lastVerified: '2026-03-11T02:00:27.507Z'
     environment-bootstrap:
       path: .aiox-core/development/tasks/environment-bootstrap.md
       layer: L2
@@ -1941,7 +1941,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:02ed701bea38ee11ad7e83a310ad55b3d84f36f37a344fda6b252fe3230d50cb
-      lastVerified: '2026-03-06T11:53:37.104Z'
+      lastVerified: '2026-03-11T02:00:27.508Z'
     execute-checklist:
       path: .aiox-core/development/tasks/execute-checklist.md
       layer: L2
@@ -1978,7 +1978,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9bd751605efd593e0708bac6e3f1c66a91ba5f33a5069c655b6d16cf6621859c
-      lastVerified: '2026-03-06T11:53:37.105Z'
+      lastVerified: '2026-03-11T02:00:27.508Z'
     execute-epic-plan:
       path: .aiox-core/development/tasks/execute-epic-plan.md
       layer: L2
@@ -2008,7 +2008,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0c3ee4e1802927fb8f21be172daeb356797033ff082fea07523025a373bea387
-      lastVerified: '2026-03-06T11:53:37.105Z'
+      lastVerified: '2026-03-11T02:00:27.508Z'
     export-design-tokens-dtcg:
       path: .aiox-core/development/tasks/export-design-tokens-dtcg.md
       layer: L2
@@ -2034,7 +2034,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8819918bd7c4b6b0b0b0aadd66f5aecb2d6ca0b949206c16cb497d6d1d7a72f9
-      lastVerified: '2026-03-06T11:53:37.105Z'
+      lastVerified: '2026-03-11T02:00:27.508Z'
     extend-pattern:
       path: .aiox-core/development/tasks/extend-pattern.md
       layer: L2
@@ -2058,7 +2058,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7eaccc1d33f806bbcd2e7a90e701d6c88c00e4e98f14c14b4f705ff618ef17f8
-      lastVerified: '2026-03-06T11:53:37.106Z'
+      lastVerified: '2026-03-11T02:00:27.508Z'
     extract-patterns:
       path: .aiox-core/development/tasks/extract-patterns.md
       layer: L2
@@ -2082,7 +2082,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:aa8981c254d00a76c66c6c4f9569b0be1785f4537137ee23129049abae92f3b4
-      lastVerified: '2026-03-06T11:53:37.107Z'
+      lastVerified: '2026-03-11T02:00:27.509Z'
     extract-tokens:
       path: .aiox-core/development/tasks/extract-tokens.md
       layer: L2
@@ -2108,7 +2108,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8266d4caf51507fe82510c04a54b6a33c7e2d1f10862e4e242f009b214edd7ee
-      lastVerified: '2026-03-06T11:53:37.107Z'
+      lastVerified: '2026-03-11T02:00:27.509Z'
     facilitate-brainstorming-session:
       path: .aiox-core/development/tasks/facilitate-brainstorming-session.md
       layer: L2
@@ -2133,7 +2133,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c351428e7aa1af079046bbf357af98668675943fd13920b98b7ecfd9f87a6081
-      lastVerified: '2026-03-06T11:53:37.107Z'
+      lastVerified: '2026-03-11T02:00:27.509Z'
     generate-ai-frontend-prompt:
       path: .aiox-core/development/tasks/generate-ai-frontend-prompt.md
       layer: L2
@@ -2165,7 +2165,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d4c2abf28b065922f1e67c95fa2a69dd792c9828c6dd31d2fc173a5361b021aa
-      lastVerified: '2026-03-06T11:53:37.108Z'
+      lastVerified: '2026-03-11T02:00:27.509Z'
     generate-documentation:
       path: .aiox-core/development/tasks/generate-documentation.md
       layer: L2
@@ -2191,7 +2191,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec03841e1f72b8b55a156e03a7d6ef061f0cf942beb7d66f61d3bf6bdbaaa93b
-      lastVerified: '2026-03-06T11:53:37.108Z'
+      lastVerified: '2026-03-11T02:00:27.509Z'
     generate-migration-strategy:
       path: .aiox-core/development/tasks/generate-migration-strategy.md
       layer: L2
@@ -2216,7 +2216,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a944f9294553cad38c4e2a13143388a48dc330667e5b1b04dfcd1f5a2644541
-      lastVerified: '2026-03-06T11:53:37.109Z'
+      lastVerified: '2026-03-11T02:00:27.509Z'
     generate-shock-report:
       path: .aiox-core/development/tasks/generate-shock-report.md
       layer: L2
@@ -2241,7 +2241,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:04ebdca5f8bad14504f76d3e1fde4b426a4cd4ce8fe8dc4f9391f3c711bb6970
-      lastVerified: '2026-03-06T11:53:37.109Z'
+      lastVerified: '2026-03-11T02:00:27.509Z'
     github-devops-github-pr-automation:
       path: .aiox-core/development/tasks/github-devops-github-pr-automation.md
       layer: L2
@@ -2274,7 +2274,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2149c952074e661e77cfe6caa1bc2cb7366c930c9782eb308a8513a54f3d1629
-      lastVerified: '2026-03-06T11:53:37.110Z'
+      lastVerified: '2026-03-11T02:00:27.510Z'
     github-devops-pre-push-quality-gate:
       path: .aiox-core/development/tasks/github-devops-pre-push-quality-gate.md
       layer: L2
@@ -2306,7 +2306,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3709049cefce2dc03f54a16830114e67fa6b4cf37f0f999638d5d1521f0979d8
-      lastVerified: '2026-03-06T11:53:37.110Z'
+      lastVerified: '2026-03-11T02:00:27.510Z'
     github-devops-repository-cleanup:
       path: .aiox-core/development/tasks/github-devops-repository-cleanup.md
       layer: L2
@@ -2332,7 +2332,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:34135e86820be5218daf7031f4daa115d6ef9a727c7c0cb3a6f28c59f8e694c1
-      lastVerified: '2026-03-06T11:53:37.111Z'
+      lastVerified: '2026-03-11T02:00:27.510Z'
     github-devops-version-management:
       path: .aiox-core/development/tasks/github-devops-version-management.md
       layer: L2
@@ -2359,7 +2359,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1e217bea7df36731cfa5c3fb5a3b97399a57fef5989e59c303c3163bb3e5ecd7
-      lastVerified: '2026-03-06T11:53:37.111Z'
+      lastVerified: '2026-03-11T02:00:27.510Z'
     github-issue-triage:
       path: .aiox-core/development/tasks/github-issue-triage.md
       layer: L2
@@ -2380,7 +2380,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:61178caa7bc647dcae5e53d3f0515d6dab0cdc927e245b2db5844dc35d9e3d6f
-      lastVerified: '2026-03-06T11:53:37.111Z'
+      lastVerified: '2026-03-11T02:00:27.510Z'
     gotcha:
       path: .aiox-core/development/tasks/gotcha.md
       layer: L2
@@ -2405,7 +2405,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a9117d8a4c85c1be044975d829c936be0037c1751ef42b0fb2d19861702aecc6
-      lastVerified: '2026-03-06T11:53:37.112Z'
+      lastVerified: '2026-03-11T02:00:27.510Z'
     gotchas:
       path: .aiox-core/development/tasks/gotchas.md
       layer: L2
@@ -2431,7 +2431,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ecf526697d6c55416aaea97939cd2002e8f32eaa7001d31e823d7766688d2bf5
-      lastVerified: '2026-03-06T11:53:37.112Z'
+      lastVerified: '2026-03-11T02:00:27.511Z'
     ids-governor:
       path: .aiox-core/development/tasks/ids-governor.md
       layer: L2
@@ -2455,7 +2455,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cfb1aefffdf2db0d35cae8fdde2f5afbcea62b9b616e78a43390756c9b8e6b9c
-      lastVerified: '2026-03-06T11:53:37.112Z'
+      lastVerified: '2026-03-11T02:00:27.511Z'
     ids-health:
       path: .aiox-core/development/tasks/ids-health.md
       layer: L2
@@ -2478,7 +2478,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d5196b3741fb537707e1a99c71514e439447121df500002644dfebe43da4a70f
-      lastVerified: '2026-03-06T11:53:37.112Z'
+      lastVerified: '2026-03-11T02:00:27.511Z'
     ids-query:
       path: .aiox-core/development/tasks/ids-query.md
       layer: L2
@@ -2502,7 +2502,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c15596fdfc0bf86e4b6053313e7e91195c073d6c9066df4d626c5a3e2c13e99b
-      lastVerified: '2026-03-06T11:53:37.112Z'
+      lastVerified: '2026-03-11T02:00:27.511Z'
     improve-self:
       path: .aiox-core/development/tasks/improve-self.md
       layer: L2
@@ -2536,7 +2536,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ccabfaad3cdba01a151b313afdf0e1c41c8a981ec2140531f24500149b4a7646
-      lastVerified: '2026-03-06T11:53:37.113Z'
+      lastVerified: '2026-03-11T02:00:27.511Z'
     index-docs:
       path: .aiox-core/development/tasks/index-docs.md
       layer: L2
@@ -2567,7 +2567,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d8553b437ad8a4dc9dc37bd38939164ee0d0f76f2bb46d30a8318cf4413415f5
-      lastVerified: '2026-03-06T11:53:37.113Z'
+      lastVerified: '2026-03-11T02:00:27.511Z'
     init-project-status:
       path: .aiox-core/development/tasks/init-project-status.md
       layer: L2
@@ -2595,7 +2595,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0c2f801d30da8f926542e8d29507886cb79ec324e717c75607b9fbb5555dc16b
-      lastVerified: '2026-03-06T11:53:37.114Z'
+      lastVerified: '2026-03-11T02:00:27.512Z'
     integrate-squad:
       path: .aiox-core/development/tasks/integrate-squad.md
       layer: L2
@@ -2617,7 +2617,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c1dbded4048033ea0a5f10c8bb53e045e14930d8442a1bf35c67bb16c0c8939a
-      lastVerified: '2026-03-06T11:53:37.147Z'
+      lastVerified: '2026-03-11T02:00:27.512Z'
     kb-mode-interaction:
       path: .aiox-core/development/tasks/kb-mode-interaction.md
       layer: L2
@@ -2647,7 +2647,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73ef3d164b2576f80f37bfc5bc6ea2276a59778f9bcc41a77fd288fab7f2e61f
-      lastVerified: '2026-03-06T11:53:37.147Z'
+      lastVerified: '2026-03-11T02:00:27.512Z'
     learn-patterns:
       path: .aiox-core/development/tasks/learn-patterns.md
       layer: L2
@@ -2673,7 +2673,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0042edaa7d638aa4e476607d026a406411a6b9177f3a29a25d78773ee27e9c0f
-      lastVerified: '2026-03-06T11:53:37.149Z'
+      lastVerified: '2026-03-11T02:00:27.513Z'
     list-mcps:
       path: .aiox-core/development/tasks/list-mcps.md
       layer: L2
@@ -2694,7 +2694,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c2eca1a9c8d0be7c83a3e2eea59b33155bf7955f534eb0b36b27ed3852ea7dd1
-      lastVerified: '2026-03-06T11:53:37.149Z'
+      lastVerified: '2026-03-11T02:00:27.513Z'
     list-worktrees:
       path: .aiox-core/development/tasks/list-worktrees.md
       layer: L2
@@ -2723,7 +2723,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a29055766b289c22597532b5623e6e56dbbf6ca8d59193da6e6a0159213cb00b
-      lastVerified: '2026-03-06T11:53:37.150Z'
+      lastVerified: '2026-03-11T02:00:27.513Z'
     mcp-workflow:
       path: .aiox-core/development/tasks/mcp-workflow.md
       layer: L2
@@ -2745,7 +2745,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c09227efc590cc68ae9d32fe010de2dd8db621a2102b36d92a6fbb30f8f27cf
-      lastVerified: '2026-03-06T11:53:37.151Z'
+      lastVerified: '2026-03-11T02:00:27.513Z'
     merge-worktree:
       path: .aiox-core/development/tasks/merge-worktree.md
       layer: L2
@@ -2767,7 +2767,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e33a96e1961bbaba60f2258f4a98b8c9d384754a07eba705732f41d61ed2d4f4
-      lastVerified: '2026-03-06T11:53:37.151Z'
+      lastVerified: '2026-03-11T02:00:27.513Z'
     modify-agent:
       path: .aiox-core/development/tasks/modify-agent.md
       layer: L2
@@ -2795,7 +2795,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:74e6ef74967508f8a05cfc629bac7d5ffd5bd67c7d598cc623fd426442049824
-      lastVerified: '2026-03-06T11:53:37.151Z'
+      lastVerified: '2026-03-11T02:00:27.513Z'
     modify-task:
       path: .aiox-core/development/tasks/modify-task.md
       layer: L2
@@ -2821,7 +2821,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e81346cb686226a2bca0657e9c6367adcbf76d6cbd5d81cc892702c3a655d96a
-      lastVerified: '2026-03-06T11:53:37.152Z'
+      lastVerified: '2026-03-11T02:00:27.513Z'
     modify-workflow:
       path: .aiox-core/development/tasks/modify-workflow.md
       layer: L2
@@ -2848,7 +2848,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7cbfc3488912240b0782d116b27c5410d724c7822f94efe6cd64df954c3b4b50
-      lastVerified: '2026-03-06T11:53:37.167Z'
+      lastVerified: '2026-03-11T02:00:27.514Z'
     next:
       path: .aiox-core/development/tasks/next.md
       layer: L2
@@ -2874,7 +2874,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f3f685218c1df95ef399a9ba3c8ea7c29607e591acc2a7fbc2847a2883f08e02
-      lastVerified: '2026-03-06T11:53:37.168Z'
+      lastVerified: '2026-03-11T02:00:27.514Z'
     orchestrate-resume:
       path: .aiox-core/development/tasks/orchestrate-resume.md
       layer: L2
@@ -2895,7 +2895,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c15ca8e699269246cc48a581ca6a956acf6ba9b717024274836d6447cfbccc76
-      lastVerified: '2026-03-06T11:53:37.168Z'
+      lastVerified: '2026-03-11T02:00:27.514Z'
     orchestrate-status:
       path: .aiox-core/development/tasks/orchestrate-status.md
       layer: L2
@@ -2916,7 +2916,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fe47c904e6329f758c001f6cc56383ea32059ce988c3d190e8d6ebcc42376ec9
-      lastVerified: '2026-03-06T11:53:37.168Z'
+      lastVerified: '2026-03-11T02:00:27.514Z'
     orchestrate-stop:
       path: .aiox-core/development/tasks/orchestrate-stop.md
       layer: L2
@@ -2937,7 +2937,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:87f82b66a711ed468ea2f97ce5201469c2990010fed95ddbd975bb8ab49a3547
-      lastVerified: '2026-03-06T11:53:37.169Z'
+      lastVerified: '2026-03-11T02:00:27.514Z'
     orchestrate:
       path: .aiox-core/development/tasks/orchestrate.md
       layer: L2
@@ -2957,7 +2957,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ca30ad1efa28ea5c7eeebd07f944fa0202ab9522ae6c32c8a19ca9ff2d30a8ce
-      lastVerified: '2026-03-06T11:53:37.169Z'
+      lastVerified: '2026-03-11T02:00:27.514Z'
     patterns:
       path: .aiox-core/development/tasks/patterns.md
       layer: L2
@@ -2981,7 +2981,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:99dc215422f88e1dafa138e577c2c96bc65cf9657ca99b9ca00e72b3d17ec843
-      lastVerified: '2026-03-06T11:53:37.169Z'
+      lastVerified: '2026-03-11T02:00:27.514Z'
     plan-create-context:
       path: .aiox-core/development/tasks/plan-create-context.md
       layer: L2
@@ -3012,7 +3012,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2374473d1984288dc37c80c298fc564facadf0b8b886b8a98520c8b39c9bc82a
-      lastVerified: '2026-03-06T11:53:37.170Z'
+      lastVerified: '2026-03-11T02:00:27.514Z'
     plan-create-implementation:
       path: .aiox-core/development/tasks/plan-create-implementation.md
       layer: L2
@@ -3041,7 +3041,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3c186ead114afe21638b933d2e312538ed3a7bb9ee3dfee0ee0dc86fcc0025cc
-      lastVerified: '2026-03-06T11:53:37.171Z'
+      lastVerified: '2026-03-11T02:00:27.515Z'
     plan-execute-subtask:
       path: .aiox-core/development/tasks/plan-execute-subtask.md
       layer: L2
@@ -3072,7 +3072,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a6c9c283579d0b5d3f337816ed192f4dda99c3634ac55da98fa0c0d332e4d963
-      lastVerified: '2026-03-06T11:53:37.171Z'
+      lastVerified: '2026-03-11T02:00:27.515Z'
     po-backlog-add:
       path: .aiox-core/development/tasks/po-backlog-add.md
       layer: L2
@@ -3099,7 +3099,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6f553ba9bf2638c183c4a59caa56d73baa641263080125ed0f9d87a18e9f376f
-      lastVerified: '2026-03-06T11:53:37.172Z'
+      lastVerified: '2026-03-11T02:00:27.515Z'
     po-close-story:
       path: .aiox-core/development/tasks/po-close-story.md
       layer: L2
@@ -3125,7 +3125,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:df93883e8af967351586dff250f79748008f6dc2ac15b78ac85715023a8d3ba4
-      lastVerified: '2026-03-06T11:53:37.172Z'
+      lastVerified: '2026-03-11T02:00:27.515Z'
     po-manage-story-backlog:
       path: .aiox-core/development/tasks/po-manage-story-backlog.md
       layer: L2
@@ -3153,7 +3153,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ed619e87c9753428eaea969d05d046b7f26af4f825d792ffcf026dc4f475b6e5
-      lastVerified: '2026-03-06T11:53:37.172Z'
+      lastVerified: '2026-03-11T02:00:27.516Z'
     po-pull-story-from-clickup:
       path: .aiox-core/development/tasks/po-pull-story-from-clickup.md
       layer: L2
@@ -3184,7 +3184,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:27fa2887a3da901319bafd7bd714c0abb31c638554aecaf924d412d25a7072bc
-      lastVerified: '2026-03-06T11:53:37.173Z'
+      lastVerified: '2026-03-11T02:00:27.516Z'
     po-pull-story:
       path: .aiox-core/development/tasks/po-pull-story.md
       layer: L2
@@ -3211,7 +3211,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d6f23501d4f35011fddf5242ed739208e9ec4d767210cd961e6d48373f33a2a3
-      lastVerified: '2026-03-06T11:53:37.173Z'
+      lastVerified: '2026-03-11T02:00:27.516Z'
     po-stories-index:
       path: .aiox-core/development/tasks/po-stories-index.md
       layer: L2
@@ -3239,7 +3239,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9e078929826bdec66e9cddbc9f0883568d32cc130e119e3a1da3345b54121dd3
-      lastVerified: '2026-03-06T11:53:37.174Z'
+      lastVerified: '2026-03-11T02:00:27.516Z'
     po-sync-story-to-clickup:
       path: .aiox-core/development/tasks/po-sync-story-to-clickup.md
       layer: L2
@@ -3270,7 +3270,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:03f25fea39d33c6f4febd1dfd467b643bef5cd3d89ceb4766282c173ce810698
-      lastVerified: '2026-03-06T11:53:37.174Z'
+      lastVerified: '2026-03-11T02:00:27.516Z'
     po-sync-story:
       path: .aiox-core/development/tasks/po-sync-story.md
       layer: L2
@@ -3299,7 +3299,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:67c5e1b02c0d499f12c6727d88a18407f926f440741fb5f8f6e2afa937adec2e
-      lastVerified: '2026-03-06T11:53:37.174Z'
+      lastVerified: '2026-03-11T02:00:27.516Z'
     pr-automation:
       path: .aiox-core/development/tasks/pr-automation.md
       layer: L2
@@ -3329,7 +3329,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:90bba47136ccc37c74454a4537728b958955fd487e46e3b8dca869b994c8d1c1
-      lastVerified: '2026-03-06T11:53:37.187Z'
+      lastVerified: '2026-03-11T02:00:27.516Z'
     propose-modification:
       path: .aiox-core/development/tasks/propose-modification.md
       layer: L2
@@ -3359,7 +3359,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa340dc0749f40ba7f1ed12ebe107c53f212f764cf7318ee7a816d059528f69e
-      lastVerified: '2026-03-06T11:53:37.188Z'
+      lastVerified: '2026-03-11T02:00:27.517Z'
     publish-npm:
       path: .aiox-core/development/tasks/publish-npm.md
       layer: L2
@@ -3385,7 +3385,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d69f833690fd01256c9b99cc7bd7bb67704f5894ffa9171af7cb94253ecd98cd
-      lastVerified: '2026-03-06T11:53:37.200Z'
+      lastVerified: '2026-03-11T02:00:27.517Z'
     qa-after-creation:
       path: .aiox-core/development/tasks/qa-after-creation.md
       layer: L2
@@ -3406,7 +3406,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e9f6ceff7a0bc00d4fc035e890b7f1178c6ea43f447d135774b46a00713450e6
-      lastVerified: '2026-03-06T11:53:37.201Z'
+      lastVerified: '2026-03-11T02:00:27.517Z'
     qa-backlog-add-followup:
       path: .aiox-core/development/tasks/qa-backlog-add-followup.md
       layer: L2
@@ -3436,7 +3436,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:167e6f253eaf69e5751c294eec6a677153996b148ce70ba242506c2812f41535
-      lastVerified: '2026-03-06T11:53:37.201Z'
+      lastVerified: '2026-03-11T02:00:27.517Z'
     qa-browser-console-check:
       path: .aiox-core/development/tasks/qa-browser-console-check.md
       layer: L2
@@ -3459,7 +3459,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:deddbb5aed026e5b8b4d100a84baea6f4f85b3a249e56033f6e35e7ac08e2f80
-      lastVerified: '2026-03-06T11:53:37.201Z'
+      lastVerified: '2026-03-11T02:00:27.517Z'
     qa-create-fix-request:
       path: .aiox-core/development/tasks/qa-create-fix-request.md
       layer: L2
@@ -3488,7 +3488,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:709ed6f4c0260bf95e9801e22ef75f2b02958f967aaf6b1b6ffc4b7ee34b3e03
-      lastVerified: '2026-03-06T11:53:37.202Z'
+      lastVerified: '2026-03-11T02:00:27.517Z'
     qa-evidence-requirements:
       path: .aiox-core/development/tasks/qa-evidence-requirements.md
       layer: L2
@@ -3511,7 +3511,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cfa30b79bf1eac27511c94de213dbae761f3fb5544da07cc38563bcbd9187569
-      lastVerified: '2026-03-06T11:53:37.204Z'
+      lastVerified: '2026-03-11T02:00:27.517Z'
     qa-false-positive-detection:
       path: .aiox-core/development/tasks/qa-false-positive-detection.md
       layer: L2
@@ -3535,7 +3535,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f1a816365c588e7521617fc3aa7435e6f08d1ed06f4f51cce86f9529901d86ce
-      lastVerified: '2026-03-06T11:53:37.205Z'
+      lastVerified: '2026-03-11T02:00:27.517Z'
     qa-fix-issues:
       path: .aiox-core/development/tasks/qa-fix-issues.md
       layer: L2
@@ -3565,7 +3565,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b5db49f2709dbe27bb50d68f46f48b2d1c9a6b176a6025158d8f299e552eb2c3
-      lastVerified: '2026-03-06T11:53:37.205Z'
+      lastVerified: '2026-03-11T02:00:27.518Z'
     qa-gate:
       path: .aiox-core/development/tasks/qa-gate.md
       layer: L2
@@ -3595,7 +3595,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:25fc098d7c71554836925632c4a3f99aff9ade392e1ab1c669ae0983f49c6070
-      lastVerified: '2026-03-06T11:53:37.206Z'
+      lastVerified: '2026-03-11T02:00:27.518Z'
     qa-generate-tests:
       path: .aiox-core/development/tasks/qa-generate-tests.md
       layer: L2
@@ -3630,7 +3630,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:245885950328b086ffbe9320bba2e814b3f6b5e3e5342bac904ccd814d4e8519
-      lastVerified: '2026-03-06T11:53:37.207Z'
+      lastVerified: '2026-03-11T02:00:27.518Z'
     qa-library-validation:
       path: .aiox-core/development/tasks/qa-library-validation.md
       layer: L2
@@ -3653,7 +3653,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:366df913fe32f08ec4bf883c4b6f9781af22cc4bfa23ce25cfdbe56f562b013e
-      lastVerified: '2026-03-06T11:53:37.208Z'
+      lastVerified: '2026-03-11T02:00:27.518Z'
     qa-migration-validation:
       path: .aiox-core/development/tasks/qa-migration-validation.md
       layer: L2
@@ -3675,7 +3675,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2f855a1b918066755b8b16d0db7c347b32df372996217542905713459eb29bc4
-      lastVerified: '2026-03-06T11:53:37.208Z'
+      lastVerified: '2026-03-11T02:00:27.518Z'
     qa-nfr-assess:
       path: .aiox-core/development/tasks/qa-nfr-assess.md
       layer: L2
@@ -3700,7 +3700,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f2816ad58335c6d3b68bfc18d95f58b75358f8cb2cab844c7712ef36635a5e37
-      lastVerified: '2026-03-06T11:53:37.208Z'
+      lastVerified: '2026-03-11T02:00:27.519Z'
     qa-review-build:
       path: .aiox-core/development/tasks/qa-review-build.md
       layer: L2
@@ -3730,7 +3730,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9fcc1fd52b5cd18cf0039478c817e17aacf93e09f3e06de4ed308dc36075b5d5
-      lastVerified: '2026-03-06T11:53:37.209Z'
+      lastVerified: '2026-03-11T02:00:27.519Z'
     qa-review-proposal:
       path: .aiox-core/development/tasks/qa-review-proposal.md
       layer: L2
@@ -3761,7 +3761,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:928c0c1929f9935966ba24c27e590ae98b402095f3f54de6aa209d0e5ec9220c
-      lastVerified: '2026-03-06T11:53:37.209Z'
+      lastVerified: '2026-03-11T02:00:27.519Z'
     qa-review-story:
       path: .aiox-core/development/tasks/qa-review-story.md
       layer: L2
@@ -3791,7 +3791,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cc3e189824c656ff6ed2db04bd0a2a03d6293bccbec7e9b7a321daf64b9f1563
-      lastVerified: '2026-03-06T11:53:37.210Z'
+      lastVerified: '2026-03-11T02:00:27.519Z'
     qa-risk-profile:
       path: .aiox-core/development/tasks/qa-risk-profile.md
       layer: L2
@@ -3818,7 +3818,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:69b2b6edb38330234766bef8ed3c27469843e88fb30e130837922541c717432d
-      lastVerified: '2026-03-06T11:53:37.210Z'
+      lastVerified: '2026-03-11T02:00:27.520Z'
     qa-run-tests:
       path: .aiox-core/development/tasks/qa-run-tests.md
       layer: L2
@@ -3846,7 +3846,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f40850e70ffea9aecfb266e784575e0aa0483ea390ab8aae59df3829fd5fa6d8
-      lastVerified: '2026-03-06T11:53:37.211Z'
+      lastVerified: '2026-03-11T02:00:27.520Z'
     qa-security-checklist:
       path: .aiox-core/development/tasks/qa-security-checklist.md
       layer: L2
@@ -3868,7 +3868,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e155fba83e78f55830558def7ffe03b23c65dd6c2bbe63733b3966d1df6946ab
-      lastVerified: '2026-03-06T11:53:37.212Z'
+      lastVerified: '2026-03-11T02:00:27.520Z'
     qa-test-design:
       path: .aiox-core/development/tasks/qa-test-design.md
       layer: L2
@@ -3895,7 +3895,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:00e2aac4ec1587949b4bbdbd52f84adb8dc10a06395e9f68cc339c4a6fdb7405
-      lastVerified: '2026-03-06T11:53:37.212Z'
+      lastVerified: '2026-03-11T02:00:27.520Z'
     qa-trace-requirements:
       path: .aiox-core/development/tasks/qa-trace-requirements.md
       layer: L2
@@ -3922,7 +3922,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5c4a95d42d33b16ab77606d7a2dd5b18bb78f81f3872150454f10950bc0ee047
-      lastVerified: '2026-03-06T11:53:37.213Z'
+      lastVerified: '2026-03-11T02:00:27.520Z'
     release-management:
       path: .aiox-core/development/tasks/release-management.md
       layer: L2
@@ -3951,7 +3951,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:80a9a1ead93c66bfe59cb75215661052e7b4abccc483cd9d01a07034fca2311c
-      lastVerified: '2026-03-06T11:53:37.214Z'
+      lastVerified: '2026-03-11T02:00:27.521Z'
     remove-mcp:
       path: .aiox-core/development/tasks/remove-mcp.md
       layer: L2
@@ -3972,7 +3972,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3f4bf3f8d4d651109dc783e95598ab21569447295f22a7b868d3973f0848aa4c
-      lastVerified: '2026-03-06T11:53:37.214Z'
+      lastVerified: '2026-03-11T02:00:27.521Z'
     remove-worktree:
       path: .aiox-core/development/tasks/remove-worktree.md
       layer: L2
@@ -4001,7 +4001,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0ac9497e0a85e16f9e0a5357da43ae8571d1bf2ba98028f9968d2656df3ee36f
-      lastVerified: '2026-03-06T11:53:37.214Z'
+      lastVerified: '2026-03-11T02:00:27.521Z'
     resolve-github-issue:
       path: .aiox-core/development/tasks/resolve-github-issue.md
       layer: L2
@@ -4028,7 +4028,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d1e8f775eee3367f0a553f3e767477bad1833e72a731a2df94cde56d5b5eda97
-      lastVerified: '2026-03-06T11:53:37.215Z'
+      lastVerified: '2026-03-11T02:00:27.521Z'
     review-contributor-pr:
       path: .aiox-core/development/tasks/review-contributor-pr.md
       layer: L2
@@ -4050,7 +4050,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dfb5f03fae16171777742b06a9e54ee25711d1d94cedc2152ef9c9331310b608
-      lastVerified: '2026-03-06T11:53:37.215Z'
+      lastVerified: '2026-03-11T02:00:27.521Z'
     run-design-system-pipeline:
       path: .aiox-core/development/tasks/run-design-system-pipeline.md
       layer: L2
@@ -4076,7 +4076,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ff4c225b922da347b63aeb6d8aa95484c1c9281eb1e4b4c4ab0ecef0a1a54c26
-      lastVerified: '2026-03-06T11:53:37.215Z'
+      lastVerified: '2026-03-11T02:00:27.521Z'
     run-workflow-engine:
       path: .aiox-core/development/tasks/run-workflow-engine.md
       layer: L2
@@ -4105,7 +4105,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:885b63bbfb3506740398768bc4979947acfc4063c5638d89566f6e6da74aaabb
-      lastVerified: '2026-03-06T11:53:37.216Z'
+      lastVerified: '2026-03-11T02:00:27.522Z'
     run-workflow:
       path: .aiox-core/development/tasks/run-workflow.md
       layer: L2
@@ -4131,7 +4131,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:01a7addd0554399249541012f93f3ab2dd46e69336ba4f96737bc4e271b22b4b
-      lastVerified: '2026-03-06T11:53:37.216Z'
+      lastVerified: '2026-03-11T02:00:27.522Z'
     search-mcp:
       path: .aiox-core/development/tasks/search-mcp.md
       layer: L2
@@ -4153,7 +4153,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c7d9239c740b250baf9d82a5aa3baf1cd0bb8c671f0889c9a6fc6c0a668ac9c
-      lastVerified: '2026-03-06T11:53:37.216Z'
+      lastVerified: '2026-03-11T02:00:27.522Z'
     security-audit:
       path: .aiox-core/development/tasks/security-audit.md
       layer: L2
@@ -4175,7 +4175,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8ae6068628080d67c4c981d0c6e87d6347ddcc2e363d985ef578de22e94d6ae1
-      lastVerified: '2026-03-06T11:53:37.217Z'
+      lastVerified: '2026-03-11T02:00:27.522Z'
     security-scan:
       path: .aiox-core/development/tasks/security-scan.md
       layer: L2
@@ -4198,7 +4198,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2232ced35524452c49197fb4c09099dfc61c4980f31a8cd7fda3cc1b152068ca
-      lastVerified: '2026-03-06T11:53:37.217Z'
+      lastVerified: '2026-03-11T02:00:27.522Z'
     session-resume:
       path: .aiox-core/development/tasks/session-resume.md
       layer: L2
@@ -4221,7 +4221,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0130ea9c24b5c74a7803985f485663dd373edd366c8cbaa5d0143119a4e3cc3e
-      lastVerified: '2026-03-06T11:53:37.217Z'
+      lastVerified: '2026-03-11T02:00:27.522Z'
     setup-database:
       path: .aiox-core/development/tasks/setup-database.md
       layer: L2
@@ -4245,7 +4245,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3240013a44d42143a63280f0a1d6a8756a2572027e39b6fe913c1ed956442a38
-      lastVerified: '2026-03-06T11:53:37.218Z'
+      lastVerified: '2026-03-11T02:00:27.523Z'
     setup-design-system:
       path: .aiox-core/development/tasks/setup-design-system.md
       layer: L2
@@ -4270,7 +4270,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9cb43d28c66a6b7a8d36a16fc0256ea25c9bb49e214e37bce42cae4908450677
-      lastVerified: '2026-03-06T11:53:37.218Z'
+      lastVerified: '2026-03-11T02:00:27.523Z'
     setup-github:
       path: .aiox-core/development/tasks/setup-github.md
       layer: L2
@@ -4297,7 +4297,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:515cc5f26383c6fde61e38acb4678ead15d701ddc32c668a9b9bcfc9a02f2850
-      lastVerified: '2026-03-06T11:53:37.219Z'
+      lastVerified: '2026-03-11T02:00:27.523Z'
     setup-llm-routing:
       path: .aiox-core/development/tasks/setup-llm-routing.md
       layer: L2
@@ -4323,7 +4323,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:97334fdf1e679d9bd1deecf048f54760c3efdebf38af4daafe82094323f05865
-      lastVerified: '2026-03-06T11:53:37.219Z'
+      lastVerified: '2026-03-11T02:00:27.523Z'
     setup-mcp-docker:
       path: .aiox-core/development/tasks/setup-mcp-docker.md
       layer: L2
@@ -4349,7 +4349,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b65a663641b6667ac46848eab02ecb75da28e09e2cfa4d7d12f979c423eef999
-      lastVerified: '2026-03-06T11:53:37.220Z'
+      lastVerified: '2026-03-11T02:00:27.524Z'
     setup-project-docs:
       path: .aiox-core/development/tasks/setup-project-docs.md
       layer: L2
@@ -4381,7 +4381,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5e2969779d62d05a26fb49d5959d25224de748d2c70aaa72b6f219fb149decee
-      lastVerified: '2026-03-06T11:53:37.220Z'
+      lastVerified: '2026-03-11T02:00:27.524Z'
     shard-doc:
       path: .aiox-core/development/tasks/shard-doc.md
       layer: L2
@@ -4414,7 +4414,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:614fb73a40c4569d30e42a6a5536fbb374f2174bd709a73ad1026df595f50f52
-      lastVerified: '2026-03-06T11:53:37.220Z'
+      lastVerified: '2026-03-11T02:00:27.525Z'
     sm-create-next-story:
       path: .aiox-core/development/tasks/sm-create-next-story.md
       layer: L2
@@ -4452,7 +4452,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:86ee70cbe6ac6812dd9bbacc6e591046a9def3455efba19581155258173f91ba
-      lastVerified: '2026-03-06T11:53:37.221Z'
+      lastVerified: '2026-03-11T02:00:27.525Z'
     spec-assess-complexity:
       path: .aiox-core/development/tasks/spec-assess-complexity.md
       layer: L2
@@ -4478,7 +4478,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:860d6c4641282a426840ccea8bed766c8eddeb9806e4e0a806a330f70e5b6eca
-      lastVerified: '2026-03-06T11:53:37.222Z'
+      lastVerified: '2026-03-11T02:00:27.525Z'
     spec-critique:
       path: .aiox-core/development/tasks/spec-critique.md
       layer: L2
@@ -4507,7 +4507,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d2c3615b84dff942bb1c36fe1d89d025a5c52eedf15a382e75bba6cee085e7dd
-      lastVerified: '2026-03-06T11:53:37.222Z'
+      lastVerified: '2026-03-11T02:00:27.525Z'
     spec-gather-requirements:
       path: .aiox-core/development/tasks/spec-gather-requirements.md
       layer: L2
@@ -4534,7 +4534,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b2ae9cd6da1233bd610a0a8023dcf1dfece81ab75a1cb6da6b9016e0351a7d40
-      lastVerified: '2026-03-06T11:53:37.223Z'
+      lastVerified: '2026-03-11T02:00:27.526Z'
     spec-research-dependencies:
       path: .aiox-core/development/tasks/spec-research-dependencies.md
       layer: L2
@@ -4561,7 +4561,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c13f6fed7af8e1f8e20295e697637fc6831e559ba9d67d7649786626f2619a43
-      lastVerified: '2026-03-06T11:53:37.223Z'
+      lastVerified: '2026-03-11T02:00:27.526Z'
     spec-write-spec:
       path: .aiox-core/development/tasks/spec-write-spec.md
       layer: L2
@@ -4593,7 +4593,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1ecef348cf83403243398c362629e016ff299b4e0634d7a0581b39d779a113bf
-      lastVerified: '2026-03-06T11:53:37.224Z'
+      lastVerified: '2026-03-11T02:00:27.526Z'
     squad-creator-analyze:
       path: .aiox-core/development/tasks/squad-creator-analyze.md
       layer: L2
@@ -4620,7 +4620,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8aeeae86b0afd75c4f79e8a5f1cca02b3633c9d925ee39725a66795befecc8a8
-      lastVerified: '2026-03-06T11:53:37.224Z'
+      lastVerified: '2026-03-11T02:00:27.526Z'
     squad-creator-create:
       path: .aiox-core/development/tasks/squad-creator-create.md
       layer: L2
@@ -4648,7 +4648,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e4a8b8799837fb0ea60eb9baf3bbe57a27f1c1c7dd67ec8fd0c9d5d8a17bbce2
-      lastVerified: '2026-03-06T11:53:37.226Z'
+      lastVerified: '2026-03-11T02:00:27.526Z'
     squad-creator-design:
       path: .aiox-core/development/tasks/squad-creator-design.md
       layer: L2
@@ -4673,7 +4673,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b5851f22a2466107bf506707a01be7ff857b27b19d5d4ec4c5d0506cb6719e80
-      lastVerified: '2026-03-06T11:53:37.226Z'
+      lastVerified: '2026-03-11T02:00:27.526Z'
     squad-creator-download:
       path: .aiox-core/development/tasks/squad-creator-download.md
       layer: L2
@@ -4695,7 +4695,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5d75af6d41624a4c40d6734031ebc2a8f7eb4eb3ec22f10de32c92d600ddf332
-      lastVerified: '2026-03-06T11:53:37.227Z'
+      lastVerified: '2026-03-11T02:00:27.526Z'
     squad-creator-extend:
       path: .aiox-core/development/tasks/squad-creator-extend.md
       layer: L2
@@ -4724,7 +4724,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2d4a0bbe65d21aea5869b8df3a1e1d81a67e027402c4270b8dd1cc8b7c595573
-      lastVerified: '2026-03-06T11:53:37.227Z'
+      lastVerified: '2026-03-11T02:00:27.527Z'
     squad-creator-list:
       path: .aiox-core/development/tasks/squad-creator-list.md
       layer: L2
@@ -4748,7 +4748,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6bc04c23b31daa2f4e8448a5c28540ed8c35903c1b2c77e3ce7b0986268c8710
-      lastVerified: '2026-03-06T11:53:37.227Z'
+      lastVerified: '2026-03-11T02:00:27.527Z'
     squad-creator-migrate:
       path: .aiox-core/development/tasks/squad-creator-migrate.md
       layer: L2
@@ -4774,7 +4774,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:69a15d3db12cc1268740378fcd411a0a011c3f441e3eea6feaaf0b95f4bf8c1e
-      lastVerified: '2026-03-06T11:53:37.227Z'
+      lastVerified: '2026-03-11T02:00:27.527Z'
     squad-creator-publish:
       path: .aiox-core/development/tasks/squad-creator-publish.md
       layer: L2
@@ -4796,7 +4796,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9f744f0c1e70e18945bfdc22ea48a103862cdb7fffcbc36ac61d44473248b124
-      lastVerified: '2026-03-06T11:53:37.228Z'
+      lastVerified: '2026-03-11T02:00:27.527Z'
     squad-creator-sync-ide-command:
       path: .aiox-core/development/tasks/squad-creator-sync-ide-command.md
       layer: L2
@@ -4819,7 +4819,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4221574f07adb5fb53c7c0c9f85656222a97e623b5e4072cee37e34b82f3f379
-      lastVerified: '2026-03-06T11:53:37.228Z'
+      lastVerified: '2026-03-11T02:00:27.527Z'
     squad-creator-sync-synkra:
       path: .aiox-core/development/tasks/squad-creator-sync-synkra.md
       layer: L2
@@ -4842,7 +4842,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dd03f844de8aa1f1caac31b7791ae96b4a221a650728fb13ff6a6245f2e5f75a
-      lastVerified: '2026-03-06T11:53:37.228Z'
+      lastVerified: '2026-03-11T02:00:27.527Z'
     squad-creator-validate:
       path: .aiox-core/development/tasks/squad-creator-validate.md
       layer: L2
@@ -4868,7 +4868,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:782cc7e67b8d061475d94eff8312d5ec23d3ea84630797d9190384d3b3fafd8e
-      lastVerified: '2026-03-06T11:53:37.228Z'
+      lastVerified: '2026-03-11T02:00:27.528Z'
     story-checkpoint:
       path: .aiox-core/development/tasks/story-checkpoint.md
       layer: L2
@@ -4894,7 +4894,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:467fabe8b0c0c7fcd1bd122fdbdc883992a54656c6774c8cea2963789873ee4a
-      lastVerified: '2026-03-06T11:53:37.228Z'
+      lastVerified: '2026-03-11T02:00:27.528Z'
     sync-documentation:
       path: .aiox-core/development/tasks/sync-documentation.md
       layer: L2
@@ -4918,7 +4918,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8be6c2123aa935ddab5e845375c28213f70476cc9dfb10fd0e444c6d40a7e4ae
-      lastVerified: '2026-03-06T11:53:37.229Z'
+      lastVerified: '2026-03-11T02:00:27.528Z'
     sync-registry-intel:
       path: .aiox-core/development/tasks/sync-registry-intel.md
       layer: L2
@@ -4942,7 +4942,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:908df7d093442ccfd15805dabbd9f16e1f34b92ddb692f408a77484bb3d69a53
-      lastVerified: '2026-03-06T11:53:37.229Z'
+      lastVerified: '2026-03-11T02:00:27.528Z'
     tailwind-upgrade:
       path: .aiox-core/development/tasks/tailwind-upgrade.md
       layer: L2
@@ -4967,7 +4967,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa0bea0fc5513e13782bbb0bdb0564f15d7cc2d30b7954f26e52c980767d4469
-      lastVerified: '2026-03-06T11:53:37.229Z'
+      lastVerified: '2026-03-11T02:00:27.528Z'
     test-as-user:
       path: .aiox-core/development/tasks/test-as-user.md
       layer: L2
@@ -4994,7 +4994,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9117f1cf85c63be672b0e0f7207274ad73f384cf0299f5c32f9c2f7ad092a701
-      lastVerified: '2026-03-06T11:53:37.230Z'
+      lastVerified: '2026-03-11T02:00:27.528Z'
     test-validation-task:
       path: .aiox-core/development/tasks/test-validation-task.md
       layer: L2
@@ -5016,7 +5016,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2868bd169192b345cba423f2134d46a0d0337f9fe7135476b593e8e9b81617db
-      lastVerified: '2026-03-06T11:53:37.230Z'
+      lastVerified: '2026-03-11T02:00:27.528Z'
     triage-github-issues:
       path: .aiox-core/development/tasks/triage-github-issues.md
       layer: L2
@@ -5041,7 +5041,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73e1e42f0998a701f8855de6e8666150a284e44efd41878927defa17eded4cfe
-      lastVerified: '2026-03-06T11:53:37.230Z'
+      lastVerified: '2026-03-11T02:00:27.528Z'
     undo-last:
       path: .aiox-core/development/tasks/undo-last.md
       layer: L2
@@ -5068,7 +5068,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c038fd862dadcf7a4ad62e347ffa66e6335bc9bbd63d2e675a810381fb257f8a
-      lastVerified: '2026-03-06T11:53:37.230Z'
+      lastVerified: '2026-03-11T02:00:27.529Z'
     update-aiox:
       path: .aiox-core/development/tasks/update-aiox.md
       layer: L2
@@ -5092,7 +5092,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a88b1f79f52aad5aaaf2c7d385314718fd5f09316f37b65553b838b2cb445f95
-      lastVerified: '2026-03-06T11:53:37.230Z'
+      lastVerified: '2026-03-11T02:00:27.529Z'
     update-manifest:
       path: .aiox-core/development/tasks/update-manifest.md
       layer: L2
@@ -5118,7 +5118,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0ef0a5ed8638d1fa00317796acbd8419ca1bbbfa0c5e42109dda3d82300d8c12
-      lastVerified: '2026-03-06T11:53:37.232Z'
+      lastVerified: '2026-03-11T02:00:27.529Z'
     update-source-tree:
       path: .aiox-core/development/tasks/update-source-tree.md
       layer: L2
@@ -5142,7 +5142,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1d7eb7cbc8fa582375edc0275e98415f110e0507cb77744954fa342592ac1c56
-      lastVerified: '2026-03-06T11:53:37.233Z'
+      lastVerified: '2026-03-11T02:00:27.529Z'
     ux-create-wireframe:
       path: .aiox-core/development/tasks/ux-create-wireframe.md
       layer: L2
@@ -5167,7 +5167,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d3fe6c03050d98d0a46024c6c6aae32d4fb5e6d7b4a06b01401c54b0853469ce
-      lastVerified: '2026-03-06T11:53:37.233Z'
+      lastVerified: '2026-03-11T02:00:27.529Z'
     ux-ds-scan-artifact:
       path: .aiox-core/development/tasks/ux-ds-scan-artifact.md
       layer: L2
@@ -5195,7 +5195,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5a6eb9d40350c3cc15099f8f42beb8a15d64021916e4ec2e82142b33cecb1635
-      lastVerified: '2026-03-06T11:53:37.234Z'
+      lastVerified: '2026-03-11T02:00:27.529Z'
     ux-user-research:
       path: .aiox-core/development/tasks/ux-user-research.md
       layer: L2
@@ -5221,7 +5221,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0c497783693c6b49d71a99c136f3c016f94afe1fd7556eb6c050aa05a60adade
-      lastVerified: '2026-03-06T11:53:37.234Z'
+      lastVerified: '2026-03-11T02:00:27.529Z'
     validate-agents:
       path: .aiox-core/development/tasks/validate-agents.md
       layer: L2
@@ -5241,7 +5241,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b278ba27cf8171d143aba30bd2f708b9226526dae70e9b881f52b5e1e908525f
-      lastVerified: '2026-03-06T11:53:37.234Z'
+      lastVerified: '2026-03-11T02:00:27.529Z'
     validate-next-story:
       path: .aiox-core/development/tasks/validate-next-story.md
       layer: L2
@@ -5279,7 +5279,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a7e0dbd89753d72248a6171d6bd4aa88d97e9c5051a5889d566c509d048d113c
-      lastVerified: '2026-03-06T11:53:37.235Z'
+      lastVerified: '2026-03-11T02:00:27.529Z'
     validate-tech-preset:
       path: .aiox-core/development/tasks/validate-tech-preset.md
       layer: L2
@@ -5302,7 +5302,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:50a65289c223c1a79b0bebe4120f3f703df45d42522309e658f6d0f5c9fdb54e
-      lastVerified: '2026-03-06T11:53:37.235Z'
+      lastVerified: '2026-03-11T02:00:27.530Z'
     validate-workflow:
       path: .aiox-core/development/tasks/validate-workflow.md
       layer: L2
@@ -5326,8 +5326,8 @@ entities:
         score: 0.8
         constraints: []
         extensionPoints: []
-      checksum: sha256:97d591c9ce8a932e7fa21206b58448c85c5340e254460d221e6b3bd0b5278565
-      lastVerified: '2026-03-06T11:53:37.235Z'
+      checksum: sha256:e01147feb106d803a298447e5a4988d5310e65cd5b5e291f771923d457056008
+      lastVerified: '2026-03-11T02:00:27.530Z'
     verify-subtask:
       path: .aiox-core/development/tasks/verify-subtask.md
       layer: L2
@@ -5351,7 +5351,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4ad9d89256ed9c34f104ae951e7d3b3739f6c5611f22fcf98ab5b666b60cc39f
-      lastVerified: '2026-03-06T11:53:37.235Z'
+      lastVerified: '2026-03-11T02:00:27.530Z'
     waves:
       path: .aiox-core/development/tasks/waves.md
       layer: L2
@@ -5376,7 +5376,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f5bfc1c3d03bf9fbf7c7ac859dd5c388d327abc154f6c064e33dcbae3f94dbd9
-      lastVerified: '2026-03-06T11:53:37.236Z'
+      lastVerified: '2026-03-11T02:00:27.530Z'
     yolo-toggle:
       path: .aiox-core/development/tasks/yolo-toggle.md
       layer: L2
@@ -5399,7 +5399,30 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4fd6b6d8b2dc0130377ab66fcdf328e48df7701fb621cf919932245886642405
-      lastVerified: '2026-03-06T11:53:37.236Z'
+      lastVerified: '2026-03-11T02:00:27.530Z'
+    README:
+      path: .aiox-core/development/tasks/blocks/README.md
+      layer: L2
+      type: task
+      purpose: '{One-line description}'
+      keywords:
+        - readme
+        - aiox
+        - task
+        - blocks
+        - system
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps:
+        - block-loader
+      lifecycle: experimental
+      adaptability:
+        score: 0.8
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:484409d3b069c30a14ba28873388567f06d613e6feb9acb14537434d1db03446
+      lastVerified: '2026-03-11T02:00:27.530Z'
     agent-prompt-template:
       path: .aiox-core/development/tasks/blocks/agent-prompt-template.md
       layer: L2
@@ -5423,7 +5446,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7f61c142e66622159ed2ef119ed0abbc95ed514f21749a957f1aaa3babc57b36
-      lastVerified: '2026-03-06T11:53:37.236Z'
+      lastVerified: '2026-03-11T02:00:27.530Z'
     context-loading:
       path: .aiox-core/development/tasks/blocks/context-loading.md
       layer: L2
@@ -5446,7 +5469,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:281c958fa18a2a104c41a3b4b0d0338298034e4bf4e4f5b5085d10d8f603d797
-      lastVerified: '2026-03-06T11:53:37.236Z'
+      lastVerified: '2026-03-11T02:00:27.530Z'
     execution-pattern:
       path: .aiox-core/development/tasks/blocks/execution-pattern.md
       layer: L2
@@ -5468,7 +5491,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a29498d6f59be665a1fe494f3d2ce138da1b7f7eb62028f60acbe7a577bb2bd
-      lastVerified: '2026-03-06T11:53:37.237Z'
+      lastVerified: '2026-03-11T02:00:27.530Z'
     finalization:
       path: .aiox-core/development/tasks/blocks/finalization.md
       layer: L2
@@ -5489,30 +5512,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8414839ac579a6e25c8ad8cc3218bb5f216288ef30a0a995dde59d3d7dc9130e
-      lastVerified: '2026-03-06T11:53:37.237Z'
-    README:
-      path: .aiox-core/development/tasks/blocks/README.md
-      layer: L2
-      type: task
-      purpose: '{One-line description}'
-      keywords:
-        - readme
-        - aiox
-        - task
-        - blocks
-        - system
-      usedBy: []
-      dependencies: []
-      externalDeps: []
-      plannedDeps:
-        - block-loader
-      lifecycle: experimental
-      adaptability:
-        score: 0.8
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:484409d3b069c30a14ba28873388567f06d613e6feb9acb14537434d1db03446
-      lastVerified: '2026-03-06T11:53:37.237Z'
+      lastVerified: '2026-03-11T02:00:27.530Z'
   templates:
     activation-instructions-inline-greeting:
       path: .aiox-core/product/templates/activation-instructions-inline-greeting.yaml
@@ -5535,7 +5535,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d4d3dc2bf0c06c0094ab0e76029c0ad322222e3420240ac3abcac6c150a4ae01
-      lastVerified: '2026-03-06T11:53:37.242Z'
+      lastVerified: '2026-03-11T02:00:27.532Z'
     activation-instructions-template:
       path: .aiox-core/product/templates/activation-instructions-template.md
       layer: L2
@@ -5556,7 +5556,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b4df5343728e565d975c28cad8a1a9dac370d0cf827689ced1c553268dc265e7
-      lastVerified: '2026-03-06T11:53:37.242Z'
+      lastVerified: '2026-03-11T02:00:27.532Z'
     agent-template:
       path: .aiox-core/product/templates/agent-template.yaml
       layer: L2
@@ -5579,7 +5579,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:98676fcc493c0d5f09264dcc52fcc2cf1129f9a195824ecb4c2ec035c2515121
-      lastVerified: '2026-03-06T11:53:37.243Z'
+      lastVerified: '2026-03-11T02:00:27.532Z'
     aiox-ai-config:
       path: .aiox-core/product/templates/aiox-ai-config.yaml
       layer: L2
@@ -5601,7 +5601,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:58023a5108ee66b16f93c82ee8a7c0414852f7c887257a8ff9040f060b140746
-      lastVerified: '2026-03-06T11:53:37.243Z'
+      lastVerified: '2026-03-11T02:00:27.532Z'
     architecture-tmpl:
       path: .aiox-core/product/templates/architecture-tmpl.yaml
       layer: L2
@@ -5622,7 +5622,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9483f38486932842e1bc1a73c35b3f90fa2cd9c703c7d5effabea7dc8f76350a
-      lastVerified: '2026-03-06T11:53:37.244Z'
+      lastVerified: '2026-03-11T02:00:27.533Z'
     brainstorming-output-tmpl:
       path: .aiox-core/product/templates/brainstorming-output-tmpl.yaml
       layer: L2
@@ -5643,7 +5643,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:acd98caed4a32328afdf3f3f42554a4f45e507cc527e95593fb7e63ccb8e66a1
-      lastVerified: '2026-03-06T11:53:37.244Z'
+      lastVerified: '2026-03-11T02:00:27.533Z'
     brownfield-architecture-tmpl:
       path: .aiox-core/product/templates/brownfield-architecture-tmpl.yaml
       layer: L2
@@ -5665,12 +5665,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5d399d93a42b674758515e5cf70ffb21cd77befc9f54a8fe0b9dba0773bbbf66
-      lastVerified: '2026-03-06T11:53:37.245Z'
+      lastVerified: '2026-03-11T02:00:27.534Z'
     brownfield-prd-tmpl:
       path: .aiox-core/product/templates/brownfield-prd-tmpl.yaml
       layer: L2
       type: template
-      purpose: Entity at .aiox-core\product\templates\brownfield-prd-tmpl.yaml
+      purpose: Entity at .aiox-core/product/templates/brownfield-prd-tmpl.yaml
       keywords:
         - brownfield
         - prd
@@ -5687,7 +5687,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bc1852d15e3a383c7519e5976094de3055c494fdd467acd83137700c900c4c61
-      lastVerified: '2026-03-06T11:53:37.245Z'
+      lastVerified: '2026-03-11T02:00:27.534Z'
     brownfield-risk-report-tmpl:
       path: .aiox-core/product/templates/brownfield-risk-report-tmpl.yaml
       layer: L2
@@ -5710,7 +5710,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2aca2b93e48ea944bce3c933f7466b4e520e4c26ec486e23f0a82cccf6e0356b
-      lastVerified: '2026-03-06T11:53:37.245Z'
+      lastVerified: '2026-03-11T02:00:27.534Z'
     changelog-template:
       path: .aiox-core/product/templates/changelog-template.md
       layer: L2
@@ -5730,7 +5730,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:af44d857c9bf8808e89419d1d859557c3c827de143be3c0f36f2a053c9ee9197
-      lastVerified: '2026-03-06T11:53:37.246Z'
+      lastVerified: '2026-03-11T02:00:27.534Z'
     command-rationalization-matrix:
       path: .aiox-core/product/templates/command-rationalization-matrix.md
       layer: L2
@@ -5752,7 +5752,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:651157c5e6ad75323e24d5685660addb4f2cfe8bfa01e0c64a8e7e10c90f1d12
-      lastVerified: '2026-03-06T11:53:37.246Z'
+      lastVerified: '2026-03-11T02:00:27.534Z'
     competitor-analysis-tmpl:
       path: .aiox-core/product/templates/competitor-analysis-tmpl.yaml
       layer: L2
@@ -5774,7 +5774,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:690cde6406250883a765eddcbad415c737268525340cf2c8679c8f3074c9d507
-      lastVerified: '2026-03-06T11:53:37.246Z'
+      lastVerified: '2026-03-11T02:00:27.535Z'
     current-approach-tmpl:
       path: .aiox-core/product/templates/current-approach-tmpl.md
       layer: L2
@@ -5797,7 +5797,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec258049a5cda587b24523faf6b26ed0242765f4e732af21c4f42e42cf326714
-      lastVerified: '2026-03-06T11:53:37.247Z'
+      lastVerified: '2026-03-11T02:00:27.535Z'
     design-story-tmpl:
       path: .aiox-core/product/templates/design-story-tmpl.yaml
       layer: L2
@@ -5824,7 +5824,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2bfefc11ae2bcfc679dbd924c58f8b764fa23538c14cb25344d6edef41968f29
-      lastVerified: '2026-03-06T11:53:37.247Z'
+      lastVerified: '2026-03-11T02:00:27.535Z'
     ds-artifact-analysis:
       path: .aiox-core/product/templates/ds-artifact-analysis.md
       layer: L2
@@ -5847,12 +5847,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2ef1866841e4dcd55f9510f7ca14fd1f754f1e9c8a66cdc74d37ebcee13ede5d
-      lastVerified: '2026-03-06T11:53:37.248Z'
+      lastVerified: '2026-03-11T02:00:27.535Z'
     front-end-architecture-tmpl:
       path: .aiox-core/product/templates/front-end-architecture-tmpl.yaml
       layer: L2
       type: template
-      purpose: Entity at .aiox-core\product\templates\front-end-architecture-tmpl.yaml
+      purpose: Entity at .aiox-core/product/templates/front-end-architecture-tmpl.yaml
       keywords:
         - front
         - end
@@ -5870,7 +5870,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de0432b4f98236c3a1d6cc9975b90fbc57727653bdcf6132355c0bcf0b4dbb9c
-      lastVerified: '2026-03-06T11:53:37.249Z'
+      lastVerified: '2026-03-11T02:00:27.535Z'
     front-end-spec-tmpl:
       path: .aiox-core/product/templates/front-end-spec-tmpl.yaml
       layer: L2
@@ -5893,7 +5893,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9033c7cccbd0893c11545c680f29c6743de8e7ad8e761c6c2487e2985b0a4411
-      lastVerified: '2026-03-06T11:53:37.249Z'
+      lastVerified: '2026-03-11T02:00:27.535Z'
     fullstack-architecture-tmpl:
       path: .aiox-core/product/templates/fullstack-architecture-tmpl.yaml
       layer: L2
@@ -5915,7 +5915,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1ac74304138be53d87808b8e4afe6f870936a1f3a9e35e18c3321b3d42145215
-      lastVerified: '2026-03-06T11:53:37.250Z'
+      lastVerified: '2026-03-11T02:00:27.535Z'
     github-actions-cd:
       path: .aiox-core/product/templates/github-actions-cd.yml
       layer: L2
@@ -5937,7 +5937,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e6d6f2da3909a76d188137962076988f8e639a8f580e278ddb076b917a159a63
-      lastVerified: '2026-03-06T11:53:37.250Z'
+      lastVerified: '2026-03-11T02:00:27.536Z'
     github-actions-ci:
       path: .aiox-core/product/templates/github-actions-ci.yml
       layer: L2
@@ -5959,7 +5959,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5628f43737eb39ba06d9c127dc42c9d89dc1ac712560ea948dee4cc3707fb517
-      lastVerified: '2026-03-06T11:53:37.250Z'
+      lastVerified: '2026-03-11T02:00:27.536Z'
     github-pr-template:
       path: .aiox-core/product/templates/github-pr-template.md
       layer: L2
@@ -5982,7 +5982,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:472729ec721fbf37ece2027861bb44e0d7a8f5a5f12d6fddb5b4a58a1fc34dd6
-      lastVerified: '2026-03-06T11:53:37.250Z'
+      lastVerified: '2026-03-11T02:00:27.536Z'
     gordon-mcp:
       path: .aiox-core/product/templates/gordon-mcp.yaml
       layer: L2
@@ -6004,7 +6004,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:54d961455a216f968bcb8234c5bf6cda3676e683f43dfcad7a18abc92dc767ab
-      lastVerified: '2026-03-06T11:53:37.250Z'
+      lastVerified: '2026-03-11T02:00:27.536Z'
     index-strategy-tmpl:
       path: .aiox-core/product/templates/index-strategy-tmpl.yaml
       layer: L2
@@ -6025,7 +6025,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6db2b40f6eef47f4faa31ce513ee7b0d5f04d9a5e081a72e0cdbad402eb444ae
-      lastVerified: '2026-03-06T11:53:37.250Z'
+      lastVerified: '2026-03-11T02:00:27.536Z'
     market-research-tmpl:
       path: .aiox-core/product/templates/market-research-tmpl.yaml
       layer: L2
@@ -6047,7 +6047,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a908f070009aa0403f9db542585401912aabe7913726bd2fa26b7954f162b674
-      lastVerified: '2026-03-06T11:53:37.251Z'
+      lastVerified: '2026-03-11T02:00:27.536Z'
     migration-plan-tmpl:
       path: .aiox-core/product/templates/migration-plan-tmpl.yaml
       layer: L2
@@ -6068,7 +6068,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d0b8580cab768484a2730b7a7f1032e2bab9643940d29dd3c351b7ac930e8ea1
-      lastVerified: '2026-03-06T11:53:37.251Z'
+      lastVerified: '2026-03-11T02:00:27.536Z'
     migration-strategy-tmpl:
       path: .aiox-core/product/templates/migration-strategy-tmpl.md
       layer: L2
@@ -6091,7 +6091,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:957ffccbe9eb1f1ea90a8951ef9eb187d22e50c2f95c2ff048580892d2f2e25b
-      lastVerified: '2026-03-06T11:53:37.252Z'
+      lastVerified: '2026-03-11T02:00:27.537Z'
     personalized-agent-template:
       path: .aiox-core/product/templates/personalized-agent-template.md
       layer: L2
@@ -6112,7 +6112,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:64062d7d4756859c3522e2a228b9079d1c7a5e22c8d1da69a7f0aa148f6181f2
-      lastVerified: '2026-03-06T11:53:37.252Z'
+      lastVerified: '2026-03-11T02:00:27.537Z'
     personalized-checklist-template:
       path: .aiox-core/product/templates/personalized-checklist-template.md
       layer: L2
@@ -6137,7 +6137,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:269ea02fb70b16e94f84ca1910e1911b1fe9fb190f6ed6e22ced869bde3a2e2d
-      lastVerified: '2026-03-06T11:53:37.252Z'
+      lastVerified: '2026-03-11T02:00:27.537Z'
     personalized-task-template-v2:
       path: .aiox-core/product/templates/personalized-task-template-v2.md
       layer: L2
@@ -6160,7 +6160,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:50dae1fdfd967c1713c76e51a418bb0d00f5d9546cade796973da94faac978d3
-      lastVerified: '2026-03-06T11:53:37.253Z'
+      lastVerified: '2026-03-11T02:00:27.537Z'
     personalized-task-template:
       path: .aiox-core/product/templates/personalized-task-template.md
       layer: L2
@@ -6182,7 +6182,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7d47e5603d8c950afcfd64dc54820bb93681c35f040a842dfcf7f77ead16f53f
-      lastVerified: '2026-03-06T11:53:37.253Z'
+      lastVerified: '2026-03-11T02:00:27.537Z'
     personalized-template-file:
       path: .aiox-core/product/templates/personalized-template-file.yaml
       layer: L2
@@ -6205,7 +6205,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8de995f022e873f8230000c07b55510c52c1477f30c4cd868f1c6fc5ffa9fd9b
-      lastVerified: '2026-03-06T11:53:37.253Z'
+      lastVerified: '2026-03-11T02:00:27.537Z'
     personalized-workflow-template:
       path: .aiox-core/product/templates/personalized-workflow-template.yaml
       layer: L2
@@ -6228,12 +6228,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2e61ec76a8638046aad135b3a8538810f32b1c7abc6353e35af61766453f74ba
-      lastVerified: '2026-03-06T11:53:37.254Z'
+      lastVerified: '2026-03-11T02:00:27.537Z'
     prd-tmpl:
       path: .aiox-core/product/templates/prd-tmpl.yaml
       layer: L2
       type: template
-      purpose: Entity at .aiox-core\product\templates\prd-tmpl.yaml
+      purpose: Entity at .aiox-core/product/templates/prd-tmpl.yaml
       keywords:
         - prd
         - tmpl
@@ -6249,12 +6249,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:25c239f40e05f24aee1986601a98865188dbe3ea00a705028efc3adad6d420f3
-      lastVerified: '2026-03-06T11:53:37.254Z'
+      lastVerified: '2026-03-11T02:00:27.537Z'
     project-brief-tmpl:
       path: .aiox-core/product/templates/project-brief-tmpl.yaml
       layer: L2
       type: template
-      purpose: Entity at .aiox-core\product\templates\project-brief-tmpl.yaml
+      purpose: Entity at .aiox-core/product/templates/project-brief-tmpl.yaml
       keywords:
         - project
         - brief
@@ -6271,7 +6271,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b8d388268c24dc5018f48a87036d591b11cb122fafe9b59c17809b06ea5d9d58
-      lastVerified: '2026-03-06T11:53:37.254Z'
+      lastVerified: '2026-03-11T02:00:27.538Z'
     qa-gate-tmpl:
       path: .aiox-core/product/templates/qa-gate-tmpl.yaml
       layer: L2
@@ -6292,7 +6292,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a0d3e4a37ee8f719aacb8a31949522bfa239982198d0f347ea7d3f44ad8003ca
-      lastVerified: '2026-03-06T11:53:37.255Z'
+      lastVerified: '2026-03-11T02:00:27.538Z'
     qa-report-tmpl:
       path: .aiox-core/product/templates/qa-report-tmpl.md
       layer: L2
@@ -6314,7 +6314,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b2b0059050648fad63bfad7fa128225990b2fa6a6fb914902b2a5baf707c1cc6
-      lastVerified: '2026-03-06T11:53:37.269Z'
+      lastVerified: '2026-03-11T02:00:27.538Z'
     rls-policies-tmpl:
       path: .aiox-core/product/templates/rls-policies-tmpl.yaml
       layer: L2
@@ -6335,7 +6335,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3c303ab5a5f95c89f0caf9c632296e8ca43e29a921484523016c1c5bc320428f
-      lastVerified: '2026-03-06T11:53:37.271Z'
+      lastVerified: '2026-03-11T02:00:27.538Z'
     schema-design-tmpl:
       path: .aiox-core/product/templates/schema-design-tmpl.yaml
       layer: L2
@@ -6356,7 +6356,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7c5b7dfc67e1332e1fbf39657169094e2b92cd4fd6c7b441c3586981c732af95
-      lastVerified: '2026-03-06T11:53:37.271Z'
+      lastVerified: '2026-03-11T02:00:27.538Z'
     spec-tmpl:
       path: .aiox-core/product/templates/spec-tmpl.md
       layer: L2
@@ -6377,7 +6377,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ff625ad82e4e0f07c137ab5cd0567caac7980ab985783d2f76443dc900bffa5
-      lastVerified: '2026-03-06T11:53:37.272Z'
+      lastVerified: '2026-03-11T02:00:27.538Z'
     state-persistence-tmpl:
       path: .aiox-core/product/templates/state-persistence-tmpl.yaml
       layer: L2
@@ -6401,12 +6401,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7ff9caabce83ccc14acb05e9d06eaf369a8ebd54c2ddf4988efcc942f6c51037
-      lastVerified: '2026-03-06T11:53:37.272Z'
+      lastVerified: '2026-03-11T02:00:27.538Z'
     story-tmpl:
       path: .aiox-core/product/templates/story-tmpl.yaml
       layer: L2
       type: template
-      purpose: Entity at .aiox-core\product\templates\story-tmpl.yaml
+      purpose: Entity at .aiox-core/product/templates/story-tmpl.yaml
       keywords:
         - story
         - tmpl
@@ -6432,7 +6432,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0b64b49e5332cbce7d36da1ff40495628cb6ce650855b752dc82372706d41e13
-      lastVerified: '2026-03-06T11:53:37.272Z'
+      lastVerified: '2026-03-11T02:00:27.538Z'
     task-execution-report:
       path: .aiox-core/product/templates/task-execution-report.md
       layer: L2
@@ -6453,7 +6453,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e0f08a3e199234f3d2207ba8f435786b7d8e1b36174f46cb82fc3666b9a9309e
-      lastVerified: '2026-03-06T11:53:37.273Z'
+      lastVerified: '2026-03-11T02:00:27.539Z'
     task-template:
       path: .aiox-core/product/templates/task-template.md
       layer: L2
@@ -6474,7 +6474,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:aeb3a2843c1ca70a094601573899a47bb5956f3b5cd7a8bbad9d624ae39cf1fe
-      lastVerified: '2026-03-06T11:53:37.273Z'
+      lastVerified: '2026-03-11T02:00:27.539Z'
     tokens-schema-tmpl:
       path: .aiox-core/product/templates/tokens-schema-tmpl.yaml
       layer: L2
@@ -6496,7 +6496,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:66a7c164278cbe8b41dcc8525e382bdf5c59673a6694930aa33b857f199b4c2b
-      lastVerified: '2026-03-06T11:53:37.274Z'
+      lastVerified: '2026-03-11T02:00:27.539Z'
     workflow-template:
       path: .aiox-core/product/templates/workflow-template.yaml
       layer: L2
@@ -6518,7 +6518,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7185fbc069702ef6c4444c2c0cbf3d95f692435406ab3cad811768de4b7d4a28
-      lastVerified: '2026-03-06T11:53:37.274Z'
+      lastVerified: '2026-03-11T02:00:27.539Z'
     antigravity-rules:
       path: .aiox-core/product/templates/ide-rules/antigravity-rules.md
       layer: L2
@@ -6547,7 +6547,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:150fd84d590c2d41f169afdc2368743cb5a90a94a29df2f217b5e5a8e9c3ee1b
-      lastVerified: '2026-03-06T11:53:37.274Z'
+      lastVerified: '2026-03-11T02:00:27.539Z'
     claude-rules:
       path: .aiox-core/product/templates/ide-rules/claude-rules.md
       layer: L2
@@ -6580,7 +6580,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d5723c0a6d77b7137e9b8699937841f7452302b60905cd35276a319e6ce01742
-      lastVerified: '2026-03-06T11:53:37.275Z'
+      lastVerified: '2026-03-11T02:00:27.539Z'
     codex-rules:
       path: .aiox-core/product/templates/ide-rules/codex-rules.md
       layer: L2
@@ -6615,7 +6615,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:18302f137bda51c687b7c7ad76a17f73d84a1e254801ab9e72837d577962b7c5
-      lastVerified: '2026-03-06T11:53:37.275Z'
+      lastVerified: '2026-03-11T02:00:27.539Z'
     copilot-rules:
       path: .aiox-core/product/templates/ide-rules/copilot-rules.md
       layer: L2
@@ -6638,7 +6638,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5f7ecf4f6dbac28bc49b3a61d0902dcc28023b2918082195aab721b0a24847be
-      lastVerified: '2026-03-06T11:53:37.275Z'
+      lastVerified: '2026-03-11T02:00:27.539Z'
     cursor-rules:
       path: .aiox-core/product/templates/ide-rules/cursor-rules.md
       layer: L2
@@ -6667,7 +6667,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:40c5a75ec40a9d2da713336ced608eb4606bf7e76fe9b34827e888ed27903464
-      lastVerified: '2026-03-06T11:53:37.275Z'
+      lastVerified: '2026-03-11T02:00:27.539Z'
     gemini-rules:
       path: .aiox-core/product/templates/ide-rules/gemini-rules.md
       layer: L2
@@ -6688,13 +6688,13 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:20f687384c4deb909e9171f8e83f40b962a9cc717755b62d88db285316b2188a
-      lastVerified: '2026-03-06T11:53:37.275Z'
+      lastVerified: '2026-03-11T02:00:27.539Z'
   scripts:
     activation-runtime:
       path: .aiox-core/development/scripts/activation-runtime.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\activation-runtime.js
+      purpose: Entity at .aiox-core/development/scripts/activation-runtime.js
       keywords:
         - activation
         - runtime
@@ -6710,7 +6710,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3750084310b5a88e2f8d345ad4b417a408f2633d10dab11f4d648e8e10caa90c
-      lastVerified: '2026-03-06T11:53:37.277Z'
+      lastVerified: '2026-03-11T02:00:27.541Z'
     agent-assignment-resolver:
       path: .aiox-core/development/scripts/agent-assignment-resolver.js
       layer: L2
@@ -6730,7 +6730,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ae8a89d038cd9af894d9ec45d8b97ed930f84f70e88f17dbf1a3c556e336c75e
-      lastVerified: '2026-03-06T11:53:37.278Z'
+      lastVerified: '2026-03-11T02:00:27.541Z'
     agent-config-loader:
       path: .aiox-core/development/scripts/agent-config-loader.js
       layer: L2
@@ -6755,7 +6755,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6935a5574f887d88101c44340a96f2a4f8d01b2bdeb433108b84253178a106c7
-      lastVerified: '2026-03-06T11:53:37.278Z'
+      lastVerified: '2026-03-11T02:00:27.542Z'
     agent-exit-hooks:
       path: .aiox-core/development/scripts/agent-exit-hooks.js
       layer: L2
@@ -6776,7 +6776,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7aee7f33cae1bc4192a5085898caaf57f4866ce68488637d0f90a6372b616ce8
-      lastVerified: '2026-03-06T11:53:37.278Z'
+      lastVerified: '2026-03-11T02:00:27.542Z'
     apply-inline-greeting-all-agents:
       path: .aiox-core/development/scripts/apply-inline-greeting-all-agents.js
       layer: L2
@@ -6798,7 +6798,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5de6a7ddcab1ae34043b8a030b664deb9ce79e187ca30d22656716240e76a030
-      lastVerified: '2026-03-06T11:53:37.278Z'
+      lastVerified: '2026-03-11T02:00:27.542Z'
     approval-workflow:
       path: .aiox-core/development/scripts/approval-workflow.js
       layer: L2
@@ -6817,12 +6817,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:06979905e62b61e6dde1d2e1714ce61b9a4538a31f31ae1e5f41365f36395b09
-      lastVerified: '2026-03-06T11:53:37.279Z'
+      lastVerified: '2026-03-11T02:00:27.542Z'
     audit-agent-config:
       path: .aiox-core/development/scripts/audit-agent-config.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\audit-agent-config.js
+      purpose: Entity at .aiox-core/development/scripts/audit-agent-config.js
       keywords:
         - audit
         - agent
@@ -6837,7 +6837,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d3908286737b3951a0140224aae604d63ab485d503d1f0fb83bc902112637db0
-      lastVerified: '2026-03-06T11:53:37.279Z'
+      lastVerified: '2026-03-11T02:00:27.542Z'
     backlog-manager:
       path: .aiox-core/development/scripts/backlog-manager.js
       layer: L2
@@ -6859,12 +6859,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7790e867301aed155dcad303feb8113ffd45abe99052e70749ceaae894e9620b
-      lastVerified: '2026-03-06T11:53:37.307Z'
+      lastVerified: '2026-03-11T02:00:27.542Z'
     backup-manager:
       path: .aiox-core/development/scripts/backup-manager.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\backup-manager.js
+      purpose: Entity at .aiox-core/development/scripts/backup-manager.js
       keywords:
         - backup
         - manager
@@ -6880,7 +6880,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:81c9fd6a4b8a8e7feb1f7a9d6ba790e597ad8113a9ca0723ae20eb111bfb3cee
-      lastVerified: '2026-03-06T11:53:37.308Z'
+      lastVerified: '2026-03-11T02:00:27.542Z'
     batch-update-agents-session-context:
       path: .aiox-core/development/scripts/batch-update-agents-session-context.js
       layer: L2
@@ -6902,12 +6902,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d6fa38b55d788f0832021a15492d6b19d8967b481c05b87ab67d33a90ff7269b
-      lastVerified: '2026-03-06T11:53:37.308Z'
+      lastVerified: '2026-03-11T02:00:27.543Z'
     branch-manager:
       path: .aiox-core/development/scripts/branch-manager.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\branch-manager.js
+      purpose: Entity at .aiox-core/development/scripts/branch-manager.js
       keywords:
         - branch
         - manager
@@ -6922,7 +6922,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5d292b329fea370ee9e0930c5d6e9cb5c69af78ec1435ee194ddba0c3d2232a1
-      lastVerified: '2026-03-06T11:53:37.309Z'
+      lastVerified: '2026-03-11T02:00:27.543Z'
     code-quality-improver:
       path: .aiox-core/development/scripts/code-quality-improver.js
       layer: L2
@@ -6942,7 +6942,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d0c844089e53dcd6c06755d4cb432a60fbebcedcf5a86ed635650573549a1941
-      lastVerified: '2026-03-06T11:53:37.309Z'
+      lastVerified: '2026-03-11T02:00:27.543Z'
     commit-message-generator:
       path: .aiox-core/development/scripts/commit-message-generator.js
       layer: L2
@@ -6964,7 +6964,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c5990a5a012a2994d9a4d29ded445fef21d51e0b8203292104fbbd76b3e23826
-      lastVerified: '2026-03-06T11:53:37.310Z'
+      lastVerified: '2026-03-11T02:00:27.543Z'
     conflict-resolver:
       path: .aiox-core/development/scripts/conflict-resolver.js
       layer: L2
@@ -6984,12 +6984,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8971b9aca2ab23a9478ac70e59710ec843f483fcbe088371444f4fc9b56c5278
-      lastVerified: '2026-03-06T11:53:37.312Z'
+      lastVerified: '2026-03-11T02:00:27.543Z'
     decision-context:
       path: .aiox-core/development/scripts/decision-context.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\decision-context.js
+      purpose: Entity at .aiox-core/development/scripts/decision-context.js
       keywords:
         - decision
         - context
@@ -7004,7 +7004,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7deca4e738f078e2ccded6e8e26d2322697ea7b9fedf5a48fe8eec18e227c347
-      lastVerified: '2026-03-06T11:53:37.312Z'
+      lastVerified: '2026-03-11T02:00:27.543Z'
     decision-log-generator:
       path: .aiox-core/development/scripts/decision-log-generator.js
       layer: L2
@@ -7031,12 +7031,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:15f1c67d72d2572c68cf8738dfc549166c424475f6706502496f4e21596db504
-      lastVerified: '2026-03-06T11:53:37.313Z'
+      lastVerified: '2026-03-11T02:00:27.543Z'
     decision-log-indexer:
       path: .aiox-core/development/scripts/decision-log-indexer.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\decision-log-indexer.js
+      purpose: Entity at .aiox-core/development/scripts/decision-log-indexer.js
       keywords:
         - decision
         - log
@@ -7052,7 +7052,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4525176b92aefc6ea7387fc350e325192af044769b4774fde5bf35d74f93fd56
-      lastVerified: '2026-03-06T11:53:37.313Z'
+      lastVerified: '2026-03-11T02:00:27.544Z'
     decision-recorder:
       path: .aiox-core/development/scripts/decision-recorder.js
       layer: L2
@@ -7075,7 +7075,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73a259407434e4c4653232e578d408ea6dbde5b809a8c16b7cb169933b941c1c
-      lastVerified: '2026-03-06T11:53:37.314Z'
+      lastVerified: '2026-03-11T02:00:27.544Z'
     dependency-analyzer:
       path: .aiox-core/development/scripts/dependency-analyzer.js
       layer: L2
@@ -7094,12 +7094,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0ab1a54c3df1cd81c8bc4b7f4d769f91c7b0bfa6ce38b8c7e1d7d5b223d2245f
-      lastVerified: '2026-03-06T11:53:37.314Z'
+      lastVerified: '2026-03-11T02:00:27.544Z'
     dev-context-loader:
       path: .aiox-core/development/scripts/dev-context-loader.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\dev-context-loader.js
+      purpose: Entity at .aiox-core/development/scripts/dev-context-loader.js
       keywords:
         - dev
         - context
@@ -7114,7 +7114,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0db8d8c4ec863935b02263560d90a901462fb51a87e922baee26882c9d3b8f7c
-      lastVerified: '2026-03-06T11:53:37.314Z'
+      lastVerified: '2026-03-11T02:00:27.544Z'
     diff-generator:
       path: .aiox-core/development/scripts/diff-generator.js
       layer: L2
@@ -7133,12 +7133,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cad97b0096fc034fa6ed6cbd14a963abe32d880c1ce8034b6aa62af2e2239833
-      lastVerified: '2026-03-06T11:53:37.315Z'
+      lastVerified: '2026-03-11T02:00:27.544Z'
     elicitation-engine:
       path: .aiox-core/development/scripts/elicitation-engine.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\elicitation-engine.js
+      purpose: Entity at .aiox-core/development/scripts/elicitation-engine.js
       keywords:
         - elicitation
         - engine
@@ -7154,12 +7154,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ce7ea9b9c7e3600fcec27eee444a2860c15ec187ca449f3b63564f453d71c50
-      lastVerified: '2026-03-06T11:53:37.315Z'
+      lastVerified: '2026-03-11T02:00:27.544Z'
     elicitation-session-manager:
       path: .aiox-core/development/scripts/elicitation-session-manager.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\elicitation-session-manager.js
+      purpose: Entity at .aiox-core/development/scripts/elicitation-session-manager.js
       keywords:
         - elicitation
         - session
@@ -7175,12 +7175,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0a7141f2cf61e8fa32f8c861633b50e87e75bc6023b650756c1b55ad947d314b
-      lastVerified: '2026-03-06T11:53:37.315Z'
+      lastVerified: '2026-03-11T02:00:27.544Z'
     generate-greeting:
       path: .aiox-core/development/scripts/generate-greeting.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\generate-greeting.js
+      purpose: Entity at .aiox-core/development/scripts/generate-greeting.js
       keywords:
         - generate
         - greeting
@@ -7195,12 +7195,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:49b857fe36a0216a0df8395a6847f14608bd6a228817276201d22598a6862a4f
-      lastVerified: '2026-03-06T11:53:37.315Z'
+      lastVerified: '2026-03-11T02:00:27.544Z'
     git-wrapper:
       path: .aiox-core/development/scripts/git-wrapper.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\git-wrapper.js
+      purpose: Entity at .aiox-core/development/scripts/git-wrapper.js
       keywords:
         - git
         - wrapper
@@ -7215,7 +7215,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cb3abc56f9c001a80f18766d949b0d8916eb91d4644c0ee2d642ac62a03a73d3
-      lastVerified: '2026-03-06T11:53:37.316Z'
+      lastVerified: '2026-03-11T02:00:27.545Z'
     greeting-builder:
       path: .aiox-core/development/scripts/greeting-builder.js
       layer: L2
@@ -7246,12 +7246,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6f7aad3bd400c77463af5665cec45e0256350671a113d2fcad83a6adfa5dbbac
-      lastVerified: '2026-03-06T11:53:37.316Z'
+      lastVerified: '2026-03-11T02:00:27.545Z'
     greeting-config-cli:
       path: .aiox-core/development/scripts/greeting-config-cli.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\greeting-config-cli.js
+      purpose: Entity at .aiox-core/development/scripts/greeting-config-cli.js
       keywords:
         - greeting
         - config
@@ -7267,12 +7267,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c6e5c4dac08349b17cae64562311a5c2fab8d7c29bc96d86cbe2b43846312b3d
-      lastVerified: '2026-03-06T11:53:37.316Z'
+      lastVerified: '2026-03-11T02:00:27.545Z'
     greeting-preference-manager:
       path: .aiox-core/development/scripts/greeting-preference-manager.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\greeting-preference-manager.js
+      purpose: Entity at .aiox-core/development/scripts/greeting-preference-manager.js
       keywords:
         - greeting
         - preference
@@ -7290,12 +7290,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f6e8034fb7eb27a05f0ef186351282073c3e9b7d5d1db67fb88814c9b72fc219
-      lastVerified: '2026-03-06T11:53:37.317Z'
+      lastVerified: '2026-03-11T02:00:27.545Z'
     issue-triage:
       path: .aiox-core/development/scripts/issue-triage.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\issue-triage.js
+      purpose: Entity at .aiox-core/development/scripts/issue-triage.js
       keywords:
         - issue
         - triage
@@ -7309,7 +7309,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a9f9741b1426732f19803bf9f292b15d8eed0fb875cf02df70735f48512f2310
-      lastVerified: '2026-03-06T11:53:37.317Z'
+      lastVerified: '2026-03-11T02:00:27.545Z'
     manifest-preview:
       path: .aiox-core/development/scripts/manifest-preview.js
       layer: L2
@@ -7330,7 +7330,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:93fff0b2f1993f1f03352a8d9162b93368a7f3b0caf1223ea23b228d092d2084
-      lastVerified: '2026-03-06T11:53:37.317Z'
+      lastVerified: '2026-03-11T02:00:27.545Z'
     metrics-tracker:
       path: .aiox-core/development/scripts/metrics-tracker.js
       layer: L2
@@ -7350,7 +7350,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ac90ed08276a66591c8170ef5b5501f46cb1ba9d276b383e20fc77a563083312
-      lastVerified: '2026-03-06T11:53:37.317Z'
+      lastVerified: '2026-03-11T02:00:27.545Z'
     migrate-task-to-v2:
       path: .aiox-core/development/scripts/migrate-task-to-v2.js
       layer: L2
@@ -7371,12 +7371,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6bfef70de9592d53657f10a4e5c4582ac0ff11868d29e78b86676db45816152d
-      lastVerified: '2026-03-06T11:53:37.318Z'
+      lastVerified: '2026-03-11T02:00:27.545Z'
     modification-validator:
       path: .aiox-core/development/scripts/modification-validator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\modification-validator.js
+      purpose: Entity at .aiox-core/development/scripts/modification-validator.js
       keywords:
         - modification
         - validator
@@ -7393,7 +7393,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8bff78c5ce3a7c1add30f21f3b835aafd1b54b1752b7f24fc687a672026d7b13
-      lastVerified: '2026-03-06T11:53:37.318Z'
+      lastVerified: '2026-03-11T02:00:27.546Z'
     pattern-learner:
       path: .aiox-core/development/scripts/pattern-learner.js
       layer: L2
@@ -7413,12 +7413,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d562b095bd15dc12a4f474883a1ddb25fa4b7353729c1ff1eaa53675b964de52
-      lastVerified: '2026-03-06T11:53:37.318Z'
+      lastVerified: '2026-03-11T02:00:27.546Z'
     performance-analyzer:
       path: .aiox-core/development/scripts/performance-analyzer.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\performance-analyzer.js
+      purpose: Entity at .aiox-core/development/scripts/performance-analyzer.js
       keywords:
         - performance
         - analyzer
@@ -7432,7 +7432,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:52fc6c7dd22d7bdbbdfe51393c845075ee4fad75067fd91665682b9f0654e7c4
-      lastVerified: '2026-03-06T11:53:37.319Z'
+      lastVerified: '2026-03-11T02:00:27.546Z'
     populate-entity-registry:
       path: .aiox-core/development/scripts/populate-entity-registry.js
       layer: L2
@@ -7453,7 +7453,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3021b425f334c63d6462e64f6316f8b4036bd77b0b49ae419f20695fe3d1a89d
-      lastVerified: '2026-03-06T11:53:37.319Z'
+      lastVerified: '2026-03-11T02:00:27.546Z'
     refactoring-suggester:
       path: .aiox-core/development/scripts/refactoring-suggester.js
       layer: L2
@@ -7472,7 +7472,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d50ea6b609c9cf8385979386fee4b4385d11ebcde15460260f66d04c705f6cd9
-      lastVerified: '2026-03-06T11:53:37.319Z'
+      lastVerified: '2026-03-11T02:00:27.546Z'
     rollback-handler:
       path: .aiox-core/development/scripts/rollback-handler.js
       layer: L2
@@ -7493,7 +7493,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1017334a2fcc7c13cf46f12da127525435c0689e4d123d44156699431e941cd8
-      lastVerified: '2026-03-06T11:53:37.320Z'
+      lastVerified: '2026-03-11T02:00:27.546Z'
     security-checker:
       path: .aiox-core/development/scripts/security-checker.js
       layer: L2
@@ -7512,12 +7512,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e567af91b0b79e7ba51399cf6bfe4279417e632465f923bc8334c28f9405883c
-      lastVerified: '2026-03-06T11:53:37.320Z'
+      lastVerified: '2026-03-11T02:00:27.546Z'
     skill-validator:
       path: .aiox-core/development/scripts/skill-validator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\skill-validator.js
+      purpose: Entity at .aiox-core/development/scripts/skill-validator.js
       keywords:
         - skill
         - validator
@@ -7531,12 +7531,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b6bab880896a6fdb16d288c11e1d8fe3fa9f57f144b213bcb6eca1560ec38af1
-      lastVerified: '2026-03-06T11:53:37.320Z'
+      lastVerified: '2026-03-11T02:00:27.547Z'
     story-index-generator:
       path: .aiox-core/development/scripts/story-index-generator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\story-index-generator.js
+      purpose: Entity at .aiox-core/development/scripts/story-index-generator.js
       keywords:
         - story
         - index
@@ -7552,7 +7552,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c9ce1d2f89e76b9b2250aaa2b49a2881fc331dfbdec0bc0c5b7e1ec7767af140
-      lastVerified: '2026-03-06T11:53:37.320Z'
+      lastVerified: '2026-03-11T02:00:27.547Z'
     story-manager:
       path: .aiox-core/development/scripts/story-manager.js
       layer: L2
@@ -7578,12 +7578,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ba05c6dc3b29dad5ca57b0dafad8951d750bc30bdc04a9b083d4878c6f84f8f2
-      lastVerified: '2026-03-06T11:53:37.321Z'
+      lastVerified: '2026-03-11T02:00:27.547Z'
     story-update-hook:
       path: .aiox-core/development/scripts/story-update-hook.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\story-update-hook.js
+      purpose: Entity at .aiox-core/development/scripts/story-update-hook.js
       keywords:
         - story
         - update
@@ -7600,7 +7600,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:554a162e434717f86858ef04d8fdfe3ac40decf060cdc3d4d4987959fb2c51df
-      lastVerified: '2026-03-06T11:53:37.321Z'
+      lastVerified: '2026-03-11T02:00:27.547Z'
     task-identifier-resolver:
       path: .aiox-core/development/scripts/task-identifier-resolver.js
       layer: L2
@@ -7620,12 +7620,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ef63e5302a7393d4409e50fc437fdf33bd85f40b1907862ccfd507188f072d22
-      lastVerified: '2026-03-06T11:53:37.321Z'
+      lastVerified: '2026-03-11T02:00:27.547Z'
     template-engine:
       path: .aiox-core/development/scripts/template-engine.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\template-engine.js
+      purpose: Entity at .aiox-core/development/scripts/template-engine.js
       keywords:
         - template
         - engine
@@ -7639,12 +7639,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b97d091cb9a09e64d8632ae106cd00b3fd8a25bfbdb60d8cda6e5591c7dfd67f
-      lastVerified: '2026-03-06T11:53:37.321Z'
+      lastVerified: '2026-03-11T02:00:27.547Z'
     template-validator:
       path: .aiox-core/development/scripts/template-validator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\template-validator.js
+      purpose: Entity at .aiox-core/development/scripts/template-validator.js
       keywords:
         - template
         - validator
@@ -7659,12 +7659,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fb87e8d076b57469d33034f2cae32fd01eae81900317a267d26ab18eebaacb17
-      lastVerified: '2026-03-06T11:53:37.321Z'
+      lastVerified: '2026-03-11T02:00:27.547Z'
     test-generator:
       path: .aiox-core/development/scripts/test-generator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\test-generator.js
+      purpose: Entity at .aiox-core/development/scripts/test-generator.js
       keywords:
         - test
         - generator
@@ -7678,7 +7678,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c49f0d828ba4e5d996f6dc4fedd540fe2a95091de5e45093018686181493d164
-      lastVerified: '2026-03-06T11:53:37.322Z'
+      lastVerified: '2026-03-11T02:00:27.547Z'
     test-greeting-system:
       path: .aiox-core/development/scripts/test-greeting-system.js
       layer: L2
@@ -7699,7 +7699,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:598f32f09db543e67c0e79da78aaa6e2c78eb54b8f91a5014a27c67468e663bb
-      lastVerified: '2026-03-06T11:53:37.322Z'
+      lastVerified: '2026-03-11T02:00:27.547Z'
     transaction-manager:
       path: .aiox-core/development/scripts/transaction-manager.js
       layer: L2
@@ -7719,7 +7719,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c1049e40ffa489206b48a8c95b0a55093ebf95fc2b2fb522e33b0fc8023d7d2a
-      lastVerified: '2026-03-06T11:53:37.322Z'
+      lastVerified: '2026-03-11T02:00:27.547Z'
     unified-activation-pipeline:
       path: .aiox-core/development/scripts/unified-activation-pipeline.js
       layer: L2
@@ -7751,12 +7751,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de2d4a10b01da32d31c1f810feed429804da6869bb958d5a5ebe626589d0a2f6
-      lastVerified: '2026-03-06T11:53:37.322Z'
+      lastVerified: '2026-03-11T02:00:27.548Z'
     usage-tracker:
       path: .aiox-core/development/scripts/usage-tracker.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\usage-tracker.js
+      purpose: Entity at .aiox-core/development/scripts/usage-tracker.js
       keywords:
         - usage
         - tracker
@@ -7771,12 +7771,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6057623755bf0ee1d9e0fb36740fc41914a5f8ca8ad994d40edec260e273744b
-      lastVerified: '2026-03-06T11:53:37.323Z'
+      lastVerified: '2026-03-11T02:00:27.548Z'
     validate-filenames:
       path: .aiox-core/development/scripts/validate-filenames.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\validate-filenames.js
+      purpose: Entity at .aiox-core/development/scripts/validate-filenames.js
       keywords:
         - validate
         - filenames
@@ -7790,12 +7790,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0228b1538ff02dfe1f747038cbb5e86630683a3c950e27d6315bcd762b1a93fd
-      lastVerified: '2026-03-06T11:53:37.323Z'
+      lastVerified: '2026-03-11T02:00:27.548Z'
     validate-task-v2:
       path: .aiox-core/development/scripts/validate-task-v2.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\validate-task-v2.js
+      purpose: Entity at .aiox-core/development/scripts/validate-task-v2.js
       keywords:
         - validate
         - task
@@ -7810,12 +7810,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4abe50b097c2d0f7a722b691ecd84021ea48b76a017ad76f4c49f748d002fe09
-      lastVerified: '2026-03-06T11:53:37.323Z'
+      lastVerified: '2026-03-11T02:00:27.548Z'
     verify-workflow-gaps:
       path: .aiox-core/development/scripts/verify-workflow-gaps.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\verify-workflow-gaps.js
+      purpose: Entity at .aiox-core/development/scripts/verify-workflow-gaps.js
       keywords:
         - verify
         - workflow
@@ -7836,7 +7836,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a06a3fac2c4fdf995f18d6108d48855a1156b763ef906a3943b94dc9a709c167
-      lastVerified: '2026-03-06T11:53:37.324Z'
+      lastVerified: '2026-03-11T02:00:27.549Z'
     version-tracker:
       path: .aiox-core/development/scripts/version-tracker.js
       layer: L2
@@ -7855,7 +7855,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d11804b82497e2a9c6e83191095681f5d57ac956b69975294f3f9d2efd0a7bdd
-      lastVerified: '2026-03-06T11:53:37.324Z'
+      lastVerified: '2026-03-11T02:00:27.549Z'
     workflow-navigator:
       path: .aiox-core/development/scripts/workflow-navigator.js
       layer: L2
@@ -7877,12 +7877,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:45bd9f0317b6a0b9e9577b5b26550f1b7fafec2c45c1b542a6947ffd69a70fec
-      lastVerified: '2026-03-06T11:53:37.324Z'
+      lastVerified: '2026-03-11T02:00:27.549Z'
     workflow-state-manager:
       path: .aiox-core/development/scripts/workflow-state-manager.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\workflow-state-manager.js
+      purpose: Entity at .aiox-core/development/scripts/workflow-state-manager.js
       keywords:
         - workflow
         - state
@@ -7900,12 +7900,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3a896079b32b8efb8c532c0626c4ce14fb52cc92afbb086f6f2d2a0367d60dec
-      lastVerified: '2026-03-06T11:53:37.324Z'
+      lastVerified: '2026-03-11T02:00:27.549Z'
     workflow-validator:
       path: .aiox-core/development/scripts/workflow-validator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\workflow-validator.js
+      purpose: data.description,
       keywords:
         - workflow
         - validator
@@ -7923,13 +7923,13 @@ entities:
         score: 0.7
         constraints: []
         extensionPoints: []
-      checksum: sha256:55bd8375e570cf0c738c10ebc52637462b89cb9cde16c3b53b48e60c3cac49f4
-      lastVerified: '2026-03-06T11:53:37.325Z'
+      checksum: sha256:abb16e5cd34ec06bbca0a31af3fc500c3a5c98f66d0a72546e4a2827653abcd3
+      lastVerified: '2026-03-11T02:00:27.550Z'
     yaml-validator:
       path: .aiox-core/development/scripts/yaml-validator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\yaml-validator.js
+      purpose: Entity at .aiox-core/development/scripts/yaml-validator.js
       keywords:
         - yaml
         - validator
@@ -7943,12 +7943,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:916864f9e56e1ccb7fc1596bd2da47400e4037f848a0d4e2bc46d0fa24cc544f
-      lastVerified: '2026-03-06T11:53:37.325Z'
+      lastVerified: '2026-03-11T02:00:27.550Z'
     index:
       path: .aiox-core/development/scripts/squad/index.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\squad\index.js
+      purpose: Entity at .aiox-core/development/scripts/squad/index.js
       keywords:
         - index
       usedBy:
@@ -7969,7 +7969,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d9bab56298104c00cc55d5e68bcf8bf660bc0f2a3f8c7609dc2ed911d34a4492
-      lastVerified: '2026-03-06T11:53:37.325Z'
+      lastVerified: '2026-03-11T02:00:27.550Z'
     squad-analyzer:
       path: .aiox-core/development/scripts/squad/squad-analyzer.js
       layer: L2
@@ -7989,7 +7989,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3aa6fd5273ee0cc35331d4150ed98ef43e8ab678c7c7eaaf4b6ea4b40c657b0c
-      lastVerified: '2026-03-06T11:53:37.325Z'
+      lastVerified: '2026-03-11T02:00:27.550Z'
     squad-designer:
       path: .aiox-core/development/scripts/squad/squad-designer.js
       layer: L2
@@ -8012,7 +8012,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:101cbb7d6ded0d6f991b29ac63dfee2c7bb86cbc8c4fefef728b7d12c3352829
-      lastVerified: '2026-03-06T11:53:37.326Z'
+      lastVerified: '2026-03-11T02:00:27.550Z'
     squad-downloader:
       path: .aiox-core/development/scripts/squad/squad-downloader.js
       layer: L2
@@ -8034,7 +8034,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e171444c33222c3ee7b34a874ce2298de010ddf9f883d9741084621084564dc9
-      lastVerified: '2026-03-06T11:53:37.326Z'
+      lastVerified: '2026-03-11T02:00:27.550Z'
     squad-extender:
       path: .aiox-core/development/scripts/squad/squad-extender.js
       layer: L2
@@ -8055,7 +8055,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de3ee647aa5d1fb32a4216777f3bd4716022fec64f0566c0a004b0ea4d110cca
-      lastVerified: '2026-03-06T11:53:37.326Z'
+      lastVerified: '2026-03-11T02:00:27.550Z'
     squad-generator:
       path: .aiox-core/development/scripts/squad/squad-generator.js
       layer: L2
@@ -8079,12 +8079,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c8c75b71af915c95b781662ba5cdee5899fd6842966fd8b90019923e091be575
-      lastVerified: '2026-03-06T11:53:37.327Z'
+      lastVerified: '2026-03-11T02:00:27.550Z'
     squad-loader:
       path: .aiox-core/development/scripts/squad/squad-loader.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\squad\squad-loader.js
+      purpose: Entity at .aiox-core/development/scripts/squad/squad-loader.js
       keywords:
         - squad
         - loader
@@ -8105,12 +8105,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7093b9457c93da6845722bf7eac660164963d5007c459afae2149340a7979f1f
-      lastVerified: '2026-03-06T11:53:37.327Z'
+      lastVerified: '2026-03-11T02:00:27.551Z'
     squad-migrator:
       path: .aiox-core/development/scripts/squad/squad-migrator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\squad\squad-migrator.js
+      purpose: Entity at .aiox-core/development/scripts/squad/squad-migrator.js
       keywords:
         - squad
         - migrator
@@ -8126,7 +8126,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:38d7906b3718701130c79ed66f2916710f0f13fb2d445b13e8cdb1c199192a0d
-      lastVerified: '2026-03-06T11:53:37.327Z'
+      lastVerified: '2026-03-11T02:00:27.552Z'
     squad-publisher:
       path: .aiox-core/development/scripts/squad/squad-publisher.js
       layer: L2
@@ -8148,12 +8148,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73b3adcf1b6edb16cd1679fe37852d1f2fde5c89cee4ea7b0ae8ca95f7ff85d2
-      lastVerified: '2026-03-06T11:53:37.333Z'
+      lastVerified: '2026-03-11T02:00:27.552Z'
     squad-validator:
       path: .aiox-core/development/scripts/squad/squad-validator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\development\scripts\squad\squad-validator.js
+      purpose: Entity at .aiox-core/development/scripts/squad/squad-validator.js
       keywords:
         - squad
         - validator
@@ -8177,13 +8177,13 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bba0ca266653ca7d6162de011165256e6e49ebe34f2136ae16a4c3393901ab27
-      lastVerified: '2026-03-06T11:53:37.333Z'
+      lastVerified: '2026-03-11T02:00:27.552Z'
   modules:
     index.esm:
       path: .aiox-core/core/index.esm.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\index.esm.js
+      purpose: Entity at .aiox-core/core/index.esm.js
       keywords:
         - index
         - esm
@@ -8208,12 +8208,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:10586193db3efc151c4347d24786a657a01f611a0ffb55ce4008e62c6fe89e40
-      lastVerified: '2026-03-06T11:53:37.340Z'
+      lastVerified: '2026-03-11T02:00:27.555Z'
     index:
       path: .aiox-core/core/index.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\index.js
+      purpose: Entity at .aiox-core/core/index.js
       keywords:
         - index
       usedBy: []
@@ -8239,12 +8239,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:970b617b0e723e8248065f698eca2298a5a0b72e3e43ee820ea85294555736e2
-      lastVerified: '2026-03-06T11:53:37.341Z'
+      lastVerified: '2026-03-11T02:00:27.555Z'
     code-intel-client:
       path: .aiox-core/core/code-intel/code-intel-client.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\code-intel\code-intel-client.js
+      purpose: Entity at .aiox-core/core/code-intel/code-intel-client.js
       keywords:
         - code
         - intel
@@ -8261,12 +8261,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c9a08a37775acf90397aa079a4ad2c5edcc47f2cfd592b26ae9f3d154d1deb8
-      lastVerified: '2026-03-06T11:53:37.341Z'
+      lastVerified: '2026-03-11T02:00:27.555Z'
     code-intel-enricher:
       path: .aiox-core/core/code-intel/code-intel-enricher.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\code-intel\code-intel-enricher.js
+      purpose: Entity at .aiox-core/core/code-intel/code-intel-enricher.js
       keywords:
         - code
         - intel
@@ -8281,12 +8281,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ee54acdce08258a5f52ee51b38e5c4ffe727e42c8682818120addf7f6863549f
-      lastVerified: '2026-03-06T11:53:37.341Z'
+      lastVerified: '2026-03-11T02:00:27.556Z'
     hook-runtime:
       path: .aiox-core/core/code-intel/hook-runtime.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\code-intel\hook-runtime.js
+      purpose: Entity at .aiox-core/core/code-intel/hook-runtime.js
       keywords:
         - hook
         - runtime
@@ -8301,12 +8301,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4d812dc503650ef90249ad2993b3f713aea806138a27455a6a9757329d829c8e
-      lastVerified: '2026-03-06T11:53:37.342Z'
+      lastVerified: '2026-03-11T02:00:27.556Z'
     registry-syncer:
       path: .aiox-core/core/code-intel/registry-syncer.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\code-intel\registry-syncer.js
+      purpose: Entity at .aiox-core/core/code-intel/registry-syncer.js
       keywords:
         - registry
         - syncer
@@ -8323,12 +8323,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:701102a519457938d5b9187b75a1f97d85cb5466cef23bce5edfb48b34c69ab8
-      lastVerified: '2026-03-06T11:53:37.342Z'
+      lastVerified: '2026-03-11T02:00:27.556Z'
     config-cache:
       path: .aiox-core/core/config/config-cache.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\config\config-cache.js
+      purpose: Entity at .aiox-core/core/config/config-cache.js
       keywords:
         - config
         - cache
@@ -8342,12 +8342,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:527a788cbe650aa6b13d1101ebc16419489bfef20b2ee93042f6eb6a51e898e9
-      lastVerified: '2026-03-06T11:53:37.342Z'
+      lastVerified: '2026-03-11T02:00:27.557Z'
     config-loader:
       path: .aiox-core/core/config/config-loader.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\config\config-loader.js
+      purpose: Entity at .aiox-core/core/config/config-loader.js
       keywords:
         - config
         - loader
@@ -8363,12 +8363,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e19fee885b060c85ee75df71a016259b8e4c21e6c7045a58514afded3a2386a8
-      lastVerified: '2026-03-06T11:53:37.343Z'
+      lastVerified: '2026-03-11T02:00:27.557Z'
     config-resolver:
       path: .aiox-core/core/config/config-resolver.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\config\config-resolver.js
+      purpose: Entity at .aiox-core/core/config/config-resolver.js
       keywords:
         - config
         - resolver
@@ -8390,12 +8390,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3b29df6954cec440debef87cb4e4e7610c94dc74e562d32c74b8ec57d893213b
-      lastVerified: '2026-03-06T11:53:37.343Z'
+      lastVerified: '2026-03-11T02:00:27.557Z'
     env-interpolator:
       path: .aiox-core/core/config/env-interpolator.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\config\env-interpolator.js
+      purpose: Entity at .aiox-core/core/config/env-interpolator.js
       keywords:
         - env
         - interpolator
@@ -8411,12 +8411,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d9d9782d1c685fc1734034f656903ff35ac71665c0bedb3fc479544c89d1ece1
-      lastVerified: '2026-03-06T11:53:37.343Z'
+      lastVerified: '2026-03-11T02:00:27.557Z'
     merge-utils:
       path: .aiox-core/core/config/merge-utils.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\config\merge-utils.js
+      purpose: Entity at .aiox-core/core/config/merge-utils.js
       keywords:
         - merge
         - utils
@@ -8432,12 +8432,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e25cb65f4c4e855cfeb4acced46d64a8c9cf7e55a97ac051ec3d985b8855c823
-      lastVerified: '2026-03-06T11:53:37.343Z'
+      lastVerified: '2026-03-11T02:00:27.557Z'
     migrate-config:
       path: .aiox-core/core/config/migrate-config.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\config\migrate-config.js
+      purpose: Entity at .aiox-core/core/config/migrate-config.js
       keywords:
         - migrate
         - config
@@ -8451,12 +8451,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5f46e718e0891d6bf5f46d0f9375960a8e12d010b9699cb287bd0fe71f252f41
-      lastVerified: '2026-03-06T11:53:37.344Z'
+      lastVerified: '2026-03-11T02:00:27.557Z'
     template-overrides:
       path: .aiox-core/core/config/template-overrides.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\config\template-overrides.js
+      purpose: Entity at .aiox-core/core/config/template-overrides.js
       keywords:
         - template
         - overrides
@@ -8470,12 +8470,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1708dc8764e7f88dfefd7684240afcd5f13657170ac104aed99145e2bb8ae82c
-      lastVerified: '2026-03-06T11:53:37.344Z'
+      lastVerified: '2026-03-11T02:00:27.557Z'
     fix-handler:
       path: .aiox-core/core/doctor/fix-handler.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\fix-handler.js
+      purpose: Entity at .aiox-core/core/doctor/fix-handler.js
       keywords:
         - fix
         - handler
@@ -8491,7 +8491,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c8255536f08a622b2773819080bdbf5d65f8f3f43b77eb257d98064cd74903a3
-      lastVerified: '2026-03-06T11:53:37.344Z'
+      lastVerified: '2026-03-11T02:00:27.557Z'
     agent-elicitation:
       path: .aiox-core/core/elicitation/agent-elicitation.js
       layer: L1
@@ -8512,12 +8512,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ef13ebff1375279e7b8f0f0bbd3699a0d201f9a67127efa64c4142159a26f417
-      lastVerified: '2026-03-06T11:53:37.344Z'
+      lastVerified: '2026-03-11T02:00:27.557Z'
     elicitation-engine:
       path: .aiox-core/core/elicitation/elicitation-engine.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\elicitation\elicitation-engine.js
+      purpose: Entity at .aiox-core/core/elicitation/elicitation-engine.js
       keywords:
         - elicitation
         - engine
@@ -8537,12 +8537,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:256f31ef3a5dd0ba085beb2a1556194e5f2e47d4d15cfeba6896b0022933400c
-      lastVerified: '2026-03-06T11:53:37.345Z'
+      lastVerified: '2026-03-11T02:00:27.557Z'
     session-manager:
       path: .aiox-core/core/elicitation/session-manager.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\elicitation\session-manager.js
+      purpose: Entity at .aiox-core/core/elicitation/session-manager.js
       keywords:
         - session
         - manager
@@ -8559,7 +8559,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:79e410d808c4b15802d04c9c7f806796c048e846a69d1a69783c619954771f9b
-      lastVerified: '2026-03-06T11:53:37.345Z'
+      lastVerified: '2026-03-11T02:00:27.558Z'
     task-elicitation:
       path: .aiox-core/core/elicitation/task-elicitation.js
       layer: L1
@@ -8580,7 +8580,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cc44ad635e60cbdb67d18209b4b50d1fb2824de2234ec607a6639eb1754bfc75
-      lastVerified: '2026-03-06T11:53:37.345Z'
+      lastVerified: '2026-03-11T02:00:27.558Z'
     workflow-elicitation:
       path: .aiox-core/core/elicitation/workflow-elicitation.js
       layer: L1
@@ -8602,12 +8602,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:722d9b28d2485e3b5b89af6ea136e6d3907b805b9870f6e07e943d0264dc7fff
-      lastVerified: '2026-03-06T11:53:37.345Z'
+      lastVerified: '2026-03-11T02:00:27.558Z'
     dashboard-emitter:
       path: .aiox-core/core/events/dashboard-emitter.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\events\dashboard-emitter.js
+      purpose: Entity at .aiox-core/core/events/dashboard-emitter.js
       keywords:
         - dashboard
         - emitter
@@ -8623,12 +8623,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:20f3d2297c29a64bae34ac8097cc0b54f4f706b19f0dbd6c752a20d7c4ad9eb1
-      lastVerified: '2026-03-06T11:53:37.345Z'
+      lastVerified: '2026-03-11T02:00:27.558Z'
     types:
       path: .aiox-core/core/events/types.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\events\types.js
+      purpose: Entity at .aiox-core/core/events/types.js
       keywords:
         - types
       usedBy:
@@ -8642,7 +8642,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b9b69520fb8f51aaa9c768006282dfbf17846df9edc829ddc6557d7fa9930865
-      lastVerified: '2026-03-06T11:53:37.346Z'
+      lastVerified: '2026-03-11T02:00:27.558Z'
     autonomous-build-loop:
       path: .aiox-core/core/execution/autonomous-build-loop.js
       layer: L1
@@ -8668,7 +8668,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:22246474800340c7a97c8b865f5f9e3cb162efd45c5db1be2f9f729969a0b6d0
-      lastVerified: '2026-03-06T11:53:37.347Z'
+      lastVerified: '2026-03-11T02:00:27.558Z'
     build-orchestrator:
       path: .aiox-core/core/execution/build-orchestrator.js
       layer: L1
@@ -8693,12 +8693,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3698635011a845dfc43c46dfd7f15c0aa3ab488938ea3bd281de29157f5c4687
-      lastVerified: '2026-03-06T11:53:37.364Z'
+      lastVerified: '2026-03-11T02:00:27.558Z'
     build-state-manager:
       path: .aiox-core/core/execution/build-state-manager.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\execution\build-state-manager.js
+      purpose: Entity at .aiox-core/core/execution/build-state-manager.js
       keywords:
         - build
         - state
@@ -8718,7 +8718,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:595523caf6db26624e7a483489345b9498ae15d99c2568073a2c0c45d5b46a54
-      lastVerified: '2026-03-06T11:53:37.365Z'
+      lastVerified: '2026-03-11T02:00:27.559Z'
     context-injector:
       path: .aiox-core/core/execution/context-injector.js
       layer: L1
@@ -8740,12 +8740,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a183255eb4831f701086f23f371f94a9ce10c46ea18c8369ec0fd756777f042f
-      lastVerified: '2026-03-06T11:53:37.365Z'
+      lastVerified: '2026-03-11T02:00:27.559Z'
     parallel-executor:
       path: .aiox-core/core/execution/parallel-executor.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\execution\parallel-executor.js
+      purpose: Entity at .aiox-core/core/execution/parallel-executor.js
       keywords:
         - parallel
         - executor
@@ -8760,7 +8760,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:46870e5c8ff8db3ee0386e477d427cc98eeb008f630818b093a9524b410590ae
-      lastVerified: '2026-03-06T11:53:37.365Z'
+      lastVerified: '2026-03-11T02:00:27.559Z'
     parallel-monitor:
       path: .aiox-core/core/execution/parallel-monitor.js
       layer: L1
@@ -8779,12 +8779,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:58ecd92f5de9c688f28cf952ae6cc5ee07ddf14dc89fb0ea13b2f0a527e29fae
-      lastVerified: '2026-03-06T11:53:37.366Z'
+      lastVerified: '2026-03-11T02:00:27.559Z'
     rate-limit-manager:
       path: .aiox-core/core/execution/rate-limit-manager.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\execution\rate-limit-manager.js
+      purpose: Entity at .aiox-core/core/execution/rate-limit-manager.js
       keywords:
         - rate
         - limit
@@ -8800,12 +8800,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b6e2ca99cf59a9dfa5a4e48109d0a47f36262efcc73e69f11a1c0c727d48abb
-      lastVerified: '2026-03-06T11:53:37.366Z'
+      lastVerified: '2026-03-11T02:00:27.559Z'
     result-aggregator:
       path: .aiox-core/core/execution/result-aggregator.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\execution\result-aggregator.js
+      purpose: Entity at .aiox-core/core/execution/result-aggregator.js
       keywords:
         - result
         - aggregator
@@ -8819,12 +8819,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fc662bbc649bf704a8f6e70d0203fab389c664a6b4b2932510f84c251ae26610
-      lastVerified: '2026-03-06T11:53:37.366Z'
+      lastVerified: '2026-03-11T02:00:27.559Z'
     semantic-merge-engine:
       path: .aiox-core/core/execution/semantic-merge-engine.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\execution\semantic-merge-engine.js
+      purpose: Entity at .aiox-core/core/execution/semantic-merge-engine.js
       keywords:
         - semantic
         - merge
@@ -8840,7 +8840,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:26f2a057407cf114a0611944960a8e6d58d93c5e03abe905489e6b699cb98a75
-      lastVerified: '2026-03-06T11:53:37.367Z'
+      lastVerified: '2026-03-11T02:00:27.559Z'
     subagent-dispatcher:
       path: .aiox-core/core/execution/subagent-dispatcher.js
       layer: L1
@@ -8862,7 +8862,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7affbc04de9be2bc53427670009a885f0b35e1cc183f82c2e044abf9611344b6
-      lastVerified: '2026-03-06T11:53:37.367Z'
+      lastVerified: '2026-03-11T02:00:27.560Z'
     wave-executor:
       path: .aiox-core/core/execution/wave-executor.js
       layer: L1
@@ -8883,12 +8883,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4e2324edb37ae0729062b5ac029f2891e050e7efd3a48d0f4a1dc4f227a6716b
-      lastVerified: '2026-03-06T11:53:37.368Z'
+      lastVerified: '2026-03-11T02:00:27.560Z'
     cli:
       path: .aiox-core/core/graph-dashboard/cli.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\graph-dashboard\cli.js
+      purpose: Entity at .aiox-core/core/graph-dashboard/cli.js
       keywords:
         - cli
       usedBy: []
@@ -8911,7 +8911,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1f2fd6c6b5ace42f3bddc89695fe32d01949321d96057bbf50e2e48892f2c8f5
-      lastVerified: '2026-03-06T11:53:37.368Z'
+      lastVerified: '2026-03-11T02:00:27.560Z'
     base-check:
       path: .aiox-core/core/health-check/base-check.js
       layer: L1
@@ -8967,12 +8967,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4bdc81b92825c72ab185fa8f161aa0348d63071f2bc0d894317199e00c269f8d
-      lastVerified: '2026-03-06T11:53:37.368Z'
+      lastVerified: '2026-03-11T02:00:27.560Z'
     check-registry:
       path: .aiox-core/core/health-check/check-registry.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\health-check\check-registry.js
+      purpose: Entity at .aiox-core/core/health-check/check-registry.js
       keywords:
         - check
         - registry
@@ -8992,12 +8992,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:131564effd0499f61a2420914be706b9134db955b4adf09bd03eee511c323867
-      lastVerified: '2026-03-06T11:53:37.369Z'
+      lastVerified: '2026-03-11T02:00:27.560Z'
     engine:
       path: .aiox-core/core/health-check/engine.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\health-check\engine.js
+      purpose: Entity at .aiox-core/core/health-check/engine.js
       keywords:
         - engine
       usedBy: []
@@ -9011,7 +9011,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7a53405621243960ce482e8d3052a40caf8704d670a9f3388eca294056971497
-      lastVerified: '2026-03-06T11:53:37.369Z'
+      lastVerified: '2026-03-11T02:00:27.560Z'
     ideation-engine:
       path: .aiox-core/core/ideation/ideation-engine.js
       layer: L1
@@ -9031,12 +9031,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d9108fa47ed7a9131703739befb214b97d5b8e546faf1b49d8ae9d083756c589
-      lastVerified: '2026-03-06T11:53:37.370Z'
+      lastVerified: '2026-03-11T02:00:27.560Z'
     circuit-breaker:
       path: .aiox-core/core/ids/circuit-breaker.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\ids\circuit-breaker.js
+      purpose: Entity at .aiox-core/core/ids/circuit-breaker.js
       keywords:
         - circuit
         - breaker
@@ -9051,7 +9051,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b35331ba71a6ce17869bab255e087fc540291243f9884fc21ed89f7efc122a4
-      lastVerified: '2026-03-06T11:53:37.370Z'
+      lastVerified: '2026-03-11T02:00:27.560Z'
     framework-governor:
       path: .aiox-core/core/ids/framework-governor.js
       layer: L1
@@ -9073,7 +9073,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ef7a3b7444a51f2f122c114c662b1db544d1c9e7833dc6f77dce30ac3a2005a2
-      lastVerified: '2026-03-06T11:53:37.370Z'
+      lastVerified: '2026-03-11T02:00:27.560Z'
     incremental-decision-engine:
       path: .aiox-core/core/ids/incremental-decision-engine.js
       layer: L1
@@ -9094,12 +9094,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:257b1f67f6df8eb91fe0a95405563611b8bf2f836cbca2398a0a394e40d6c219
-      lastVerified: '2026-03-06T11:53:37.371Z'
+      lastVerified: '2026-03-11T02:00:27.561Z'
     layer-classifier:
       path: .aiox-core/core/ids/layer-classifier.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\ids\layer-classifier.js
+      purpose: Entity at .aiox-core/core/ids/layer-classifier.js
       keywords:
         - layer
         - classifier
@@ -9114,7 +9114,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4ae1e7d341076a13d08b8b5baf7a687ad2c7df673d50fc3554d522fe79debcdc
-      lastVerified: '2026-03-06T11:53:37.371Z'
+      lastVerified: '2026-03-11T02:00:27.561Z'
     registry-healer:
       path: .aiox-core/core/ids/registry-healer.js
       layer: L1
@@ -9134,12 +9134,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2b128ea4c1e8bc8f9324390ab55c1b3623c9ad3352522cbecec1acaefe472c5d
-      lastVerified: '2026-03-06T11:53:37.371Z'
+      lastVerified: '2026-03-11T02:00:27.561Z'
     registry-loader:
       path: .aiox-core/core/ids/registry-loader.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\ids\registry-loader.js
+      purpose: Entity at .aiox-core/core/ids/registry-loader.js
       keywords:
         - registry
         - loader
@@ -9158,12 +9158,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:88c67bace0a5ab6a14cb1d096e3f9cab9f5edc0dd8377788e27b692ccefbd487
-      lastVerified: '2026-03-06T11:53:37.372Z'
+      lastVerified: '2026-03-11T02:00:27.561Z'
     registry-updater:
       path: .aiox-core/core/ids/registry-updater.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\ids\registry-updater.js
+      purpose: Entity at .aiox-core/core/ids/registry-updater.js
       keywords:
         - registry
         - updater
@@ -9178,12 +9178,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4873507324efab32ba59e1ade70aaa79f318f9c5d689bdb747d8721effba38d1
-      lastVerified: '2026-03-06T11:53:37.372Z'
+      lastVerified: '2026-03-11T02:00:27.561Z'
     verification-gate:
       path: .aiox-core/core/ids/verification-gate.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\ids\verification-gate.js
+      purpose: Entity at .aiox-core/core/ids/verification-gate.js
       keywords:
         - verification
         - gate
@@ -9198,12 +9198,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:96050661c90fa52bfc755911d02c9194ec35c00e71fc6bbc92a13686dd53bb91
-      lastVerified: '2026-03-06T11:53:37.372Z'
+      lastVerified: '2026-03-11T02:00:27.561Z'
     manifest-generator:
       path: .aiox-core/core/manifest/manifest-generator.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\manifest\manifest-generator.js
+      purpose: Entity at .aiox-core/core/manifest/manifest-generator.js
       keywords:
         - manifest
         - generator
@@ -9217,7 +9217,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:81b796990dd747bbb9785d205dbe5f6d5556754fc51745fb84b7ce4675acbdbf
-      lastVerified: '2026-03-06T11:53:37.372Z'
+      lastVerified: '2026-03-11T02:00:27.561Z'
     manifest-validator:
       path: .aiox-core/core/manifest/manifest-validator.js
       layer: L1
@@ -9236,12 +9236,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3558e7dbf653eac385222a299d0eddaaf77e119a70ec034f7a7291c401d7be2c
-      lastVerified: '2026-03-06T11:53:37.372Z'
+      lastVerified: '2026-03-11T02:00:27.561Z'
     config-migrator:
       path: .aiox-core/core/mcp/config-migrator.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\mcp\config-migrator.js
+      purpose: Entity at .aiox-core/core/mcp/config-migrator.js
       keywords:
         - config
         - migrator
@@ -9257,12 +9257,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0603a288d79e8526a2c757834bab5191bbc240b1b9dcb548b09d10cee97de322
-      lastVerified: '2026-03-06T11:53:37.373Z'
+      lastVerified: '2026-03-11T02:00:27.561Z'
     global-config-manager:
       path: .aiox-core/core/mcp/global-config-manager.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\mcp\global-config-manager.js
+      purpose: Entity at .aiox-core/core/mcp/global-config-manager.js
       keywords:
         - global
         - config
@@ -9279,12 +9279,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c010cfff03119c8369a3c4c3cc73ce31d79108dc15c5c66e67f63766a2a2c5d8
-      lastVerified: '2026-03-06T11:53:37.373Z'
+      lastVerified: '2026-03-11T02:00:27.562Z'
     os-detector:
       path: .aiox-core/core/mcp/os-detector.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\mcp\os-detector.js
+      purpose: Entity at .aiox-core/core/mcp/os-detector.js
       keywords:
         - os
         - detector
@@ -9300,12 +9300,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7c5eb398bf1e53ddc5e31a9367d01709eba56bc53f653430ea7de07e32aa2a11
-      lastVerified: '2026-03-06T11:53:37.373Z'
+      lastVerified: '2026-03-11T02:00:27.562Z'
     symlink-manager:
       path: .aiox-core/core/mcp/symlink-manager.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\mcp\symlink-manager.js
+      purpose: Entity at .aiox-core/core/mcp/symlink-manager.js
       keywords:
         - symlink
         - manager
@@ -9321,7 +9321,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b2c68e5664f7f8595b81cbfba69be16d7f37f8d21608c99ddd066808aa2653c1
-      lastVerified: '2026-03-06T11:53:37.373Z'
+      lastVerified: '2026-03-11T02:00:27.562Z'
     gotchas-memory:
       path: .aiox-core/core/memory/gotchas-memory.js
       layer: L1
@@ -9348,7 +9348,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0063eff42caf0dda759c0390ac323e7b102f5507f27b8beb7b0acc2fbec407c4
-      lastVerified: '2026-03-06T11:53:37.374Z'
+      lastVerified: '2026-03-11T02:00:27.562Z'
     agent-invoker:
       path: .aiox-core/core/orchestration/agent-invoker.js
       layer: L1
@@ -9368,7 +9368,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5e1e3428163c35b0c91f694b76a5ca1e520249de1f7f65aae87e6723c01a45e7
-      lastVerified: '2026-03-06T11:53:37.374Z'
+      lastVerified: '2026-03-11T02:00:27.562Z'
     bob-orchestrator:
       path: .aiox-core/core/orchestration/bob-orchestrator.js
       layer: L1
@@ -9401,12 +9401,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:35219c5113c262a39f249866e66c76f9f1206465dd68a66eb27d82c623b46048
-      lastVerified: '2026-03-06T11:53:37.375Z'
+      lastVerified: '2026-03-11T02:00:27.562Z'
     bob-status-writer:
       path: .aiox-core/core/orchestration/bob-status-writer.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\bob-status-writer.js
+      purpose: Entity at .aiox-core/core/orchestration/bob-status-writer.js
       keywords:
         - bob
         - status
@@ -9422,12 +9422,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d0368d44b8b45549f503d737b0fdb21afb02db8d544b19f4d0289828501ac016
-      lastVerified: '2026-03-06T11:53:37.376Z'
+      lastVerified: '2026-03-11T02:00:27.562Z'
     brownfield-handler:
       path: .aiox-core/core/orchestration/brownfield-handler.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\brownfield-handler.js
+      purpose: Entity at .aiox-core/core/orchestration/brownfield-handler.js
       keywords:
         - brownfield
         - handler
@@ -9445,7 +9445,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:370599a3de3c936e8ebf2f5d14a1d09b8b33c3ccda3027d68740171314888215
-      lastVerified: '2026-03-06T11:53:37.376Z'
+      lastVerified: '2026-03-11T02:00:27.562Z'
     checklist-runner:
       path: .aiox-core/core/orchestration/checklist-runner.js
       layer: L1
@@ -9465,12 +9465,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:40f17b74c2fe6746f45aa5750c0b85b5af22221e010951eb6e93f5796fb70a8f
-      lastVerified: '2026-03-06T11:53:37.376Z'
+      lastVerified: '2026-03-11T02:00:27.563Z'
     cli-commands:
       path: .aiox-core/core/orchestration/cli-commands.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\cli-commands.js
+      purpose: Entity at .aiox-core/core/orchestration/cli-commands.js
       keywords:
         - cli
         - commands
@@ -9485,12 +9485,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cedd09f6938b3e1e0e19c06f4763de00281ddb31529d16ab9e4f74d194a3bd3b
-      lastVerified: '2026-03-06T11:53:37.377Z'
+      lastVerified: '2026-03-11T02:00:27.563Z'
     condition-evaluator:
       path: .aiox-core/core/orchestration/condition-evaluator.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\condition-evaluator.js
+      purpose: Entity at .aiox-core/core/orchestration/condition-evaluator.js
       keywords:
         - condition
         - evaluator
@@ -9505,12 +9505,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8bf565cf56194340ff4e1d642647150775277bce649411d0338faa2c96106745
-      lastVerified: '2026-03-06T11:53:37.377Z'
+      lastVerified: '2026-03-11T02:00:27.563Z'
     context-manager:
       path: .aiox-core/core/orchestration/context-manager.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\context-manager.js
+      purpose: Entity at .aiox-core/core/orchestration/context-manager.js
       keywords:
         - context
         - manager
@@ -9525,12 +9525,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7bf273723a2c08cb84e670b9d4c55aacec51819b1fbd5f3b0c46c4ccfa2ec192
-      lastVerified: '2026-03-06T11:53:37.377Z'
+      lastVerified: '2026-03-11T02:00:27.563Z'
     dashboard-integration:
       path: .aiox-core/core/orchestration/dashboard-integration.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\dashboard-integration.js
+      purpose: Entity at .aiox-core/core/orchestration/dashboard-integration.js
       keywords:
         - dashboard
         - integration
@@ -9546,12 +9546,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8f2dd7d3885a9eaf58957505d312923e149f2771ae3ca0cda879631683f826c9
-      lastVerified: '2026-03-06T11:53:37.377Z'
+      lastVerified: '2026-03-11T02:00:27.563Z'
     data-lifecycle-manager:
       path: .aiox-core/core/orchestration/data-lifecycle-manager.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\data-lifecycle-manager.js
+      purpose: Entity at .aiox-core/core/orchestration/data-lifecycle-manager.js
       keywords:
         - data
         - lifecycle
@@ -9569,12 +9569,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:031c351aa28e96eb232db709741eb3474fbe8c25bfc834f607834fdddd8cb632
-      lastVerified: '2026-03-06T11:53:37.378Z'
+      lastVerified: '2026-03-11T02:00:27.563Z'
     epic-context-accumulator:
       path: .aiox-core/core/orchestration/epic-context-accumulator.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\epic-context-accumulator.js
+      purpose: Entity at .aiox-core/core/orchestration/epic-context-accumulator.js
       keywords:
         - epic
         - context
@@ -9589,12 +9589,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4f342f7fc05f404de2b899358f86143106737b56d6c486c98e988a67d420078b
-      lastVerified: '2026-03-06T11:53:37.378Z'
+      lastVerified: '2026-03-11T02:00:27.563Z'
     execution-profile-resolver:
       path: .aiox-core/core/orchestration/execution-profile-resolver.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\execution-profile-resolver.js
+      purpose: Entity at .aiox-core/core/orchestration/execution-profile-resolver.js
       keywords:
         - execution
         - profile
@@ -9610,12 +9610,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bb35f1c16c47c9306128c5f3e6c90df3ed91f9358576ea97a59007b74f5e9927
-      lastVerified: '2026-03-06T11:53:37.378Z'
+      lastVerified: '2026-03-11T02:00:27.563Z'
     executor-assignment:
       path: .aiox-core/core/orchestration/executor-assignment.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\executor-assignment.js
+      purpose: Entity at .aiox-core/core/orchestration/executor-assignment.js
       keywords:
         - executor
         - assignment
@@ -9632,12 +9632,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c046e3e837dbbb82d3877985192d3438d49f369274ac709789b913c502ada617
-      lastVerified: '2026-03-06T11:53:37.378Z'
+      lastVerified: '2026-03-11T02:00:27.563Z'
     gate-evaluator:
       path: .aiox-core/core/orchestration/gate-evaluator.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\gate-evaluator.js
+      purpose: Entity at .aiox-core/core/orchestration/gate-evaluator.js
       keywords:
         - gate
         - evaluator
@@ -9652,12 +9652,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:66a6ff6afefcdbf3e5149100b8e10aad95feaa5a84a0a993255ddb939b1c0eb4
-      lastVerified: '2026-03-06T11:53:37.379Z'
+      lastVerified: '2026-03-11T02:00:27.564Z'
     gemini-model-selector:
       path: .aiox-core/core/orchestration/gemini-model-selector.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\gemini-model-selector.js
+      purpose: Entity at .aiox-core/core/orchestration/gemini-model-selector.js
       keywords:
         - gemini
         - model
@@ -9673,12 +9673,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2fe54c401ae60c0b5dc07f74c7a464992a0558b10c0b61f183c06943441d0d57
-      lastVerified: '2026-03-06T11:53:37.379Z'
+      lastVerified: '2026-03-11T02:00:27.564Z'
     greenfield-handler:
       path: .aiox-core/core/orchestration/greenfield-handler.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\greenfield-handler.js
+      purpose: Entity at .aiox-core/core/orchestration/greenfield-handler.js
       keywords:
         - greenfield
         - handler
@@ -9697,12 +9697,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e4e951e1347f846f4df0af2a7692838a734418030331cb25ce6fa86721beafdf
-      lastVerified: '2026-03-06T11:53:37.379Z'
+      lastVerified: '2026-03-11T02:00:27.565Z'
     lock-manager:
       path: .aiox-core/core/orchestration/lock-manager.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\lock-manager.js
+      purpose: Entity at .aiox-core/core/orchestration/lock-manager.js
       keywords:
         - lock
         - manager
@@ -9718,7 +9718,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3917ef9443f8a0e0de0c79715de54fe1e9451faa9860ee2f0c0f588dfaaf7a09
-      lastVerified: '2026-03-06T11:53:37.380Z'
+      lastVerified: '2026-03-11T02:00:27.565Z'
     master-orchestrator:
       path: .aiox-core/core/orchestration/master-orchestrator.js
       layer: L1
@@ -9743,13 +9743,13 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:61b874d74fae62e9307861b02b7505538f1c94362fe638fc3941b0665dcbbdf6
-      lastVerified: '2026-03-06T11:53:37.383Z'
+      checksum: sha256:9f9a8c6be08bf371eff33076e01c8aeec610aec27a81534dad93e15f0824d983
+      lastVerified: '2026-03-11T02:01:00.102Z'
     message-formatter:
       path: .aiox-core/core/orchestration/message-formatter.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\message-formatter.js
+      purpose: Entity at .aiox-core/core/orchestration/message-formatter.js
       keywords:
         - message
         - formatter
@@ -9764,12 +9764,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b7413c04fa22db1c5fc2f5c2aa47bb8ca0374e079894a44df21b733da6c258ae
-      lastVerified: '2026-03-06T11:53:37.383Z'
+      lastVerified: '2026-03-11T02:00:27.565Z'
     recovery-handler:
       path: .aiox-core/core/orchestration/recovery-handler.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\recovery-handler.js
+      purpose: Entity at .aiox-core/core/orchestration/recovery-handler.js
       keywords:
         - recovery
         - handler
@@ -9787,7 +9787,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6a9ef025f95885849aa893188299aca698cea2ea428cc302012833032c9e106e
-      lastVerified: '2026-03-06T11:53:37.384Z'
+      lastVerified: '2026-03-11T02:00:27.566Z'
     session-state:
       path: .aiox-core/core/orchestration/session-state.js
       layer: L1
@@ -9812,7 +9812,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:72aa24d7a7a256a56973d7b4e7b03c968eabeb0d22be23af75f65f2e45ac88b3
-      lastVerified: '2026-03-06T11:53:37.384Z'
+      lastVerified: '2026-03-11T02:00:27.566Z'
     skill-dispatcher:
       path: .aiox-core/core/orchestration/skill-dispatcher.js
       layer: L1
@@ -9832,7 +9832,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ebee66973a1df5d9dfed195ac6d83765a92023ba504e1814674345094fb8117
-      lastVerified: '2026-03-06T11:53:37.384Z'
+      lastVerified: '2026-03-11T02:00:27.567Z'
     subagent-prompt-builder:
       path: .aiox-core/core/orchestration/subagent-prompt-builder.js
       layer: L1
@@ -9853,12 +9853,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c014eaae229e6c84742273701a6ef21a19343e34ef8be38d5d6a9bc59ecd8b02
-      lastVerified: '2026-03-06T11:53:37.384Z'
+      lastVerified: '2026-03-11T02:00:27.567Z'
     surface-checker:
       path: .aiox-core/core/orchestration/surface-checker.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\surface-checker.js
+      purpose: Entity at .aiox-core/core/orchestration/surface-checker.js
       keywords:
         - surface
         - checker
@@ -9876,12 +9876,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:92e9d5bea78c3db4940c39f79e537821b36451cd524d69e6b738272aa63c08b6
-      lastVerified: '2026-03-06T11:53:37.385Z'
+      lastVerified: '2026-03-11T02:00:27.567Z'
     task-complexity-classifier:
       path: .aiox-core/core/orchestration/task-complexity-classifier.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\task-complexity-classifier.js
+      purpose: Entity at .aiox-core/core/orchestration/task-complexity-classifier.js
       keywords:
         - task
         - complexity
@@ -9897,12 +9897,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:33b3b7c349352d607c156e0018c508f0869a1c7d233d107bed194a51bc608c93
-      lastVerified: '2026-03-06T11:53:37.385Z'
+      lastVerified: '2026-03-11T02:00:27.567Z'
     tech-stack-detector:
       path: .aiox-core/core/orchestration/tech-stack-detector.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\tech-stack-detector.js
+      purpose: Entity at .aiox-core/core/orchestration/tech-stack-detector.js
       keywords:
         - tech
         - stack
@@ -9919,7 +9919,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:074c52757e181cc1e344b26ae191ac67488d18e9da2b06b5def23abb6c64c056
-      lastVerified: '2026-03-06T11:53:37.385Z'
+      lastVerified: '2026-03-11T02:00:27.567Z'
     terminal-spawner:
       path: .aiox-core/core/orchestration/terminal-spawner.js
       layer: L1
@@ -9940,12 +9940,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a6453c6acf0ff007444adeaa5e4620890fff38f0b31b058a2da04d790fb098ab
-      lastVerified: '2026-03-06T11:53:37.390Z'
+      lastVerified: '2026-03-11T02:00:27.573Z'
     workflow-executor:
       path: .aiox-core/core/orchestration/workflow-executor.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\workflow-executor.js
+      purpose: Entity at .aiox-core/core/orchestration/workflow-executor.js
       keywords:
         - workflow
         - executor
@@ -9966,12 +9966,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:49372791e5729fd7987c80efe1400168e8d59eac000a009b88d9fde6735cf4db
-      lastVerified: '2026-03-06T11:53:37.391Z'
+      lastVerified: '2026-03-11T02:00:27.573Z'
     workflow-orchestrator:
       path: .aiox-core/core/orchestration/workflow-orchestrator.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\workflow-orchestrator.js
+      purpose: Entity at .aiox-core/core/orchestration/workflow-orchestrator.js
       keywords:
         - workflow
         - orchestrator
@@ -9993,12 +9993,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:82816bd5e6fecc9bbb77292444e53254c72bf93e5c04260784743354c6a58627
-      lastVerified: '2026-03-06T11:53:37.391Z'
+      lastVerified: '2026-03-11T02:00:27.573Z'
     operation-guard:
       path: .aiox-core/core/permissions/operation-guard.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\permissions\operation-guard.js
+      purpose: Entity at .aiox-core/core/permissions/operation-guard.js
       keywords:
         - operation
         - guard
@@ -10014,7 +10014,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f9b1b1bd547145c0d8a0f47534af0678ee852df6236acd05c53e479cb0e3f0bd
-      lastVerified: '2026-03-06T11:53:37.392Z'
+      lastVerified: '2026-03-11T02:00:27.573Z'
     permission-mode:
       path: .aiox-core/core/permissions/permission-mode.js
       layer: L1
@@ -10035,12 +10035,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:84f09067c7154d97cb2252b9a7def00562acf569cfc3b035d6d4e39fb40d4033
-      lastVerified: '2026-03-06T11:53:37.392Z'
+      lastVerified: '2026-03-11T02:00:27.573Z'
     base-layer:
       path: .aiox-core/core/quality-gates/base-layer.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\quality-gates\base-layer.js
+      purpose: Entity at .aiox-core/core/quality-gates/base-layer.js
       keywords:
         - base
         - layer
@@ -10057,12 +10057,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a9a3921da08176b0bd44f338a59abc1f5107f3b1ee56571e840bf4e8ed233f4
-      lastVerified: '2026-03-06T11:53:37.416Z'
+      lastVerified: '2026-03-11T02:00:27.573Z'
     checklist-generator:
       path: .aiox-core/core/quality-gates/checklist-generator.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\quality-gates\checklist-generator.js
+      purpose: Entity at .aiox-core/core/quality-gates/checklist-generator.js
       keywords:
         - checklist
         - generator
@@ -10077,7 +10077,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7f2800f6e2465a846c9bef8a73403e7b91bf18d1d1425804d31244bd883ec55a
-      lastVerified: '2026-03-06T11:53:37.416Z'
+      lastVerified: '2026-03-11T02:00:27.573Z'
     focus-area-recommender:
       path: .aiox-core/core/quality-gates/focus-area-recommender.js
       layer: L1
@@ -10098,12 +10098,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f6364e2d444d19a8a3d0fb59d5264ae55137d48e008f5a3efe57f92465c4b53e
-      lastVerified: '2026-03-06T11:53:37.416Z'
+      lastVerified: '2026-03-11T02:00:27.573Z'
     human-review-orchestrator:
       path: .aiox-core/core/quality-gates/human-review-orchestrator.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\quality-gates\human-review-orchestrator.js
+      purpose: Entity at .aiox-core/core/quality-gates/human-review-orchestrator.js
       keywords:
         - human
         - review
@@ -10121,12 +10121,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3462b577d1bfa561156e72483241cb3bd0a6756448bd17acb3f4d92ead144781
-      lastVerified: '2026-03-06T11:53:37.417Z'
+      lastVerified: '2026-03-11T02:00:27.574Z'
     layer1-precommit:
       path: .aiox-core/core/quality-gates/layer1-precommit.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\quality-gates\layer1-precommit.js
+      purpose: Entity at .aiox-core/core/quality-gates/layer1-precommit.js
       keywords:
         - layer1
         - precommit
@@ -10142,12 +10142,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:250b62740b473383e41b371bb59edddabd8a312f5f48a5a8e883e6196a48b8f3
-      lastVerified: '2026-03-06T11:53:37.417Z'
+      lastVerified: '2026-03-11T02:00:27.574Z'
     layer2-pr-automation:
       path: .aiox-core/core/quality-gates/layer2-pr-automation.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\quality-gates\layer2-pr-automation.js
+      purpose: Entity at .aiox-core/core/quality-gates/layer2-pr-automation.js
       keywords:
         - layer2
         - pr
@@ -10164,12 +10164,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:af31e7ac60b74b52ee983d0fcff7457042eea553b6127538cab41eb94eaee8e0
-      lastVerified: '2026-03-06T11:53:37.417Z'
+      lastVerified: '2026-03-11T02:00:27.574Z'
     layer3-human-review:
       path: .aiox-core/core/quality-gates/layer3-human-review.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\quality-gates\layer3-human-review.js
+      purpose: Entity at .aiox-core/core/quality-gates/layer3-human-review.js
       keywords:
         - layer3
         - human
@@ -10187,12 +10187,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9bf79d5adfddae55d7dddfda777cd2775aa76f82204ddd0f660f6edbd093b16b
-      lastVerified: '2026-03-06T11:53:37.418Z'
+      lastVerified: '2026-03-11T02:00:27.574Z'
     notification-manager:
       path: .aiox-core/core/quality-gates/notification-manager.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\quality-gates\notification-manager.js
+      purpose: Entity at .aiox-core/core/quality-gates/notification-manager.js
       keywords:
         - notification
         - manager
@@ -10208,12 +10208,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:89466b448383f8021075f43b870036b2e1d0277e543bd4357dd4988dc7c31b14
-      lastVerified: '2026-03-06T11:53:37.435Z'
+      lastVerified: '2026-03-11T02:00:27.574Z'
     quality-gate-manager:
       path: .aiox-core/core/quality-gates/quality-gate-manager.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\quality-gates\quality-gate-manager.js
+      purpose: Entity at .aiox-core/core/quality-gates/quality-gate-manager.js
       keywords:
         - quality
         - gate
@@ -10233,7 +10233,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b0d5ce2653218eae63121e892d886c3234a87bf98536369c75b537163e07fb26
-      lastVerified: '2026-03-06T11:53:37.435Z'
+      lastVerified: '2026-03-11T02:00:27.574Z'
     build-registry:
       path: .aiox-core/core/registry/build-registry.js
       layer: L1
@@ -10252,7 +10252,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e23f7e4f2d378de42204698eb0a818f6f8a4868a97341c8fbb92158c3e7d4767
-      lastVerified: '2026-03-06T11:53:37.435Z'
+      lastVerified: '2026-03-11T02:00:27.574Z'
     validate-registry:
       path: .aiox-core/core/registry/validate-registry.js
       layer: L1
@@ -10271,12 +10271,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d9805ce445661a3a2d9e6c73bf35cbd1bc2403419825442cd7b8f01cc1409cb3
-      lastVerified: '2026-03-06T11:53:37.436Z'
+      lastVerified: '2026-03-11T02:00:27.574Z'
     context-detector:
       path: .aiox-core/core/session/context-detector.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\session\context-detector.js
+      purpose: Entity at .aiox-core/core/session/context-detector.js
       keywords:
         - context
         - detector
@@ -10297,12 +10297,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5537563d5dfc613e16fd610c9e1407e7811c4f19745a78a4fc81c34af20000f4
-      lastVerified: '2026-03-06T11:53:37.436Z'
+      lastVerified: '2026-03-11T02:00:27.574Z'
     context-loader:
       path: .aiox-core/core/session/context-loader.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\session\context-loader.js
+      purpose: Entity at .aiox-core/core/session/context-loader.js
       keywords:
         - context
         - loader
@@ -10321,12 +10321,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e810e119059dce081d1143b16e4e6bb7aa65684169b4ebc36f55ecbaf109bd63
-      lastVerified: '2026-03-06T11:53:37.436Z'
+      lastVerified: '2026-03-11T02:00:27.574Z'
     observability-panel:
       path: .aiox-core/core/ui/observability-panel.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\ui\observability-panel.js
+      purpose: Entity at .aiox-core/core/ui/observability-panel.js
       keywords:
         - observability
         - panel
@@ -10342,12 +10342,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f73bb7b80e60d8158c5044b13bb4dd4945270d3d44b8ac3e2c30635e5040f0f8
-      lastVerified: '2026-03-06T11:53:37.436Z'
+      lastVerified: '2026-03-11T02:00:27.575Z'
     panel-renderer:
       path: .aiox-core/core/ui/panel-renderer.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\ui\panel-renderer.js
+      purpose: Entity at .aiox-core/core/ui/panel-renderer.js
       keywords:
         - panel
         - renderer
@@ -10362,12 +10362,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d51a8a9d1dd76ce6bc08d38eaf53f4f7df948cc4edc8e7f56d68c39522f64dc6
-      lastVerified: '2026-03-06T11:53:37.440Z'
+      lastVerified: '2026-03-11T02:00:27.575Z'
     output-formatter:
       path: .aiox-core/core/utils/output-formatter.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\utils\output-formatter.js
+      purpose: Entity at .aiox-core/core/utils/output-formatter.js
       keywords:
         - output
         - formatter
@@ -10381,12 +10381,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6fdfee469b7c108ec24a045b9b2719d836a242052abd285957a9ac732c6fc594
-      lastVerified: '2026-03-06T11:53:37.440Z'
+      lastVerified: '2026-03-11T02:00:27.575Z'
     security-utils:
       path: .aiox-core/core/utils/security-utils.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\utils\security-utils.js
+      purpose: Entity at .aiox-core/core/utils/security-utils.js
       keywords:
         - security
         - utils
@@ -10400,12 +10400,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:00c938eda0e142b8c204b50afdd662864b5209b60a32a0e6e847e4e4cbceee09
-      lastVerified: '2026-03-06T11:53:37.441Z'
+      lastVerified: '2026-03-11T02:00:27.575Z'
     yaml-validator:
       path: .aiox-core/core/utils/yaml-validator.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\utils\yaml-validator.js
+      purpose: Entity at .aiox-core/core/utils/yaml-validator.js
       keywords:
         - yaml
         - validator
@@ -10419,12 +10419,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:41e3715845262c2e49f58745a773e81f4feaaa2325e54bcb0226e4bf08f709dd
-      lastVerified: '2026-03-06T11:53:37.457Z'
+      lastVerified: '2026-03-11T02:00:27.575Z'
     creation-helper:
       path: .aiox-core/core/code-intel/helpers/creation-helper.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\code-intel\helpers\creation-helper.js
+      purpose: Entity at .aiox-core/core/code-intel/helpers/creation-helper.js
       keywords:
         - creation
         - helper
@@ -10439,12 +10439,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e674fdbe6979dbe961853f080d5971ba264dee23ab70abafcc21ee99356206e7
-      lastVerified: '2026-03-06T11:53:37.457Z'
+      lastVerified: '2026-03-11T02:00:27.575Z'
     dev-helper:
       path: .aiox-core/core/code-intel/helpers/dev-helper.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\code-intel\helpers\dev-helper.js
+      purpose: Entity at .aiox-core/core/code-intel/helpers/dev-helper.js
       keywords:
         - dev
         - helper
@@ -10460,7 +10460,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2418a5f541003c73cc284e88a6b0cb666896a47ffd5ed4c08648269d281efc4c
-      lastVerified: '2026-03-06T11:53:37.457Z'
+      lastVerified: '2026-03-11T02:00:27.575Z'
     devops-helper:
       path: .aiox-core/core/code-intel/helpers/devops-helper.js
       layer: L1
@@ -10482,7 +10482,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c40cfa9ac2f554a707ff68c7709ae436349041bf00ad2f42811ccbe8ba842462
-      lastVerified: '2026-03-06T11:53:37.457Z'
+      lastVerified: '2026-03-11T02:00:27.575Z'
     planning-helper:
       path: .aiox-core/core/code-intel/helpers/planning-helper.js
       layer: L1
@@ -10507,12 +10507,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2edcf275122125205a9e737035c8b25efdc4af13e7349ffc10c3ebe8ebe7654d
-      lastVerified: '2026-03-06T11:53:37.458Z'
+      lastVerified: '2026-03-11T02:00:27.575Z'
     qa-helper:
       path: .aiox-core/core/code-intel/helpers/qa-helper.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\code-intel\helpers\qa-helper.js
+      purpose: Entity at .aiox-core/core/code-intel/helpers/qa-helper.js
       keywords:
         - qa
         - helper
@@ -10527,12 +10527,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ca069dad294224dd5c3369826fb39d5c24287d49d74360049f8bbc55f190eeda
-      lastVerified: '2026-03-06T11:53:37.458Z'
+      lastVerified: '2026-03-11T02:00:27.575Z'
     story-helper:
       path: .aiox-core/core/code-intel/helpers/story-helper.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\code-intel\helpers\story-helper.js
+      purpose: Entity at .aiox-core/core/code-intel/helpers/story-helper.js
       keywords:
         - story
         - helper
@@ -10547,12 +10547,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:778466253ac66103ebc3b1caf71f44b06a0d5fb3d39fe8d3d473dd4bc73fefc6
-      lastVerified: '2026-03-06T11:53:37.458Z'
+      lastVerified: '2026-03-11T02:00:27.575Z'
     code-graph-provider:
       path: .aiox-core/core/code-intel/providers/code-graph-provider.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\code-intel\providers\code-graph-provider.js
+      purpose: Entity at .aiox-core/core/code-intel/providers/code-graph-provider.js
       keywords:
         - code
         - graph
@@ -10569,12 +10569,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:83251871bc2d65864a4e148e3921408e74662a2739bfbd12395a2daaa4bde9a0
-      lastVerified: '2026-03-06T11:53:37.459Z'
+      lastVerified: '2026-03-11T02:00:27.575Z'
     provider-interface:
       path: .aiox-core/core/code-intel/providers/provider-interface.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\code-intel\providers\provider-interface.js
+      purpose: Entity at .aiox-core/core/code-intel/providers/provider-interface.js
       keywords:
         - provider
         - interface
@@ -10590,7 +10590,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:74df278e31f240ee4499f10989c4b6f8c7c7cba6e8f317cb433a23fd6693c487
-      lastVerified: '2026-03-06T11:53:37.459Z'
+      lastVerified: '2026-03-11T02:00:27.575Z'
     registry-provider:
       path: .aiox-core/core/code-intel/providers/registry-provider.js
       layer: L1
@@ -10612,12 +10612,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d7173384a1c0ff33326d1f45ee3fba0a6cbf7d7fe0476c1a60fda5442f5486e3
-      lastVerified: '2026-03-06T11:53:37.459Z'
+      lastVerified: '2026-03-11T02:00:27.576Z'
     agent-memory:
       path: .aiox-core/core/doctor/checks/agent-memory.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\checks\agent-memory.js
+      purpose: Entity at .aiox-core/core/doctor/checks/agent-memory.js
       keywords:
         - agent
         - memory
@@ -10632,12 +10632,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:08d5d685e4fdaaedf081020229844f4a58c9fd00244e4c37eb5b3fd78f4feb61
-      lastVerified: '2026-03-06T11:53:37.459Z'
+      lastVerified: '2026-03-11T02:00:27.576Z'
     claude-md:
       path: .aiox-core/core/doctor/checks/claude-md.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\checks\claude-md.js
+      purpose: Entity at .aiox-core/core/doctor/checks/claude-md.js
       keywords:
         - claude
         - md
@@ -10651,12 +10651,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:88162c90d0b671c1a924fd6e18aeeb0fb229d19fb4204c12551feafbdef5d01d
-      lastVerified: '2026-03-06T11:53:37.459Z'
+      lastVerified: '2026-03-11T02:00:27.576Z'
     code-intel:
       path: .aiox-core/core/doctor/checks/code-intel.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\checks\code-intel.js
+      purpose: Entity at .aiox-core/core/doctor/checks/code-intel.js
       keywords:
         - code
         - intel
@@ -10681,12 +10681,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ed69815b54a686ef1076964f1eb667059712d35487fc2f1785a9897f59436fb
-      lastVerified: '2026-03-06T11:53:37.459Z'
+      lastVerified: '2026-03-11T02:00:27.576Z'
     commands-count:
       path: .aiox-core/core/doctor/checks/commands-count.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\checks\commands-count.js
+      purpose: Entity at .aiox-core/core/doctor/checks/commands-count.js
       keywords:
         - commands
         - count
@@ -10700,12 +10700,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:eb3be16a561337ed64883ba578df1cb74790fcb6edee47bfd309d2480e66fbee
-      lastVerified: '2026-03-06T11:53:37.460Z'
+      lastVerified: '2026-03-11T02:00:27.576Z'
     core-config:
       path: .aiox-core/core/doctor/checks/core-config.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\checks\core-config.js
+      purpose: Entity at .aiox-core/core/doctor/checks/core-config.js
       keywords:
         - core
         - config
@@ -10719,12 +10719,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:53ddc48091f64805c100d08fb8cac5d1b4d74e844c8cfcde122f881a428b650b
-      lastVerified: '2026-03-06T11:53:37.460Z'
+      lastVerified: '2026-03-11T02:00:27.576Z'
     entity-registry:
       path: .aiox-core/core/doctor/checks/entity-registry.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\checks\entity-registry.js
+      purpose: Entity at .aiox-core/core/doctor/checks/entity-registry.js
       keywords:
         - entity
         - registry
@@ -10738,12 +10738,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bed5f0881102fecf77e7a4f990a1363b840422701f736e806c1c69908acae0aa
-      lastVerified: '2026-03-06T11:53:37.460Z'
+      lastVerified: '2026-03-11T02:00:27.576Z'
     git-hooks:
       path: .aiox-core/core/doctor/checks/git-hooks.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\checks\git-hooks.js
+      purpose: Entity at .aiox-core/core/doctor/checks/git-hooks.js
       keywords:
         - git
         - hooks
@@ -10757,12 +10757,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3fe9411a64265c581952f40044b70cc21b324773f54e4b902e4ce390c976fa2f
-      lastVerified: '2026-03-06T11:53:37.473Z'
+      lastVerified: '2026-03-11T02:00:27.576Z'
     graph-dashboard:
       path: .aiox-core/core/doctor/checks/graph-dashboard.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\checks\graph-dashboard.js
+      purpose: Entity at .aiox-core/core/doctor/checks/graph-dashboard.js
       keywords:
         - graph
         - dashboard
@@ -10776,12 +10776,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c4a16ab33117169aac7e4e29d841eec4f28a076f6d93fb9d872749831a14a17
-      lastVerified: '2026-03-06T11:53:37.491Z'
+      lastVerified: '2026-03-11T02:00:27.576Z'
     hooks-claude-count:
       path: .aiox-core/core/doctor/checks/hooks-claude-count.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\checks\hooks-claude-count.js
+      purpose: Entity at .aiox-core/core/doctor/checks/hooks-claude-count.js
       keywords:
         - hooks
         - claude
@@ -10796,12 +10796,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:026ddf0248819b89b1147e0876a2934e38e0113d3c6380d68a752d432060e7ec
-      lastVerified: '2026-03-06T11:53:37.491Z'
+      lastVerified: '2026-03-11T02:00:27.576Z'
     ide-sync:
       path: .aiox-core/core/doctor/checks/ide-sync.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\checks\ide-sync.js
+      purpose: Entity at .aiox-core/core/doctor/checks/ide-sync.js
       keywords:
         - ide
         - sync
@@ -10815,12 +10815,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0941feb55b6dc5d3afde7e4e9ef11afbc1d9781197c9e52630056fab1c1ebea2
-      lastVerified: '2026-03-06T11:53:37.491Z'
+      lastVerified: '2026-03-11T02:00:27.576Z'
     node-version:
       path: .aiox-core/core/doctor/checks/node-version.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\checks\node-version.js
+      purpose: Entity at .aiox-core/core/doctor/checks/node-version.js
       keywords:
         - node
         - version
@@ -10834,12 +10834,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9e8bd100affa46131ac495c1e60ce87c88bbe879d459601a502589824d1aeac1
-      lastVerified: '2026-03-06T11:53:37.492Z'
+      lastVerified: '2026-03-11T02:00:27.576Z'
     npm-packages:
       path: .aiox-core/core/doctor/checks/npm-packages.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\checks\npm-packages.js
+      purpose: Entity at .aiox-core/core/doctor/checks/npm-packages.js
       keywords:
         - npm
         - packages
@@ -10853,12 +10853,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c54cb15dc3492ec50b4edc4733ecc5c41d5a00536aed87a5a5d815f472ee9f7
-      lastVerified: '2026-03-06T11:53:37.492Z'
+      lastVerified: '2026-03-11T02:00:27.576Z'
     rules-files:
       path: .aiox-core/core/doctor/checks/rules-files.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\checks\rules-files.js
+      purpose: Entity at .aiox-core/core/doctor/checks/rules-files.js
       keywords:
         - rules
         - files
@@ -10873,12 +10873,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3996e6343a224021fa684d7930dc99b66469c59cb15d416b0c024a770d722ab6
-      lastVerified: '2026-03-06T11:53:37.492Z'
+      lastVerified: '2026-03-11T02:00:27.576Z'
     settings-json:
       path: .aiox-core/core/doctor/checks/settings-json.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\checks\settings-json.js
+      purpose: Entity at .aiox-core/core/doctor/checks/settings-json.js
       keywords:
         - settings
         - json
@@ -10892,12 +10892,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bd26841b966fcfa003eca6f85416d4f877b9dcfea0e4017df9f2a97c14c33fbb
-      lastVerified: '2026-03-06T11:53:37.492Z'
+      lastVerified: '2026-03-11T02:00:27.576Z'
     skills-count:
       path: .aiox-core/core/doctor/checks/skills-count.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\checks\skills-count.js
+      purpose: Entity at .aiox-core/core/doctor/checks/skills-count.js
       keywords:
         - skills
         - count
@@ -10911,12 +10911,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0b6a19fca1765904c31a33caeeefacbe76df4641154f2f93a8300b4cacce34b8
-      lastVerified: '2026-03-06T11:53:37.493Z'
+      lastVerified: '2026-03-11T02:00:27.577Z'
     json:
       path: .aiox-core/core/doctor/formatters/json.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\doctor\formatters\json.js
+      purpose: Entity at .aiox-core/core/doctor/formatters/json.js
       keywords:
         - json
       usedBy: []
@@ -10929,7 +10929,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ea3f28f168f48ca3002661210932846f0e82c3dd9261d5e9115036f67e5a1ea4
-      lastVerified: '2026-03-06T11:53:37.493Z'
+      lastVerified: '2026-03-11T02:00:27.577Z'
     text:
       path: .aiox-core/core/doctor/formatters/text.js
       layer: L1
@@ -10947,12 +10947,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bd582b33c2d915516798627351c46d6d8edb56f655bb91037dfdbac159de77eb
-      lastVerified: '2026-03-06T11:53:37.493Z'
+      lastVerified: '2026-03-11T02:00:27.577Z'
     code-intel-source:
       path: .aiox-core/core/graph-dashboard/data-sources/code-intel-source.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\graph-dashboard\data-sources\code-intel-source.js
+      purpose: Entity at .aiox-core/core/graph-dashboard/data-sources/code-intel-source.js
       keywords:
         - code
         - intel
@@ -10970,12 +10970,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e508d6cbadcd2358fa7756dcaceefbaa510bd89155e036e2cbd386585408ff8f
-      lastVerified: '2026-03-06T11:53:37.494Z'
+      lastVerified: '2026-03-11T02:00:27.577Z'
     metrics-source:
       path: .aiox-core/core/graph-dashboard/data-sources/metrics-source.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\graph-dashboard\data-sources\metrics-source.js
+      purpose: Entity at .aiox-core/core/graph-dashboard/data-sources/metrics-source.js
       keywords:
         - metrics
         - source
@@ -10991,12 +10991,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b1e4027f82350760b67ea8f58e04a5e739f87f010838487043e29dab7301ae9e
-      lastVerified: '2026-03-06T11:53:37.494Z'
+      lastVerified: '2026-03-11T02:00:27.577Z'
     registry-source:
       path: .aiox-core/core/graph-dashboard/data-sources/registry-source.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\graph-dashboard\data-sources\registry-source.js
+      purpose: Entity at .aiox-core/core/graph-dashboard/data-sources/registry-source.js
       keywords:
         - registry
         - source
@@ -11012,12 +11012,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:32d2a4bd5b102823d5933e5f9a648ae7e647cb1918092063161fed80d32b844b
-      lastVerified: '2026-03-06T11:53:37.494Z'
+      lastVerified: '2026-03-11T02:00:27.577Z'
     dot-formatter:
       path: .aiox-core/core/graph-dashboard/formatters/dot-formatter.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\graph-dashboard\formatters\dot-formatter.js
+      purpose: Entity at .aiox-core/core/graph-dashboard/formatters/dot-formatter.js
       keywords:
         - dot
         - formatter
@@ -11032,12 +11032,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c369343f2b617a730951eb137d5ba74087bfd9f5dddbbf439e1fc2f87117d7a
-      lastVerified: '2026-03-06T11:53:37.494Z'
+      lastVerified: '2026-03-11T02:00:27.577Z'
     html-formatter:
       path: .aiox-core/core/graph-dashboard/formatters/html-formatter.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\graph-dashboard\formatters\html-formatter.js
+      purpose: Entity at .aiox-core/core/graph-dashboard/formatters/html-formatter.js
       keywords:
         - html
         - formatter
@@ -11052,12 +11052,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:81bfd3d61234cf17a0d7e25fbcdb86ddddc3f911e25a95f21604f7fe1d8d6a84
-      lastVerified: '2026-03-06T11:53:37.495Z'
+      lastVerified: '2026-03-11T02:00:27.578Z'
     json-formatter:
       path: .aiox-core/core/graph-dashboard/formatters/json-formatter.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\graph-dashboard\formatters\json-formatter.js
+      purpose: Entity at .aiox-core/core/graph-dashboard/formatters/json-formatter.js
       keywords:
         - json
         - formatter
@@ -11072,12 +11072,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0544ec384f716130a5141edc7ad6733dccd82b86e37fc1606f1120b0037c3f8d
-      lastVerified: '2026-03-06T11:53:37.495Z'
+      lastVerified: '2026-03-11T02:00:27.578Z'
     mermaid-formatter:
       path: .aiox-core/core/graph-dashboard/formatters/mermaid-formatter.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\graph-dashboard\formatters\mermaid-formatter.js
+      purpose: Entity at .aiox-core/core/graph-dashboard/formatters/mermaid-formatter.js
       keywords:
         - mermaid
         - formatter
@@ -11092,12 +11092,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a6a5361cb7cdce2632d348ad32c659a3c383471fd338e76d578cc83c0888b2d7
-      lastVerified: '2026-03-06T11:53:37.495Z'
+      lastVerified: '2026-03-11T02:00:27.578Z'
     stats-renderer:
       path: .aiox-core/core/graph-dashboard/renderers/stats-renderer.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\graph-dashboard\renderers\stats-renderer.js
+      purpose: Entity at .aiox-core/core/graph-dashboard/renderers/stats-renderer.js
       keywords:
         - stats
         - renderer
@@ -11112,12 +11112,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:375f904e8592a546f594f63b2c717db03db500e7070372db6de5524ac74ba474
-      lastVerified: '2026-03-06T11:53:37.495Z'
+      lastVerified: '2026-03-11T02:00:27.578Z'
     status-renderer:
       path: .aiox-core/core/graph-dashboard/renderers/status-renderer.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\graph-dashboard\renderers\status-renderer.js
+      purpose: Entity at .aiox-core/core/graph-dashboard/renderers/status-renderer.js
       keywords:
         - status
         - renderer
@@ -11132,12 +11132,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8e971ae267a570fac96782ee2d1ddb7787cc1efde9e17a2f23c9261ae0286acb
-      lastVerified: '2026-03-06T11:53:37.496Z'
+      lastVerified: '2026-03-11T02:00:27.578Z'
     tree-renderer:
       path: .aiox-core/core/graph-dashboard/renderers/tree-renderer.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\graph-dashboard\renderers\tree-renderer.js
+      purpose: Entity at .aiox-core/core/graph-dashboard/renderers/tree-renderer.js
       keywords:
         - tree
         - renderer
@@ -11152,12 +11152,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:067bb5aefdfff0442a6132b89cec9ac61e84c9a9295097209a71c839978cef10
-      lastVerified: '2026-03-06T11:53:37.496Z'
+      lastVerified: '2026-03-11T02:00:27.578Z'
     backup-manager:
       path: .aiox-core/core/health-check/healers/backup-manager.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\health-check\healers\backup-manager.js
+      purpose: Entity at .aiox-core/core/health-check/healers/backup-manager.js
       keywords:
         - backup
         - manager
@@ -11171,12 +11171,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2827c219b84ef9a133a057c7b15b752a7681807711de47c0807b87b16973ffb1
-      lastVerified: '2026-03-06T11:53:37.496Z'
+      lastVerified: '2026-03-11T02:00:27.578Z'
     console:
       path: .aiox-core/core/health-check/reporters/console.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\health-check\reporters\console.js
+      purpose: Entity at .aiox-core/core/health-check/reporters/console.js
       keywords:
         - console
       usedBy: []
@@ -11190,7 +11190,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:573f28a6c9c2a4087ccd349398f47351aa9a752c92a1f2e4a3c3f396682d5516
-      lastVerified: '2026-03-06T11:53:37.496Z'
+      lastVerified: '2026-03-11T02:00:27.578Z'
     markdown:
       path: .aiox-core/core/health-check/reporters/markdown.js
       layer: L1
@@ -11209,7 +11209,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9bc17bd3bc540f60bd3ea102586cd1e04b8b7ae10e8980fad75f185eec29ad51
-      lastVerified: '2026-03-06T11:53:37.497Z'
+      lastVerified: '2026-03-11T02:00:27.579Z'
     g1-epic-creation:
       path: .aiox-core/core/ids/gates/g1-epic-creation.js
       layer: L1
@@ -11229,7 +11229,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ba7c342b176f38f2c80cb141fe820b9a963a1966e33fef3a4ec568363b011c5f
-      lastVerified: '2026-03-06T11:53:37.497Z'
+      lastVerified: '2026-03-11T02:00:27.579Z'
     g2-story-creation:
       path: .aiox-core/core/ids/gates/g2-story-creation.js
       layer: L1
@@ -11249,7 +11249,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cb6312358a3d1c92a0094d25861e0747d0c1d63ffb08c82d8ed0a115a73ca1c5
-      lastVerified: '2026-03-06T11:53:37.497Z'
+      lastVerified: '2026-03-11T02:00:27.579Z'
     g3-story-validation:
       path: .aiox-core/core/ids/gates/g3-story-validation.js
       layer: L1
@@ -11269,7 +11269,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7b24912d9e80c5ca52d11950b133df6782b1c0c0914127ccef0dc8384026b4ae
-      lastVerified: '2026-03-06T11:53:37.498Z'
+      lastVerified: '2026-03-11T02:00:27.579Z'
     g4-dev-context:
       path: .aiox-core/core/ids/gates/g4-dev-context.js
       layer: L1
@@ -11289,12 +11289,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a0fdd59eb0c3a8a59862397b1af5af84971ce051929ae9d32361b7ca99a444fb
-      lastVerified: '2026-03-06T11:53:37.498Z'
+      lastVerified: '2026-03-11T02:00:27.579Z'
     active-modules.verify:
       path: .aiox-core/core/memory/__tests__/active-modules.verify.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\memory\__tests__\active-modules.verify.js
+      purpose: Entity at .aiox-core/core/memory/__tests__/active-modules.verify.js
       keywords:
         - active
         - modules
@@ -11311,12 +11311,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:895ec75f6a303edf4cffa0ab7adbb8a4876f62626cc0d7178420efd5758f21a9
-      lastVerified: '2026-03-06T11:53:37.498Z'
+      lastVerified: '2026-03-11T02:00:27.580Z'
     epic-3-executor:
       path: .aiox-core/core/orchestration/executors/epic-3-executor.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\executors\epic-3-executor.js
+      purpose: Entity at .aiox-core/core/orchestration/executors/epic-3-executor.js
       keywords:
         - epic
         - executor
@@ -11331,7 +11331,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1cadb0544660cead45f940839a0bec51f6a8ef143b7ab1dc006b89c4abb0c1c0
-      lastVerified: '2026-03-06T11:53:37.498Z'
+      lastVerified: '2026-03-11T02:00:27.580Z'
     epic-4-executor:
       path: .aiox-core/core/orchestration/executors/epic-4-executor.js
       layer: L1
@@ -11356,12 +11356,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b2f8944114839f9b02a0b46d037fa64e2d1584d3aab6ff74537e32a16b6a793d
-      lastVerified: '2026-03-06T11:53:37.498Z'
+      lastVerified: '2026-03-11T02:00:27.580Z'
     epic-5-executor:
       path: .aiox-core/core/orchestration/executors/epic-5-executor.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\executors\epic-5-executor.js
+      purpose: Entity at .aiox-core/core/orchestration/executors/epic-5-executor.js
       keywords:
         - epic
         - executor
@@ -11378,12 +11378,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d334dc728dec74fdb744f14d83f9fd2b7dabc46bcaa0d2dfae482cc131e0107b
-      lastVerified: '2026-03-06T11:53:37.499Z'
+      lastVerified: '2026-03-11T02:00:27.580Z'
     epic-6-executor:
       path: .aiox-core/core/orchestration/executors/epic-6-executor.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\executors\epic-6-executor.js
+      purpose: Entity at .aiox-core/core/orchestration/executors/epic-6-executor.js
       keywords:
         - epic
         - executor
@@ -11399,12 +11399,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1bbc14e8236f87c074db46833345a724ee5056a28b97fbb2528d4eedd350ab12
-      lastVerified: '2026-03-06T11:53:37.499Z'
+      lastVerified: '2026-03-11T02:00:27.580Z'
     epic-executor:
       path: .aiox-core/core/orchestration/executors/epic-executor.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\orchestration\executors\epic-executor.js
+      purpose: Entity at .aiox-core/core/orchestration/executors/epic-executor.js
       keywords:
         - epic
         - executor
@@ -11422,12 +11422,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f2b20cd8cc4f3473bfcc7afdc0bc20e21665bab92274433ede58eabc4691a6b9
-      lastVerified: '2026-03-06T11:53:37.499Z'
+      lastVerified: '2026-03-11T02:00:27.580Z'
     permission-mode.test:
       path: .aiox-core/core/permissions/__tests__/permission-mode.test.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\permissions\__tests__\permission-mode.test.js
+      purpose: Entity at .aiox-core/core/permissions/__tests__/permission-mode.test.js
       keywords:
         - permission
         - mode
@@ -11444,12 +11444,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8c8a48c75933a7bf3cf4588f8e4af3911cbb6b67fb07fa526a79bada8949ce2c
-      lastVerified: '2026-03-06T11:53:37.499Z'
+      lastVerified: '2026-03-11T02:00:27.580Z'
     context-builder:
       path: .aiox-core/core/synapse/context/context-builder.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\context\context-builder.js
+      purpose: Entity at .aiox-core/core/synapse/context/context-builder.js
       keywords:
         - context
         - builder
@@ -11463,12 +11463,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:121cd0a1df8a44098831cd4335536e8facf4e65b8aec48f4ce9c2d432dc6252a
-      lastVerified: '2026-03-06T11:53:37.500Z'
+      lastVerified: '2026-03-11T02:00:27.580Z'
     context-tracker:
       path: .aiox-core/core/synapse/context/context-tracker.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\context\context-tracker.js
+      purpose: Entity at .aiox-core/core/synapse/context/context-tracker.js
       keywords:
         - context
         - tracker
@@ -11483,12 +11483,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:48e94db7b1778dedecc8eae829139579ad7778ff47668597ebe766610696553f
-      lastVerified: '2026-03-06T11:53:37.500Z'
+      lastVerified: '2026-03-11T02:00:27.580Z'
     report-formatter:
       path: .aiox-core/core/synapse/diagnostics/report-formatter.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\diagnostics\report-formatter.js
+      purpose: Entity at .aiox-core/core/synapse/diagnostics/report-formatter.js
       keywords:
         - report
         - formatter
@@ -11503,12 +11503,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e6d26c1cd9910d8311306111cc3fef3a4bb1c4bd6b1ef0e4bb8f407da9baf7f1
-      lastVerified: '2026-03-06T11:53:37.500Z'
+      lastVerified: '2026-03-11T02:00:27.581Z'
     synapse-diagnostics:
       path: .aiox-core/core/synapse/diagnostics/synapse-diagnostics.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\diagnostics\synapse-diagnostics.js
+      purpose: Entity at .aiox-core/core/synapse/diagnostics/synapse-diagnostics.js
       keywords:
         - synapse
         - diagnostics
@@ -11529,12 +11529,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de9dffce0e380637027cbd64b062d3eeffc37e42a84a337e5758fbef39fe3a00
-      lastVerified: '2026-03-06T11:53:37.500Z'
+      lastVerified: '2026-03-11T02:00:27.581Z'
     domain-loader:
       path: .aiox-core/core/synapse/domain/domain-loader.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\domain\domain-loader.js
+      purpose: Entity at .aiox-core/core/synapse/domain/domain-loader.js
       keywords:
         - domain
         - loader
@@ -11557,12 +11557,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:af788f9da956b89eef1e5eb4ef4efdf05ca758c8969a2c375f568119495ebc05
-      lastVerified: '2026-03-06T11:53:37.500Z'
+      lastVerified: '2026-03-11T02:00:27.581Z'
     l0-constitution:
       path: .aiox-core/core/synapse/layers/l0-constitution.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\layers\l0-constitution.js
+      purpose: Entity at .aiox-core/core/synapse/layers/l0-constitution.js
       keywords:
         - l0
         - constitution
@@ -11578,12 +11578,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2123a6a44915aaac2a6bbd26c67c285c9d1e12b50fe42a8ada668306b07d1c4a
-      lastVerified: '2026-03-06T11:53:37.501Z'
+      lastVerified: '2026-03-11T02:00:27.581Z'
     l1-global:
       path: .aiox-core/core/synapse/layers/l1-global.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\layers\l1-global.js
+      purpose: Entity at .aiox-core/core/synapse/layers/l1-global.js
       keywords:
         - l1
         - global
@@ -11599,12 +11599,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:21f6969e6d64e9a85c876be6799db4ca7d090f0009057f4a06ead8da12392d45
-      lastVerified: '2026-03-06T11:53:37.501Z'
+      lastVerified: '2026-03-11T02:00:27.581Z'
     l2-agent:
       path: .aiox-core/core/synapse/layers/l2-agent.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\layers\l2-agent.js
+      purpose: Entity at .aiox-core/core/synapse/layers/l2-agent.js
       keywords:
         - l2
         - agent
@@ -11620,12 +11620,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a8677dc58ae7927c5292a4b52883bbc905c8112573b8b8631f0b8bc01ea2b6e6
-      lastVerified: '2026-03-06T11:53:37.501Z'
+      lastVerified: '2026-03-11T02:00:27.581Z'
     l3-workflow:
       path: .aiox-core/core/synapse/layers/l3-workflow.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\layers\l3-workflow.js
+      purpose: Entity at .aiox-core/core/synapse/layers/l3-workflow.js
       keywords:
         - l3
         - workflow
@@ -11641,12 +11641,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:496cbd71d7dac9c1daa534ffac45c622d0c032f334fedf493e9322a565b2b181
-      lastVerified: '2026-03-06T11:53:37.501Z'
+      lastVerified: '2026-03-11T02:00:27.581Z'
     l4-task:
       path: .aiox-core/core/synapse/layers/l4-task.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\layers\l4-task.js
+      purpose: Entity at .aiox-core/core/synapse/layers/l4-task.js
       keywords:
         - l4
         - task
@@ -11661,12 +11661,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:30df70c04b16e3aff95899211ef6ae3d9f0a8097ebdc7de92599fc6cb792e5f0
-      lastVerified: '2026-03-06T11:53:37.501Z'
+      lastVerified: '2026-03-11T02:00:27.581Z'
     l5-squad:
       path: .aiox-core/core/synapse/layers/l5-squad.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\layers\l5-squad.js
+      purpose: Entity at .aiox-core/core/synapse/layers/l5-squad.js
       keywords:
         - l5
         - squad
@@ -11682,12 +11682,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fabc2bcb01543ef7d249631da02297d67e42f4d0fcf9e159b79564793ce8f7bb
-      lastVerified: '2026-03-06T11:53:37.501Z'
+      lastVerified: '2026-03-11T02:00:27.581Z'
     l6-keyword:
       path: .aiox-core/core/synapse/layers/l6-keyword.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\layers\l6-keyword.js
+      purpose: Entity at .aiox-core/core/synapse/layers/l6-keyword.js
       keywords:
         - l6
         - keyword
@@ -11703,12 +11703,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8e5405999a2ce2f3ca4e62e863cf702ba27448914241f5eb8f02760bc7477523
-      lastVerified: '2026-03-06T11:53:37.501Z'
+      lastVerified: '2026-03-11T02:00:27.581Z'
     l7-star-command:
       path: .aiox-core/core/synapse/layers/l7-star-command.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\layers\l7-star-command.js
+      purpose: Entity at .aiox-core/core/synapse/layers/l7-star-command.js
       keywords:
         - l7
         - star
@@ -11725,12 +11725,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3b8372ac1c51830c1ef560b1012b112a3559651b0750e42f2037f7fe9e6787d6
-      lastVerified: '2026-03-06T11:53:37.502Z'
+      lastVerified: '2026-03-11T02:00:27.581Z'
     layer-processor:
       path: .aiox-core/core/synapse/layers/layer-processor.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\layers\layer-processor.js
+      purpose: Entity at .aiox-core/core/synapse/layers/layer-processor.js
       keywords:
         - layer
         - processor
@@ -11752,12 +11752,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73cb0e5b4bada80d8e256009004679e483792077fac4358c6466cd77136f79fa
-      lastVerified: '2026-03-06T11:53:37.502Z'
+      lastVerified: '2026-03-11T02:00:27.581Z'
     memory-bridge:
       path: .aiox-core/core/synapse/memory/memory-bridge.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\memory\memory-bridge.js
+      purpose: Entity at .aiox-core/core/synapse/memory/memory-bridge.js
       keywords:
         - memory
         - bridge
@@ -11773,12 +11773,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:820875f97ceea80fc6402c0dab1706cfe58de527897b22dea68db40b0d6ec368
-      lastVerified: '2026-03-06T11:53:37.502Z'
+      lastVerified: '2026-03-11T02:00:27.581Z'
     synapse-memory-provider:
       path: .aiox-core/core/synapse/memory/synapse-memory-provider.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\memory\synapse-memory-provider.js
+      purpose: Entity at .aiox-core/core/synapse/memory/synapse-memory-provider.js
       keywords:
         - synapse
         - memory
@@ -11796,12 +11796,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5d613d1fac7ee82c49a3f03b38735fd3cabfe87dd868494672ddfef300ea3145
-      lastVerified: '2026-03-06T11:53:37.502Z'
+      lastVerified: '2026-03-11T02:00:27.581Z'
     formatter:
       path: .aiox-core/core/synapse/output/formatter.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\output\formatter.js
+      purpose: Entity at .aiox-core/core/synapse/output/formatter.js
       keywords:
         - formatter
       usedBy: []
@@ -11815,12 +11815,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fe4f6c2f6091defb6af66dad71db0640f919b983111087f8cc5821e3d44ca864
-      lastVerified: '2026-03-06T11:53:37.502Z'
+      lastVerified: '2026-03-11T02:00:27.582Z'
     generate-constitution:
       path: .aiox-core/core/synapse/scripts/generate-constitution.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\scripts\generate-constitution.js
+      purpose: Entity at .aiox-core/core/synapse/scripts/generate-constitution.js
       keywords:
         - generate
         - constitution
@@ -11834,12 +11834,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9010d6b34667c96602b76baa1857f0629c797d911b7c42dc11414b007e5e2b91
-      lastVerified: '2026-03-06T11:53:37.503Z'
+      lastVerified: '2026-03-11T02:00:27.582Z'
     atomic-write:
       path: .aiox-core/core/synapse/utils/atomic-write.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\utils\atomic-write.js
+      purpose: Entity at .aiox-core/core/synapse/utils/atomic-write.js
       keywords:
         - atomic
         - write
@@ -11855,12 +11855,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:efeef0fbcebb184df5b79f4ba4b4b7fe274c3ba7d1c705ce1af92628e920bd8b
-      lastVerified: '2026-03-06T11:53:37.503Z'
+      lastVerified: '2026-03-11T02:00:27.582Z'
     paths:
       path: .aiox-core/core/synapse/utils/paths.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\utils\paths.js
+      purpose: Entity at .aiox-core/core/synapse/utils/paths.js
       keywords:
         - paths
       usedBy: []
@@ -11873,12 +11873,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bf8cf93c1a16295e7de055bee292e2778a152b6e7d6c648dbc054a4b04dffc10
-      lastVerified: '2026-03-06T11:53:37.503Z'
+      lastVerified: '2026-03-11T02:00:27.582Z'
     tokens:
       path: .aiox-core/core/synapse/utils/tokens.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\utils\tokens.js
+      purpose: Entity at .aiox-core/core/synapse/utils/tokens.js
       keywords:
         - tokens
       usedBy:
@@ -11894,7 +11894,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3b927daec51d0a791f3fe4ef9aafc362773450e7cf50eb4b6d8ae9011d70df9a
-      lastVerified: '2026-03-06T11:53:37.503Z'
+      lastVerified: '2026-03-11T02:00:27.582Z'
     build-config:
       path: .aiox-core/core/health-check/checks/deployment/build-config.js
       layer: L1
@@ -11914,7 +11914,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2be009177bf26ca7e1ac2f1f6bc973e409ba1feac83906c96cab0b70e60c1af7
-      lastVerified: '2026-03-06T11:53:37.503Z'
+      lastVerified: '2026-03-11T02:00:27.582Z'
     ci-config:
       path: .aiox-core/core/health-check/checks/deployment/ci-config.js
       layer: L1
@@ -11934,7 +11934,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ad8399d53c01cb989cc17e60a3547aec2a0c31ba62d2664ef47482ccd0c6b144
-      lastVerified: '2026-03-06T11:53:37.503Z'
+      lastVerified: '2026-03-11T02:00:27.582Z'
     deployment-readiness:
       path: .aiox-core/core/health-check/checks/deployment/deployment-readiness.js
       layer: L1
@@ -11954,7 +11954,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7c4706e829968ddae47f9f372140c36fd96e3148eec5dade3e1d5b7c3b276d38
-      lastVerified: '2026-03-06T11:53:37.504Z'
+      lastVerified: '2026-03-11T02:00:27.582Z'
     docker-config:
       path: .aiox-core/core/health-check/checks/deployment/docker-config.js
       layer: L1
@@ -11974,7 +11974,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a4558144220078fcc203ae662756df4f0715ffe56d94853996f01a7100a8b11a
-      lastVerified: '2026-03-06T11:53:37.504Z'
+      lastVerified: '2026-03-11T02:00:27.582Z'
     env-file:
       path: .aiox-core/core/health-check/checks/deployment/env-file.js
       layer: L1
@@ -11994,7 +11994,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2864d9210c0fcf58ac11016077ac24c23edd1dbb570ace46c1762de5f0d4ebae
-      lastVerified: '2026-03-06T11:53:37.504Z'
+      lastVerified: '2026-03-11T02:00:27.582Z'
     disk-space:
       path: .aiox-core/core/health-check/checks/local/disk-space.js
       layer: L1
@@ -12014,7 +12014,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa400f15c9bc1a61233472639bb44b6a5f4785fbe10690f8254e54edffb7dead
-      lastVerified: '2026-03-06T11:53:37.504Z'
+      lastVerified: '2026-03-11T02:00:27.582Z'
     environment-vars:
       path: .aiox-core/core/health-check/checks/local/environment-vars.js
       layer: L1
@@ -12034,7 +12034,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4da9aefdf717e267d5a0e60408b866f49ca5f49cde0e6b1fb14050046a9458d0
-      lastVerified: '2026-03-06T11:53:37.505Z'
+      lastVerified: '2026-03-11T02:00:27.582Z'
     git-install:
       path: .aiox-core/core/health-check/checks/local/git-install.js
       layer: L1
@@ -12054,7 +12054,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f17dd15a5696de04b6530f6eb99d1c29d2a19486c7220be42f87712cb0858df2
-      lastVerified: '2026-03-06T11:53:37.505Z'
+      lastVerified: '2026-03-11T02:00:27.582Z'
     ide-detection:
       path: .aiox-core/core/health-check/checks/local/ide-detection.js
       layer: L1
@@ -12074,7 +12074,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:632ccbc44b3cd4306ba2391e6cea8e91e20ccedd62bb421f46ca33cd7daa7230
-      lastVerified: '2026-03-06T11:53:37.505Z'
+      lastVerified: '2026-03-11T02:00:27.582Z'
     memory:
       path: .aiox-core/core/health-check/checks/local/memory.js
       layer: L1
@@ -12094,7 +12094,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e959adc1f7f41ab5054bb8786967722d0364700b8e5139f94f5181a0d3dfc819
-      lastVerified: '2026-03-06T11:53:37.505Z'
+      lastVerified: '2026-03-11T02:00:27.582Z'
     network:
       path: .aiox-core/core/health-check/checks/local/network.js
       layer: L1
@@ -12113,7 +12113,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:77915bfd3f27b8f02c3eb8bb4d8c37f1e34541766633dde3b0d509b223435c98
-      lastVerified: '2026-03-06T11:53:37.506Z'
+      lastVerified: '2026-03-11T02:00:27.582Z'
     npm-install:
       path: .aiox-core/core/health-check/checks/local/npm-install.js
       layer: L1
@@ -12133,7 +12133,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:592a7ed7468d4f5dc28c5261a363035545b84d4b32c2601bd52075e02f0cbdc2
-      lastVerified: '2026-03-06T11:53:37.506Z'
+      lastVerified: '2026-03-11T02:00:27.583Z'
     shell-environment:
       path: .aiox-core/core/health-check/checks/local/shell-environment.js
       layer: L1
@@ -12153,7 +12153,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c98b9d4f3636d8c229c8031ed5126fc0fe35b6b740af320e21e05aaf1b5c402
-      lastVerified: '2026-03-06T11:53:37.506Z'
+      lastVerified: '2026-03-11T02:00:27.583Z'
     agent-config:
       path: .aiox-core/core/health-check/checks/project/agent-config.js
       layer: L1
@@ -12173,7 +12173,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0195e2b95c94fcea2c7fae5636664e24657e182a0b3d8e95ce4ccf7b15809de2
-      lastVerified: '2026-03-06T11:53:37.506Z'
+      lastVerified: '2026-03-11T02:00:27.583Z'
     aiox-directory:
       path: .aiox-core/core/health-check/checks/project/aiox-directory.js
       layer: L1
@@ -12193,7 +12193,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:332d298d2ac7eb89ca6f3471f3a0970175f80c9a8735582af2ad5eb3331a8523
-      lastVerified: '2026-03-06T11:53:37.506Z'
+      lastVerified: '2026-03-11T02:00:27.583Z'
     dependencies:
       path: .aiox-core/core/health-check/checks/project/dependencies.js
       layer: L1
@@ -12212,7 +12212,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:70feccca72c7eacd5740ec9b194a80d24f997f5300487633eba9a272cbf749df
-      lastVerified: '2026-03-06T11:53:37.506Z'
+      lastVerified: '2026-03-11T02:00:27.583Z'
     framework-config:
       path: .aiox-core/core/health-check/checks/project/framework-config.js
       layer: L1
@@ -12232,7 +12232,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6ca4088a1b5399d47bc6bd04a4867b807b7003e7a91e35ddafcfcc3996f171fc
-      lastVerified: '2026-03-06T11:53:37.507Z'
+      lastVerified: '2026-03-11T02:00:27.583Z'
     package-json:
       path: .aiox-core/core/health-check/checks/project/package-json.js
       layer: L1
@@ -12252,7 +12252,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ba15da8cc0aaec18e7320db8c4942e04d3c159beb8605fa58a5939d6b77debe3
-      lastVerified: '2026-03-06T11:53:37.507Z'
+      lastVerified: '2026-03-11T02:00:27.583Z'
     task-definitions:
       path: .aiox-core/core/health-check/checks/project/task-definitions.js
       layer: L1
@@ -12272,7 +12272,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:87c6edf9210856e065cd8c491a14b8a016aad429dbae7b0f814ac8b9b3989770
-      lastVerified: '2026-03-06T11:53:37.507Z'
+      lastVerified: '2026-03-11T02:00:27.583Z'
     workflow-dependencies:
       path: .aiox-core/core/health-check/checks/project/workflow-dependencies.js
       layer: L1
@@ -12292,7 +12292,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0eb04100b5c5a56b44b09ab7ca03426e01513c4eb109cc989603484329bc49d9
-      lastVerified: '2026-03-06T11:53:37.507Z'
+      lastVerified: '2026-03-11T02:00:27.583Z'
     branch-protection:
       path: .aiox-core/core/health-check/checks/repository/branch-protection.js
       layer: L1
@@ -12312,7 +12312,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4ee18e46c088005e2f39399dbd80a4fc3e8251baf1c9cbff698d7a941af8416f
-      lastVerified: '2026-03-06T11:53:37.507Z'
+      lastVerified: '2026-03-11T02:00:27.583Z'
     commit-history:
       path: .aiox-core/core/health-check/checks/repository/commit-history.js
       layer: L1
@@ -12332,7 +12332,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ae9d221803f518b0167d71a1c9c2ea5f2392c83d6279e87fbfb3dea95f5845ba
-      lastVerified: '2026-03-06T11:53:37.507Z'
+      lastVerified: '2026-03-11T02:00:27.583Z'
     conflicts:
       path: .aiox-core/core/health-check/checks/repository/conflicts.js
       layer: L1
@@ -12351,7 +12351,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6e9eb41c2a560a8cdc9154475be65ab1a110017d28c15a991af9dca5ebf9515e
-      lastVerified: '2026-03-06T11:53:37.508Z'
+      lastVerified: '2026-03-11T02:00:27.583Z'
     git-repo:
       path: .aiox-core/core/health-check/checks/repository/git-repo.js
       layer: L1
@@ -12371,7 +12371,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:80e1a09561f744772c40575f3f4c0d3a1847fbdf9825fbf616631c5edc67a833
-      lastVerified: '2026-03-06T11:53:37.508Z'
+      lastVerified: '2026-03-11T02:00:27.583Z'
     git-status:
       path: .aiox-core/core/health-check/checks/repository/git-status.js
       layer: L1
@@ -12391,7 +12391,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:aad6379855e89558b43584e8812f04e6a2f771331bbebee116a451f9f4b177d1
-      lastVerified: '2026-03-06T11:53:37.508Z'
+      lastVerified: '2026-03-11T02:00:27.583Z'
     gitignore:
       path: .aiox-core/core/health-check/checks/repository/gitignore.js
       layer: L1
@@ -12410,7 +12410,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bec3b6a29ed336920a55d21f888ce29a4589a421d8a6695d40954ddd49eb4106
-      lastVerified: '2026-03-06T11:53:37.508Z'
+      lastVerified: '2026-03-11T02:00:27.583Z'
     large-files:
       path: .aiox-core/core/health-check/checks/repository/large-files.js
       layer: L1
@@ -12430,7 +12430,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8b1405280dd929c3ba5a47cf0a52bc7fd1f7efbc1ba3e8e4fdcbbcd56fe2a76e
-      lastVerified: '2026-03-06T11:53:37.508Z'
+      lastVerified: '2026-03-11T02:00:27.583Z'
     lockfile-integrity:
       path: .aiox-core/core/health-check/checks/repository/lockfile-integrity.js
       layer: L1
@@ -12450,7 +12450,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6b2d42f1d228f64079929c4d6cdeb9f5ed7217bb390ecfe2e00727c6f59527e0
-      lastVerified: '2026-03-06T11:53:37.509Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
     api-endpoints:
       path: .aiox-core/core/health-check/checks/services/api-endpoints.js
       layer: L1
@@ -12470,7 +12470,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2233d5af1610d5553353e21e720c9cb0ecfbb968ab605d14896705458ae7ca55
-      lastVerified: '2026-03-06T11:53:37.509Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
     claude-code:
       path: .aiox-core/core/health-check/checks/services/claude-code.js
       layer: L1
@@ -12490,7 +12490,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:69af55e5ad7e941e5e6d0a9e3aab7a4e6c2aaec491aa5955fd6c23be432b5ab7
-      lastVerified: '2026-03-06T11:53:37.509Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
     gemini-cli:
       path: .aiox-core/core/health-check/checks/services/gemini-cli.js
       layer: L1
@@ -12510,7 +12510,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1c37af5d3cd598c44bce4d37c9d90b3c72167841882d6ea3563cc55e2bfa147e
-      lastVerified: '2026-03-06T11:53:37.509Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
     github-cli:
       path: .aiox-core/core/health-check/checks/services/github-cli.js
       layer: L1
@@ -12530,7 +12530,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b94fa0d8917a8506ce80620d390e9344935a700f87bf8034c3c24d12256cd85a
-      lastVerified: '2026-03-06T11:53:37.509Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
     mcp-integration:
       path: .aiox-core/core/health-check/checks/services/mcp-integration.js
       layer: L1
@@ -12550,12 +12550,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:139b29b91e4f2d0abf50b08a272a688036132abba8f71adca9b26c3fb8eb671e
-      lastVerified: '2026-03-06T11:53:37.509Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
     consistency-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/consistency-collector.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\diagnostics\collectors\consistency-collector.js
+      purpose: Entity at .aiox-core/core/synapse/diagnostics/collectors/consistency-collector.js
       keywords:
         - consistency
         - collector
@@ -12570,12 +12570,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:65f4255f87c9900400649dc8b9aedaac4851b5939d93e127778bd93cee99db12
-      lastVerified: '2026-03-06T11:53:37.510Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
     hook-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/hook-collector.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\diagnostics\collectors\hook-collector.js
+      purpose: Entity at .aiox-core/core/synapse/diagnostics/collectors/hook-collector.js
       keywords:
         - hook
         - collector
@@ -12590,12 +12590,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c2cfa1b760bcb05decf5ad05f9159140cbe0cdc6b0f91581790e44d83dc6b660
-      lastVerified: '2026-03-06T11:53:37.510Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
     manifest-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/manifest-collector.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\diagnostics\collectors\manifest-collector.js
+      purpose: Entity at .aiox-core/core/synapse/diagnostics/collectors/manifest-collector.js
       keywords:
         - manifest
         - collector
@@ -12611,7 +12611,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3dc895eb94485320ecbaca3a1d29e3776cfb691dd7dcc71cf44b34af30e8ebb6
-      lastVerified: '2026-03-06T11:53:37.510Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
     output-analyzer:
       path: .aiox-core/core/synapse/diagnostics/collectors/output-analyzer.js
       layer: L1
@@ -12631,12 +12631,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e6846b1aba0a6cba17c297a871861d4f8199d7500220bff296a6a3291e32493e
-      lastVerified: '2026-03-06T11:53:37.510Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
     pipeline-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/pipeline-collector.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\diagnostics\collectors\pipeline-collector.js
+      purpose: Entity at .aiox-core/core/synapse/diagnostics/collectors/pipeline-collector.js
       keywords:
         - pipeline
         - collector
@@ -12652,12 +12652,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8655b6240e2f54b70def1a8c2fae00d40e2615cb95fd7ca0d64c2e0a6dfe3b73
-      lastVerified: '2026-03-06T11:53:37.510Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
     quality-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/quality-collector.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\diagnostics\collectors\quality-collector.js
+      purpose: Entity at .aiox-core/core/synapse/diagnostics/collectors/quality-collector.js
       keywords:
         - quality
         - collector
@@ -12672,12 +12672,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:30ae299eab6d569d09afe3530a5b2f1ff35ef75366a1ab56a9e2a57d39d3611c
-      lastVerified: '2026-03-06T11:53:37.511Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
     relevance-matrix:
       path: .aiox-core/core/synapse/diagnostics/collectors/relevance-matrix.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\diagnostics\collectors\relevance-matrix.js
+      purpose: Entity at .aiox-core/core/synapse/diagnostics/collectors/relevance-matrix.js
       keywords:
         - relevance
         - matrix
@@ -12692,12 +12692,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f92c4f7061dc82eed4310a27b69eade33d3015f9beb1bed688601a2dccbad22e
-      lastVerified: '2026-03-06T11:53:37.511Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
     safe-read-json:
       path: .aiox-core/core/synapse/diagnostics/collectors/safe-read-json.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\diagnostics\collectors\safe-read-json.js
+      purpose: Entity at .aiox-core/core/synapse/diagnostics/collectors/safe-read-json.js
       keywords:
         - safe
         - read
@@ -12717,12 +12717,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dc7bcd13779207ad67b1c3929b7e1e0ccfa3563f3458c20cad28cb1922e9a74c
-      lastVerified: '2026-03-06T11:53:37.511Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
     session-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/session-collector.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\diagnostics\collectors\session-collector.js
+      purpose: Entity at .aiox-core/core/synapse/diagnostics/collectors/session-collector.js
       keywords:
         - session
         - collector
@@ -12737,12 +12737,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a116d884d6947ddc8e5f3def012d93696576c584c4fde1639b8d895924fc09ea
-      lastVerified: '2026-03-06T11:53:37.511Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
     timing-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/timing-collector.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\diagnostics\collectors\timing-collector.js
+      purpose: Entity at .aiox-core/core/synapse/diagnostics/collectors/timing-collector.js
       keywords:
         - timing
         - collector
@@ -12757,12 +12757,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2523ce93f863a28f798d992c4f2fab041c91a09413b3186fd290e6035b391587
-      lastVerified: '2026-03-06T11:53:37.511Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
     uap-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/uap-collector.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core\core\synapse\diagnostics\collectors\uap-collector.js
+      purpose: Entity at .aiox-core/core/synapse/diagnostics/collectors/uap-collector.js
       keywords:
         - uap
         - collector
@@ -12777,7 +12777,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dd025894f8f0d3bd22a147dbc0debef8b83e96f3c59483653404b3cd5a01d5aa
-      lastVerified: '2026-03-06T11:53:37.512Z'
+      lastVerified: '2026-03-11T02:00:27.584Z'
   agents:
     aiox-master:
       path: .aiox-core/development/agents/aiox-master.md
@@ -12855,8 +12855,8 @@ entities:
         score: 0.3
         constraints: []
         extensionPoints: []
-      checksum: sha256:17cd10f6c2ac4fcd96d944283f239c760e2829d2de4e68098f618783ec5ae351
-      lastVerified: '2026-03-06T11:53:37.523Z'
+      checksum: sha256:a2f8c55ac39c3489b656494f24ee7793307b724a2fa35383f430b0be86694ce5
+      lastVerified: '2026-03-11T02:01:00.103Z'
     analyst:
       path: .aiox-core/development/agents/analyst.md
       layer: L2
@@ -12908,7 +12908,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:35150d764c6dc74bc02b61a4d613c9278e87ffb209403db23991339fdda4f8e2
-      lastVerified: '2026-03-06T11:53:37.525Z'
+      lastVerified: '2026-03-11T02:00:27.590Z'
     architect:
       path: .aiox-core/development/agents/architect.md
       layer: L2
@@ -12982,7 +12982,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b89e95048df940056570ecb6589f18a9a6114b96ca1b9fde130fb7bdb2ded8f
-      lastVerified: '2026-03-06T11:53:37.546Z'
+      lastVerified: '2026-03-11T02:00:27.592Z'
     data-engineer:
       path: .aiox-core/development/agents/data-engineer.md
       layer: L2
@@ -13049,7 +13049,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:61ca7c661e2634aa45583b21fb3fc34213bae89803d92e1e5f08759a04c230a0
-      lastVerified: '2026-03-06T11:53:37.548Z'
+      lastVerified: '2026-03-11T02:00:27.593Z'
     dev:
       path: .aiox-core/development/agents/dev.md
       layer: L2
@@ -13162,7 +13162,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:eaaec824273f02b9ccbe6768d9e9147a5ad0d7faa9483b9730b1f02a71ef2769
-      lastVerified: '2026-03-06T11:53:37.552Z'
+      lastVerified: '2026-03-11T02:00:27.595Z'
     devops:
       path: .aiox-core/development/agents/devops.md
       layer: L2
@@ -13239,7 +13239,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a41d02fe38b086211f4c1985b8da5e4624e21767466325032aeb9b4899f8c6b0
-      lastVerified: '2026-03-06T11:53:37.555Z'
+      lastVerified: '2026-03-11T02:00:27.598Z'
     pm:
       path: .aiox-core/development/agents/pm.md
       layer: L2
@@ -13299,7 +13299,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8c81fd9b6df9b98fa3d3654062464498396ddb4eaf0b6dc3a644ae4227982f4b
-      lastVerified: '2026-03-06T11:53:37.557Z'
+      lastVerified: '2026-03-11T02:00:27.599Z'
     po:
       path: .aiox-core/development/agents/po.md
       layer: L2
@@ -13361,7 +13361,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f9c3ddcdbf602890802327aada808a58486a2de56acb974412c5f860dc8c9c4b
-      lastVerified: '2026-03-06T11:53:37.559Z'
+      lastVerified: '2026-03-11T02:00:27.600Z'
     qa:
       path: .aiox-core/development/agents/qa.md
       layer: L2
@@ -13447,7 +13447,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6dcefe468f9e4c854080a23ec6d91c78aacd54a5f504bf77af03a6f6221753c4
-      lastVerified: '2026-03-06T11:53:37.562Z'
+      lastVerified: '2026-03-11T02:00:27.601Z'
     sm:
       path: .aiox-core/development/agents/sm.md
       layer: L2
@@ -13489,7 +13489,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0176d251fd2c7b6368f1ad4ca71000085f660b038a71b3b2cf502516119c3661
-      lastVerified: '2026-03-06T11:53:37.564Z'
+      lastVerified: '2026-03-11T02:00:27.602Z'
     squad-creator:
       path: .aiox-core/development/agents/squad-creator.md
       layer: L2
@@ -13528,7 +13528,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9ae479d628a74fdf8372da4e5a306fdc93235bce8f4957b44ad9adc76643f8e1
-      lastVerified: '2026-03-06T11:53:37.566Z'
+      lastVerified: '2026-03-11T02:00:27.602Z'
     ux-design-expert:
       path: .aiox-core/development/agents/ux-design-expert.md
       layer: L2
@@ -13599,7 +13599,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ca4ec06aaf8525668303f8bdef9c5bc868b1f084db905e8b7636c974c2faa94
-      lastVerified: '2026-03-06T11:53:37.569Z'
+      lastVerified: '2026-03-11T02:00:27.603Z'
     MEMORY:
       path: .aiox-core/development/agents/analyst/MEMORY.md
       layer: L3
@@ -13620,7 +13620,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b8b52820ba1929ba12403fc437868dd9e8a9c2532abe99296ad05864618693b0
-      lastVerified: '2026-03-06T11:53:37.569Z'
+      lastVerified: '2026-03-11T02:00:27.603Z'
   checklists:
     agent-quality-gate:
       path: .aiox-core/development/checklists/agent-quality-gate.md
@@ -13642,7 +13642,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:46395b5c10794ca98321e4baaaaa1737485bec3f6bc3a616cf948478c0a1c644
-      lastVerified: '2026-03-06T11:53:37.571Z'
+      lastVerified: '2026-03-11T02:00:27.604Z'
     brownfield-compatibility-checklist:
       path: .aiox-core/development/checklists/brownfield-compatibility-checklist.md
       layer: L2
@@ -13664,7 +13664,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c5ff5d7cd45395e8766bf5c941ece8b0d5557758ecead7bef3ac3e08abee899
-      lastVerified: '2026-03-06T11:53:37.572Z'
+      lastVerified: '2026-03-11T02:00:27.604Z'
     issue-triage-checklist:
       path: .aiox-core/development/checklists/issue-triage-checklist.md
       layer: L2
@@ -13684,7 +13684,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c6dbaae38c0e3030dbffebcbcf95e5e766e0294a7a678531531cbd7ad6e54e2b
-      lastVerified: '2026-03-06T11:53:37.572Z'
+      lastVerified: '2026-03-11T02:00:27.604Z'
     memory-audit-checklist:
       path: .aiox-core/development/checklists/memory-audit-checklist.md
       layer: L2
@@ -13706,7 +13706,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bb3ca4ea56d0294a7acc1e9f5bd690ee70c676c28950b8a7c3c25bef8e428f7e
-      lastVerified: '2026-03-06T11:53:37.572Z'
+      lastVerified: '2026-03-11T02:00:27.604Z'
     self-critique-checklist:
       path: .aiox-core/development/checklists/self-critique-checklist.md
       layer: L2
@@ -13729,7 +13729,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:158f21a6be7a7cbc90de0302678490887c2f88b1d79d925f77a8a2209d2ae003
-      lastVerified: '2026-03-06T11:53:37.572Z'
+      lastVerified: '2026-03-11T02:00:27.604Z'
   data:
     agent-config-requirements:
       path: .aiox-core/data/agent-config-requirements.yaml
@@ -13750,7 +13750,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:68e87b5777d1872c4fed6644dd3c7e3c3e8fd590df7d2b58c36d541cf8e38dd3
-      lastVerified: '2026-03-06T11:53:37.575Z'
+      lastVerified: '2026-03-11T02:00:27.605Z'
     aiox-kb:
       path: .aiox-core/data/aiox-kb.md
       layer: L3
@@ -13771,7 +13771,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:72c569d40b3c79a6235d571d901b87972dd72253b885b03b95b254f2dea05832
-      lastVerified: '2026-03-06T11:53:37.575Z'
+      lastVerified: '2026-03-11T02:00:27.605Z'
     entity-registry:
       path: .aiox-core/data/entity-registry.yaml
       layer: L3
@@ -13790,13 +13790,13 @@ entities:
         score: 0.5
         constraints: []
         extensionPoints: []
-      checksum: sha256:26d071d47598d2fd2297cb36dd9faa769e90c6d8da40a16205bd8e9d13c9b1c0
-      lastVerified: '2026-03-06T11:53:37.580Z'
+      checksum: sha256:151aca46769c614f0238e7a8e2968884c3888b438ff1c634f0eeb2505e325b83
+      lastVerified: '2026-03-11T02:00:27.607Z'
     learned-patterns:
       path: .aiox-core/data/learned-patterns.yaml
       layer: L3
       type: data
-      purpose: Entity at .aiox-core\data\learned-patterns.yaml
+      purpose: Entity at .aiox-core/data/learned-patterns.yaml
       keywords:
         - learned
         - patterns
@@ -13810,7 +13810,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
-      lastVerified: '2026-03-06T11:53:37.581Z'
+      lastVerified: '2026-03-11T02:00:27.607Z'
     mcp-tool-examples:
       path: .aiox-core/data/mcp-tool-examples.yaml
       layer: L3
@@ -13831,7 +13831,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8a38e4171d7434d79f83032d9c37f2f604d9411dbec6c3c0334d6661481745fd
-      lastVerified: '2026-03-06T11:53:37.582Z'
+      lastVerified: '2026-03-11T02:00:27.607Z'
     technical-preferences:
       path: .aiox-core/data/technical-preferences.md
       layer: L3
@@ -13853,7 +13853,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:abb9327d3ce96a3cd49e73a555da4078e81ea0c4dbfe7154420c3ec7ac1c93b7
-      lastVerified: '2026-03-06T11:53:37.582Z'
+      lastVerified: '2026-03-11T02:00:27.607Z'
     tool-registry:
       path: .aiox-core/data/tool-registry.yaml
       layer: L3
@@ -13873,7 +13873,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:64e867d0eb36c7f7ac86f4f73f1b2ff89f43f37f28a6de34389be74b9346860c
-      lastVerified: '2026-03-06T11:53:37.583Z'
+      lastVerified: '2026-03-11T02:00:27.607Z'
     workflow-chains:
       path: .aiox-core/data/workflow-chains.yaml
       layer: L3
@@ -13895,7 +13895,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1fbf1625e267eedc315cf1e08e5827c250ddc6785fb2cb139e7702def9b66268
-      lastVerified: '2026-03-06T11:53:37.583Z'
+      lastVerified: '2026-03-11T02:00:27.607Z'
     workflow-patterns:
       path: .aiox-core/data/workflow-patterns.yaml
       layer: L3
@@ -13915,7 +13915,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0e90d71ce0cc218d8710c1f195f74a24d3aa7513f5728f5e65da9220612c3617
-      lastVerified: '2026-03-06T11:53:37.595Z'
+      lastVerified: '2026-03-11T02:00:27.607Z'
     workflow-state-schema:
       path: .aiox-core/data/workflow-state-schema.yaml
       layer: L3
@@ -13935,7 +13935,27 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d80a645a9c48b8ab8168ddbe36279662d72de4fb5cd8953a6685e5d1bd9968db
-      lastVerified: '2026-03-06T11:53:37.596Z'
+      lastVerified: '2026-03-11T02:00:27.607Z'
+    _template:
+      path: .aiox-core/data/tech-presets/_template.md
+      layer: L3
+      type: data
+      purpose: '''Brief description of when to use this preset'''
+      keywords:
+        - template
+        - tech
+        - preset
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.5
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:68b26930b728908b6097fc91956c8c446e5cc0dbe627e3b737495ebcd7e9569b
+      lastVerified: '2026-03-11T02:00:27.607Z'
     csharp:
       path: .aiox-core/data/tech-presets/csharp.md
       layer: L3
@@ -13955,7 +13975,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4667d33407c59fd6c7b4558370893a14df6d461645fc840b2df2fb7508bd6fcf
-      lastVerified: '2026-03-06T11:53:37.596Z'
+      lastVerified: '2026-03-11T02:00:27.607Z'
     go:
       path: .aiox-core/data/tech-presets/go.md
       layer: L3
@@ -13975,7 +13995,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e0851caecbdc2cea6531359fe640427685cd6ed664dbf991ccb135917c4d1ec2
-      lastVerified: '2026-03-06T11:53:37.596Z'
+      lastVerified: '2026-03-11T02:00:27.608Z'
     java:
       path: .aiox-core/data/tech-presets/java.md
       layer: L3
@@ -13995,7 +14015,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b912e04412f63b59439f7cca119802bed95a6cb756221e3ba7aee45c3d2890fd
-      lastVerified: '2026-03-06T11:53:37.596Z'
+      lastVerified: '2026-03-11T02:00:27.608Z'
     nextjs-react:
       path: .aiox-core/data/tech-presets/nextjs-react.md
       layer: L3
@@ -14022,7 +14042,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:558ce0abd112ca39853fc5150bd850862e5fcfac74c8def80c3876b60c9f5d33
-      lastVerified: '2026-03-06T11:53:37.597Z'
+      lastVerified: '2026-03-11T02:00:27.608Z'
     php:
       path: .aiox-core/data/tech-presets/php.md
       layer: L3
@@ -14044,7 +14064,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:847dde754e7a98c4d11328768483358d2be7d2f10e43b6703403237987620077
-      lastVerified: '2026-03-06T11:53:37.597Z'
+      lastVerified: '2026-03-11T02:00:27.608Z'
     rust:
       path: .aiox-core/data/tech-presets/rust.md
       layer: L3
@@ -14064,27 +14084,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:58422e884e46660216d5389878ae2f0ab619da7d34f34ed1dff917dfd8fed7db
-      lastVerified: '2026-03-06T11:53:37.603Z'
-    _template:
-      path: .aiox-core/data/tech-presets/_template.md
-      layer: L3
-      type: data
-      purpose: '''Brief description of when to use this preset'''
-      keywords:
-        - template
-        - tech
-        - preset
-      usedBy: []
-      dependencies: []
-      externalDeps: []
-      plannedDeps: []
-      lifecycle: orphan
-      adaptability:
-        score: 0.5
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:68b26930b728908b6097fc91956c8c446e5cc0dbe627e3b737495ebcd7e9569b
-      lastVerified: '2026-03-06T11:53:37.603Z'
+      lastVerified: '2026-03-11T02:00:27.608Z'
   workflows:
     auto-worktree:
       path: .aiox-core/development/workflows/auto-worktree.yaml
@@ -14107,7 +14107,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:74b0dff78c2b91eda03b9914a73cc99807645c8e0b174e576d22e0b3f5b75be3
-      lastVerified: '2026-03-06T11:53:37.606Z'
+      lastVerified: '2026-03-11T02:00:27.609Z'
     brownfield-discovery:
       path: .aiox-core/development/workflows/brownfield-discovery.yaml
       layer: L2
@@ -14132,7 +14132,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a52662b683781546d4585d456aad1cb7d41343a8c934d9a6d6441f8d3dec5385
-      lastVerified: '2026-03-06T11:53:37.608Z'
+      lastVerified: '2026-03-11T02:00:27.610Z'
     brownfield-fullstack:
       path: .aiox-core/development/workflows/brownfield-fullstack.yaml
       layer: L2
@@ -14158,7 +14158,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5200308dfa759d6ce37270f63853a6c1424d47ec552142d9ada6174aaf5c22ff
-      lastVerified: '2026-03-06T11:53:37.609Z'
+      lastVerified: '2026-03-11T02:00:27.611Z'
     brownfield-service:
       path: .aiox-core/development/workflows/brownfield-service.yaml
       layer: L2
@@ -14183,7 +14183,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6ef271e25edd0dfe4235ea5aab14dbf89509250d8471580418ce58d50a1748e8
-      lastVerified: '2026-03-06T11:53:37.610Z'
+      lastVerified: '2026-03-11T02:00:27.611Z'
     brownfield-ui:
       path: .aiox-core/development/workflows/brownfield-ui.yaml
       layer: L2
@@ -14209,7 +14209,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:553a05def42e2a884d59fdeaa1aaf07566e469e3ae30daf43543e8a934c1c67f
-      lastVerified: '2026-03-06T11:53:37.611Z'
+      lastVerified: '2026-03-11T02:00:27.612Z'
     design-system-build-quality:
       path: .aiox-core/development/workflows/design-system-build-quality.yaml
       layer: L2
@@ -14231,7 +14231,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e9aa8f3e1ae22aa0799627326a3548e78eee805e5652c12a15e84dbdbcd5ffe2
-      lastVerified: '2026-03-06T11:53:37.627Z'
+      lastVerified: '2026-03-11T02:00:27.612Z'
     development-cycle:
       path: .aiox-core/development/workflows/development-cycle.yaml
       layer: L2
@@ -14245,14 +14245,19 @@ entities:
         - story-checkpoint
       dependencies: []
       externalDeps: []
-      plannedDeps: []
+      plannedDeps:
+        - '@po'
+        - ${story.executor}
+        - '@dev'
+        - ${story.quality_gate}
+        - '@devops'
       lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:e882daca473a95807e5c480c9b1c3d7b428277b075232cb907f9a253468a17c1
-      lastVerified: '2026-03-06T11:53:37.633Z'
+      checksum: sha256:c22f2700d6c3dcd227efec711ab206b4fa9e268768a15be86eea0405e2c82c4d
+      lastVerified: '2026-03-11T02:00:27.613Z'
     epic-orchestration:
       path: .aiox-core/development/workflows/epic-orchestration.yaml
       layer: L2
@@ -14272,7 +14277,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4bb9d91027036d089ab880e46e4b256290761c4dbf17d716abe61b541161fe05
-      lastVerified: '2026-03-06T11:53:37.635Z'
+      lastVerified: '2026-03-11T02:00:27.614Z'
     greenfield-fullstack:
       path: .aiox-core/development/workflows/greenfield-fullstack.yaml
       layer: L2
@@ -14301,7 +14306,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:106b47c4205ac395118a49f5d5fb194125f5c17819780f9a598ef434352013ef
-      lastVerified: '2026-03-06T11:53:37.637Z'
+      lastVerified: '2026-03-11T02:00:27.617Z'
     greenfield-service:
       path: .aiox-core/development/workflows/greenfield-service.yaml
       layer: L2
@@ -14327,7 +14332,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b22d2ea83d2079878632f50351a21d7f2a9a8035283abd6fea701033774f9bb
-      lastVerified: '2026-03-06T11:53:37.638Z'
+      lastVerified: '2026-03-11T02:00:27.618Z'
     greenfield-ui:
       path: .aiox-core/development/workflows/greenfield-ui.yaml
       layer: L2
@@ -14354,7 +14359,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e7818aa9f7c8db4efd6d7fd631fb8ff6f1aac4202c3f6253dfd6d50dd708fc30
-      lastVerified: '2026-03-06T11:53:37.640Z'
+      lastVerified: '2026-03-11T02:00:27.618Z'
     qa-loop:
       path: .aiox-core/development/workflows/qa-loop.yaml
       layer: L2
@@ -14379,7 +14384,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:585d5e5dd2cf4d5682e8db2a816caa588ecf5ae3b332f4a5ceec9f406b5f0f09
-      lastVerified: '2026-03-06T11:53:37.642Z'
+      lastVerified: '2026-03-11T02:00:27.619Z'
     spec-pipeline:
       path: .aiox-core/development/workflows/spec-pipeline.yaml
       layer: L2
@@ -14407,7 +14412,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4604ff3e2e945fbbb45006e32d8de81c73cb38782526ca3c87924549ccc29ccf
-      lastVerified: '2026-03-06T11:53:37.644Z'
+      lastVerified: '2026-03-11T02:00:27.620Z'
     story-development-cycle:
       path: .aiox-core/development/workflows/story-development-cycle.yaml
       layer: L2
@@ -14431,13 +14436,13 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6125a3545e9a8550582d7d6ea640bbd5b0e4747b80e7c67ebf60ce284591220e
-      lastVerified: '2026-03-06T11:53:37.645Z'
+      lastVerified: '2026-03-11T02:00:27.620Z'
   utils:
     output-formatter:
       path: .aiox-core/core/utils/output-formatter.js
       layer: L1
       type: util
-      purpose: Entity at .aiox-core\core\utils\output-formatter.js
+      purpose: Entity at .aiox-core/core/utils/output-formatter.js
       keywords:
         - output
         - formatter
@@ -14451,12 +14456,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6fdfee469b7c108ec24a045b9b2719d836a242052abd285957a9ac732c6fc594
-      lastVerified: '2026-03-06T11:53:37.646Z'
+      lastVerified: '2026-03-11T02:00:27.621Z'
     security-utils:
       path: .aiox-core/core/utils/security-utils.js
       layer: L1
       type: util
-      purpose: Entity at .aiox-core\core\utils\security-utils.js
+      purpose: Entity at .aiox-core/core/utils/security-utils.js
       keywords:
         - security
         - utils
@@ -14470,12 +14475,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:00c938eda0e142b8c204b50afdd662864b5209b60a32a0e6e847e4e4cbceee09
-      lastVerified: '2026-03-06T11:53:37.647Z'
+      lastVerified: '2026-03-11T02:00:27.621Z'
     yaml-validator:
       path: .aiox-core/core/utils/yaml-validator.js
       layer: L1
       type: util
-      purpose: Entity at .aiox-core\core\utils\yaml-validator.js
+      purpose: Entity at .aiox-core/core/utils/yaml-validator.js
       keywords:
         - yaml
         - validator
@@ -14489,14 +14494,14 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:41e3715845262c2e49f58745a773e81f4feaaa2325e54bcb0226e4bf08f709dd
-      lastVerified: '2026-03-06T11:53:37.647Z'
+      lastVerified: '2026-03-11T02:00:27.621Z'
   tools: {}
   infra-scripts:
     aiox-validator:
       path: .aiox-core/infrastructure/scripts/aiox-validator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\aiox-validator.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/aiox-validator.js
       keywords:
         - aiox
         - validator
@@ -14510,7 +14515,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5a91cc8b54ccd58955dbbb5925f878d9e507dc2a9358f642c62f7ee84a6156a0
-      lastVerified: '2026-03-06T11:53:37.655Z'
+      lastVerified: '2026-03-11T02:00:27.622Z'
     approach-manager:
       path: .aiox-core/infrastructure/scripts/approach-manager.js
       layer: L2
@@ -14530,7 +14535,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:22ee604ca42094f5b7939ec129c52cb1fc362ae70688cc1ef7a921c956ab38d2
-      lastVerified: '2026-03-06T11:53:37.655Z'
+      lastVerified: '2026-03-11T02:00:27.623Z'
     approval-workflow:
       path: .aiox-core/infrastructure/scripts/approval-workflow.js
       layer: L2
@@ -14550,7 +14555,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4d744a8d08cadf09bf368a1457c1bd3bc68ccef0885c324b2527222da816544b
-      lastVerified: '2026-03-06T11:53:37.656Z'
+      lastVerified: '2026-03-11T02:00:27.623Z'
     asset-inventory:
       path: .aiox-core/infrastructure/scripts/asset-inventory.js
       layer: L2
@@ -14570,7 +14575,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:25ad926a05af465389b6fb92f7c9c79c453c54047b4ebe9629ee1c153a6b3373
-      lastVerified: '2026-03-06T11:53:37.656Z'
+      lastVerified: '2026-03-11T02:00:27.623Z'
     atomic-layer-classifier:
       path: .aiox-core/infrastructure/scripts/atomic-layer-classifier.js
       layer: L2
@@ -14590,12 +14595,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ecdb368d80a69c8da7cc507aff0b18bd2e58d8bd94b9fb0ba1e074595a19e884
-      lastVerified: '2026-03-06T11:53:37.656Z'
+      lastVerified: '2026-03-11T02:00:27.623Z'
     backup-manager:
       path: .aiox-core/infrastructure/scripts/backup-manager.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\backup-manager.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/backup-manager.js
       keywords:
         - backup
         - manager
@@ -14610,7 +14615,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e7d0173f107c0576f443a7f4bc83387cdbb625518ce5749ca9059ffbf3070f44
-      lastVerified: '2026-03-06T11:53:37.657Z'
+      lastVerified: '2026-03-11T02:00:27.623Z'
     batch-creator:
       path: .aiox-core/infrastructure/scripts/batch-creator.js
       layer: L2
@@ -14633,12 +14638,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b91ca0e5d8af3d47658bc5bd754e72e654e68446c17c5e50e45ebd581535fe7d
-      lastVerified: '2026-03-06T11:53:37.657Z'
+      lastVerified: '2026-03-11T02:00:27.624Z'
     branch-manager:
       path: .aiox-core/infrastructure/scripts/branch-manager.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\branch-manager.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/branch-manager.js
       keywords:
         - branch
         - manager
@@ -14653,7 +14658,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:49f3a7a7aa36347c3e3dbc998847913c829216c71a1c659bf7a55d67a940d1c3
-      lastVerified: '2026-03-06T11:53:37.657Z'
+      lastVerified: '2026-03-11T02:00:27.624Z'
     capability-analyzer:
       path: .aiox-core/infrastructure/scripts/capability-analyzer.js
       layer: L2
@@ -14674,12 +14679,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:92f55a27e60fd6aba2a0203f1c28aa12d6f70200097ec44d849db2653f758a17
-      lastVerified: '2026-03-06T11:53:37.657Z'
+      lastVerified: '2026-03-11T02:00:27.624Z'
     changelog-generator:
       path: .aiox-core/infrastructure/scripts/changelog-generator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\changelog-generator.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/changelog-generator.js
       keywords:
         - changelog
         - generator
@@ -14693,7 +14698,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c2d6b203d39fe2ef8d6b7108beb59a03da0986f9331c22ce539d9857c7cc3612
-      lastVerified: '2026-03-06T11:53:37.658Z'
+      lastVerified: '2026-03-11T02:00:27.624Z'
     cicd-discovery:
       path: .aiox-core/infrastructure/scripts/cicd-discovery.js
       layer: L2
@@ -14712,7 +14717,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:04b5efa659f9d3baa998ca4b09f7fc6ec4800d0b165ecf118a8f10df93642228
-      lastVerified: '2026-03-06T11:53:37.658Z'
+      lastVerified: '2026-03-11T02:00:27.624Z'
     clickup-helpers:
       path: .aiox-core/infrastructure/scripts/clickup-helpers.js
       layer: L2
@@ -14734,7 +14739,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:043ceb5b712903e6b78be83c997575e8de64d5815dccef88355c20d8153af9a6
-      lastVerified: '2026-03-06T11:53:37.658Z'
+      lastVerified: '2026-03-11T02:00:27.624Z'
     code-quality-improver:
       path: .aiox-core/infrastructure/scripts/code-quality-improver.js
       layer: L2
@@ -14755,7 +14760,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:765dd10a367656b330a659b2245ef2eb9a947905fee71555198837743fc1483f
-      lastVerified: '2026-03-06T11:53:37.659Z'
+      lastVerified: '2026-03-11T02:00:27.625Z'
     codebase-mapper:
       path: .aiox-core/infrastructure/scripts/codebase-mapper.js
       layer: L2
@@ -14775,7 +14780,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b72ae317c81c01ed1d6d518d64cf18fdecb9d408ab45dba6ad45cb39c6e3a1d
-      lastVerified: '2026-03-06T11:53:37.659Z'
+      lastVerified: '2026-03-11T02:00:27.625Z'
     collect-tool-usage:
       path: .aiox-core/infrastructure/scripts/collect-tool-usage.js
       layer: L2
@@ -14795,7 +14800,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8a739b79182dc41e28b7e02aeb9ec1dde5ec49f3ca534399acc59711b3b92bbf
-      lastVerified: '2026-03-06T11:53:37.660Z'
+      lastVerified: '2026-03-11T02:00:27.625Z'
     commit-message-generator:
       path: .aiox-core/infrastructure/scripts/commit-message-generator.js
       layer: L2
@@ -14817,7 +14822,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:611b0f27acd02e49aff7a2d91b48823dc4a2d788440fff2f32bf500a1bc84132
-      lastVerified: '2026-03-06T11:53:37.660Z'
+      lastVerified: '2026-03-11T02:00:27.625Z'
     component-generator:
       path: .aiox-core/infrastructure/scripts/component-generator.js
       layer: L2
@@ -14859,7 +14864,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c74da9a766aeca878568a0e70f78141e7a772322d428f99e90fcd7b9a5fd7edc
-      lastVerified: '2026-03-06T11:53:37.660Z'
+      lastVerified: '2026-03-11T02:00:27.625Z'
     component-metadata:
       path: .aiox-core/infrastructure/scripts/component-metadata.js
       layer: L2
@@ -14881,12 +14886,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0ad8034533561b13187072eaa611510117463bacbaff12f9ae48008128560000
-      lastVerified: '2026-03-06T11:53:37.660Z'
+      lastVerified: '2026-03-11T02:00:27.625Z'
     component-search:
       path: .aiox-core/infrastructure/scripts/component-search.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\component-search.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/component-search.js
       keywords:
         - component
         - search
@@ -14902,12 +14907,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:08feb4672de885f140527e460614cbc90d90544753581f36afeec71ee8614703
-      lastVerified: '2026-03-06T11:53:37.661Z'
+      lastVerified: '2026-03-11T02:00:27.626Z'
     config-cache:
       path: .aiox-core/infrastructure/scripts/config-cache.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\config-cache.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/config-cache.js
       keywords:
         - config
         - cache
@@ -14925,12 +14930,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4f55401fee7010d01545808ed6f6c40a91ce43180d405f93d5073480512d30d5
-      lastVerified: '2026-03-06T11:53:37.661Z'
+      lastVerified: '2026-03-11T02:00:27.626Z'
     config-loader:
       path: .aiox-core/infrastructure/scripts/config-loader.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\config-loader.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/config-loader.js
       keywords:
         - config
         - loader
@@ -14947,7 +14952,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8f9489f7c57e775bfbb750761d9714505d5df3938b664cbbdf6701f9e18e240b
-      lastVerified: '2026-03-06T11:53:37.661Z'
+      lastVerified: '2026-03-11T02:00:27.626Z'
     conflict-resolver:
       path: .aiox-core/infrastructure/scripts/conflict-resolver.js
       layer: L2
@@ -14967,7 +14972,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3d2794a66f16fcea95b096386dc9c2dcd31e5938d862030e7ac1f38c00a2c0bd
-      lastVerified: '2026-03-06T11:53:37.662Z'
+      lastVerified: '2026-03-11T02:00:27.626Z'
     coverage-analyzer:
       path: .aiox-core/infrastructure/scripts/coverage-analyzer.js
       layer: L2
@@ -14987,12 +14992,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:95e70563eadf720ce4c6aa6349ace311cf34c63bc5044f71565f328a2dc9a706
-      lastVerified: '2026-03-06T11:53:37.662Z'
+      lastVerified: '2026-03-11T02:00:27.626Z'
     dashboard-status-writer:
       path: .aiox-core/infrastructure/scripts/dashboard-status-writer.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\dashboard-status-writer.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/dashboard-status-writer.js
       keywords:
         - dashboard
         - status
@@ -15007,7 +15012,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a01bc8e74ce40206bbb49453af46896388754f412961b6f6585927a382338f01
-      lastVerified: '2026-03-06T11:53:37.662Z'
+      lastVerified: '2026-03-11T02:00:27.626Z'
     dependency-analyzer:
       path: .aiox-core/infrastructure/scripts/dependency-analyzer.js
       layer: L2
@@ -15028,7 +15033,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:af326d5d70a097cc255171d8f30b1d99a302b07d96d94528cfaad3f97bdea479
-      lastVerified: '2026-03-06T11:53:37.662Z'
+      lastVerified: '2026-03-11T02:00:27.626Z'
     dependency-impact-analyzer:
       path: .aiox-core/infrastructure/scripts/dependency-impact-analyzer.js
       layer: L2
@@ -15053,12 +15058,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3c9d87250845f7def63a2230d4af43ed2d6ae84cfba6b6d72a5b9e285a66f5ed
-      lastVerified: '2026-03-06T11:53:37.663Z'
+      lastVerified: '2026-03-11T02:00:27.627Z'
     diff-generator:
       path: .aiox-core/infrastructure/scripts/diff-generator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\diff-generator.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/diff-generator.js
       keywords:
         - diff
         - generator
@@ -15074,7 +15079,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:569387c1dd8ee00d0ebc34b9f463438150ed9c96af2e5728fde83c36626211cf
-      lastVerified: '2026-03-06T11:53:37.663Z'
+      lastVerified: '2026-03-11T02:00:27.627Z'
     documentation-synchronizer:
       path: .aiox-core/infrastructure/scripts/documentation-synchronizer.js
       layer: L2
@@ -15094,7 +15099,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:94fc482ef0182608a3433824d02cb24fe0d7ab4aaa256853b9b79e603bf28e9e
-      lastVerified: '2026-03-06T11:53:37.664Z'
+      lastVerified: '2026-03-11T02:00:27.627Z'
     framework-analyzer:
       path: .aiox-core/infrastructure/scripts/framework-analyzer.js
       layer: L2
@@ -15116,7 +15121,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8bd86d50f5a3f050191a49e22e8348bbefa72e3df396313064239a2f1a4a9856
-      lastVerified: '2026-03-06T11:53:37.664Z'
+      lastVerified: '2026-03-11T02:00:27.627Z'
     generate-optimization-report:
       path: .aiox-core/infrastructure/scripts/generate-optimization-report.js
       layer: L2
@@ -15136,12 +15141,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b57357bc4120529381b811fd7c1aab901d3b67dd765d043eefc61bb22f5b8df1
-      lastVerified: '2026-03-06T11:53:37.664Z'
+      lastVerified: '2026-03-11T02:00:27.627Z'
     generate-settings-json:
       path: .aiox-core/infrastructure/scripts/generate-settings-json.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\generate-settings-json.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/generate-settings-json.js
       keywords:
         - generate
         - settings
@@ -15156,12 +15161,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bb4c6f664eb06622fd78eb455c0a74ee29ecee5fe47b4a7fcb2de8a89119ff5a
-      lastVerified: '2026-03-06T11:53:37.664Z'
+      lastVerified: '2026-03-11T02:00:27.627Z'
     git-config-detector:
       path: .aiox-core/infrastructure/scripts/git-config-detector.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\git-config-detector.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/git-config-detector.js
       keywords:
         - git
         - config
@@ -15178,12 +15183,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:52ed96d98fc6f9e83671d7d27f78dcff4f2475f3b8e339dc31922f6b2814ad78
-      lastVerified: '2026-03-06T11:53:37.665Z'
+      lastVerified: '2026-03-11T02:00:27.628Z'
     git-wrapper:
       path: .aiox-core/infrastructure/scripts/git-wrapper.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\git-wrapper.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/git-wrapper.js
       keywords:
         - git
         - wrapper
@@ -15199,7 +15204,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7130442ca72ba89e397be77000b44e2431b92a8af44d1fac63c869807641e587
-      lastVerified: '2026-03-06T11:53:37.665Z'
+      lastVerified: '2026-03-11T02:00:27.628Z'
     gotchas-documenter:
       path: .aiox-core/infrastructure/scripts/gotchas-documenter.js
       layer: L2
@@ -15219,7 +15224,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ef42171b57775622977a9221db8a7d994a33f3acaa0a72c2908d13943d45d796
-      lastVerified: '2026-03-06T11:53:37.666Z'
+      lastVerified: '2026-03-11T02:00:27.628Z'
     improvement-engine:
       path: .aiox-core/infrastructure/scripts/improvement-engine.js
       layer: L2
@@ -15239,7 +15244,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4fed61115f4148eb6b8c42ebd9d5b05732695ab1b4343e2466383baf4883d58d
-      lastVerified: '2026-03-06T11:53:37.666Z'
+      lastVerified: '2026-03-11T02:00:27.629Z'
     improvement-validator:
       path: .aiox-core/infrastructure/scripts/improvement-validator.js
       layer: L2
@@ -15261,12 +15266,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b63362e7ac1c4dbf17655be6609cab666f9f1970821da79609890f76a906c02b
-      lastVerified: '2026-03-06T11:53:37.667Z'
+      lastVerified: '2026-03-11T02:00:27.629Z'
     migrate-agent:
       path: .aiox-core/infrastructure/scripts/migrate-agent.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\migrate-agent.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/migrate-agent.js
       keywords:
         - migrate
         - agent
@@ -15281,7 +15286,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0b7330c4a7dccfe028aea2d99e4d3c2f3acface55b79c32bd51ab3bc00e33a86
-      lastVerified: '2026-03-06T11:53:37.667Z'
+      lastVerified: '2026-03-11T02:00:27.629Z'
     modification-risk-assessment:
       path: .aiox-core/infrastructure/scripts/modification-risk-assessment.js
       layer: L2
@@ -15302,12 +15307,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:974dfb83d3bfbb56f4a02385d8edb735c0acab62acb8a1a4e7c69f5ecf10c810
-      lastVerified: '2026-03-06T11:53:37.667Z'
+      lastVerified: '2026-03-11T02:00:27.629Z'
     modification-validator:
       path: .aiox-core/infrastructure/scripts/modification-validator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\modification-validator.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/modification-validator.js
       keywords:
         - modification
         - validator
@@ -15326,12 +15331,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0853fbe9e628510a0e6f8b95ac3c467d49df5cd7b15637f374928c1d3f9e2b87
-      lastVerified: '2026-03-06T11:53:37.668Z'
+      lastVerified: '2026-03-11T02:00:27.629Z'
     output-formatter:
       path: .aiox-core/infrastructure/scripts/output-formatter.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\output-formatter.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/output-formatter.js
       keywords:
         - output
         - formatter
@@ -15348,12 +15353,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6f28092d0dabf3b0b486ef06a1836d47c3247a3c331ed6cfbcd597d45496ddb6
-      lastVerified: '2026-03-06T11:53:37.668Z'
+      lastVerified: '2026-03-11T02:00:27.629Z'
     path-analyzer:
       path: .aiox-core/infrastructure/scripts/path-analyzer.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\path-analyzer.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/path-analyzer.js
       keywords:
         - path
         - analyzer
@@ -15368,7 +15373,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:47250c416f8090278b4a81de7be4a3f2592f4a20b6afc9c9e30c9cafd292e166
-      lastVerified: '2026-03-06T11:53:37.669Z'
+      lastVerified: '2026-03-11T02:00:27.630Z'
     pattern-extractor:
       path: .aiox-core/infrastructure/scripts/pattern-extractor.js
       layer: L2
@@ -15389,12 +15394,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9edc6aabdb32431466c5c8db9da883bc0a5f4457cfc74ccc6c10ed687f8e1e52
-      lastVerified: '2026-03-06T11:53:37.669Z'
+      lastVerified: '2026-03-11T02:00:27.630Z'
     performance-analyzer:
       path: .aiox-core/infrastructure/scripts/performance-analyzer.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\performance-analyzer.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/performance-analyzer.js
       keywords:
         - performance
         - analyzer
@@ -15409,7 +15414,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6d925acfbaf3cedae2b17ec262f8436c2d38d7eacd4513acfa0a6b3ebb600337
-      lastVerified: '2026-03-06T11:53:37.671Z'
+      lastVerified: '2026-03-11T02:00:27.630Z'
     performance-and-error-resolver:
       path: .aiox-core/infrastructure/scripts/performance-and-error-resolver.js
       layer: L2
@@ -15430,7 +15435,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de4246a4f01f6da08c8de8a3595505ad8837524db39458f4e6c163cb671b6097
-      lastVerified: '2026-03-06T11:53:37.672Z'
+      lastVerified: '2026-03-11T02:00:27.630Z'
     performance-optimizer:
       path: .aiox-core/infrastructure/scripts/performance-optimizer.js
       layer: L2
@@ -15450,12 +15455,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:80be8b0599b24f3f21f27ac5e53a4f3ecbb69c7b928ba101c6d1912fb19f7156
-      lastVerified: '2026-03-06T11:53:37.672Z'
+      lastVerified: '2026-03-11T02:00:27.630Z'
     performance-tracker:
       path: .aiox-core/infrastructure/scripts/performance-tracker.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\performance-tracker.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/performance-tracker.js
       keywords:
         - performance
         - tracker
@@ -15470,7 +15475,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3c98129cc1597bb637634f566f3440a47c31820e66580a65ebebca5d5771ee6f
-      lastVerified: '2026-03-06T11:53:37.673Z'
+      lastVerified: '2026-03-11T02:00:27.630Z'
     plan-tracker:
       path: .aiox-core/infrastructure/scripts/plan-tracker.js
       layer: L2
@@ -15492,12 +15497,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:12bdcdb1b05e1d36686c7ae3cd4c080e592fe41b0807d64ee08ed089d4e257da
-      lastVerified: '2026-03-06T11:53:37.673Z'
+      lastVerified: '2026-03-11T02:00:27.630Z'
     pm-adapter-factory:
       path: .aiox-core/infrastructure/scripts/pm-adapter-factory.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\pm-adapter-factory.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/pm-adapter-factory.js
       keywords:
         - pm
         - adapter
@@ -15519,7 +15524,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:72ceafb9cf559d619951f95d62a7fd645c95258eca27248985fbb2afb20aa257
-      lastVerified: '2026-03-06T11:53:37.673Z'
+      lastVerified: '2026-03-11T02:00:27.631Z'
     pm-adapter:
       path: .aiox-core/infrastructure/scripts/pm-adapter.js
       layer: L2
@@ -15538,7 +15543,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d8383516f70e1641be210dd4b033541fb6bfafd39fd5976361b8e322cdcb1058
-      lastVerified: '2026-03-06T11:53:37.674Z'
+      lastVerified: '2026-03-11T02:00:27.631Z'
     pr-review-ai:
       path: .aiox-core/infrastructure/scripts/pr-review-ai.js
       layer: L2
@@ -15558,12 +15563,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8872f4ddc23184ea3305cae682741a6a02c1efc170afaa20793c3a9951b374fc
-      lastVerified: '2026-03-06T11:53:37.674Z'
+      lastVerified: '2026-03-11T02:00:27.631Z'
     project-status-loader:
       path: .aiox-core/infrastructure/scripts/project-status-loader.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\project-status-loader.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/project-status-loader.js
       keywords:
         - project
         - status
@@ -15582,12 +15587,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:33d753efad0658a702b08f9422406423a9aceac4c88479622fc660c8e0c8eccb
-      lastVerified: '2026-03-06T11:53:37.676Z'
+      lastVerified: '2026-03-11T02:00:27.631Z'
     qa-loop-orchestrator:
       path: .aiox-core/infrastructure/scripts/qa-loop-orchestrator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\qa-loop-orchestrator.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/qa-loop-orchestrator.js
       keywords:
         - qa
         - loop
@@ -15603,7 +15608,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cadd573d7667f6aecd77940ec48c9c8af5e09685877002625faa14a68f5568c2
-      lastVerified: '2026-03-06T11:53:37.677Z'
+      lastVerified: '2026-03-11T02:00:27.631Z'
     qa-report-generator:
       path: .aiox-core/infrastructure/scripts/qa-report-generator.js
       layer: L2
@@ -15623,7 +15628,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:23756fafc80bc0b6a6926a7436cf6653df02be1d28a68cf6628f203f778ce201
-      lastVerified: '2026-03-06T11:53:37.677Z'
+      lastVerified: '2026-03-11T02:00:27.631Z'
     recovery-tracker:
       path: .aiox-core/infrastructure/scripts/recovery-tracker.js
       layer: L2
@@ -15646,7 +15651,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:09eb60cdd5b6a42a93b5f7450448899bf83e704ecec7d56ea27b560f063e2d1a
-      lastVerified: '2026-03-06T11:53:37.677Z'
+      lastVerified: '2026-03-11T02:00:27.632Z'
     refactoring-suggester:
       path: .aiox-core/infrastructure/scripts/refactoring-suggester.js
       layer: L2
@@ -15666,12 +15671,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:118d4cdbc64cf3238065f2fb98958305ae81e1384bc68f5a6c7b768f1232cd1e
-      lastVerified: '2026-03-06T11:53:37.678Z'
+      lastVerified: '2026-03-11T02:00:27.632Z'
     repository-detector:
       path: .aiox-core/infrastructure/scripts/repository-detector.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\repository-detector.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/repository-detector.js
       keywords:
         - repository
         - detector
@@ -15688,12 +15693,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:10ffca7f57d24d3729c71a9104a154500a3c72328d67884e26e38d22199af332
-      lastVerified: '2026-03-06T11:53:37.678Z'
+      lastVerified: '2026-03-11T02:00:27.632Z'
     rollback-manager:
       path: .aiox-core/infrastructure/scripts/rollback-manager.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\rollback-manager.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/rollback-manager.js
       keywords:
         - rollback
         - manager
@@ -15710,12 +15715,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fe14a4c0b55f35c30f76daf12712fb97308171683bf81d2566e0d01838d57a6e
-      lastVerified: '2026-03-06T11:53:37.679Z'
+      lastVerified: '2026-03-11T02:00:27.632Z'
     sandbox-tester:
       path: .aiox-core/infrastructure/scripts/sandbox-tester.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\sandbox-tester.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/sandbox-tester.js
       keywords:
         - sandbox
         - tester
@@ -15730,7 +15735,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:019af2e23de70d7dacb49faf031ba0c1f5553ecebe52f361bab74bfca73ba609
-      lastVerified: '2026-03-06T11:53:37.679Z'
+      lastVerified: '2026-03-11T02:00:27.632Z'
     security-checker:
       path: .aiox-core/infrastructure/scripts/security-checker.js
       layer: L2
@@ -15754,7 +15759,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d14d9376e3044e61eba40c03931a05dc518f7b8a10618d4f8c9c8a4b300e71fc
-      lastVerified: '2026-03-06T11:53:37.679Z'
+      lastVerified: '2026-03-11T02:00:27.632Z'
     spot-check-validator:
       path: .aiox-core/infrastructure/scripts/spot-check-validator.js
       layer: L2
@@ -15774,12 +15779,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4bf2d20ded322312aef98291d2a23913da565e1622bc97366c476793c6792c81
-      lastVerified: '2026-03-06T11:53:37.679Z'
+      lastVerified: '2026-03-11T02:00:27.632Z'
     status-mapper:
       path: .aiox-core/infrastructure/scripts/status-mapper.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\status-mapper.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/status-mapper.js
       keywords:
         - status
         - mapper
@@ -15794,12 +15799,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6ce6d7324350997b3e1b112aabfbbd0612ebde753ca9ed03e494869b3bb57b1f
-      lastVerified: '2026-03-06T11:53:37.679Z'
+      lastVerified: '2026-03-11T02:00:27.632Z'
     story-worktree-hooks:
       path: .aiox-core/infrastructure/scripts/story-worktree-hooks.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\story-worktree-hooks.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/story-worktree-hooks.js
       keywords:
         - story
         - worktree
@@ -15815,7 +15820,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3e719f61633200d116260931d93925197c7d2d5d857492f87974c6aae160e1a4
-      lastVerified: '2026-03-06T11:53:37.680Z'
+      lastVerified: '2026-03-11T02:00:27.633Z'
     stuck-detector:
       path: .aiox-core/infrastructure/scripts/stuck-detector.js
       layer: L2
@@ -15838,12 +15843,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d1afb4d6d17c06075d43e2327d4f84fce1a4e57a46374b0250a3028c211b1c66
-      lastVerified: '2026-03-06T11:53:37.680Z'
+      lastVerified: '2026-03-11T02:00:27.633Z'
     subtask-verifier:
       path: .aiox-core/infrastructure/scripts/subtask-verifier.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\subtask-verifier.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/subtask-verifier.js
       keywords:
         - subtask
         - verifier
@@ -15858,12 +15863,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ceb0450fa12fa48f0255bb4565858eb1a97b28c30b98d36cb61d52d72e08b054
-      lastVerified: '2026-03-06T11:53:37.680Z'
+      lastVerified: '2026-03-11T02:00:27.633Z'
     template-engine:
       path: .aiox-core/infrastructure/scripts/template-engine.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\template-engine.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/template-engine.js
       keywords:
         - template
         - engine
@@ -15879,12 +15884,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec62a12ff9ad140d32fcbdfc9b5eef636101b75f0835469f1193fee8db0a7d55
-      lastVerified: '2026-03-06T11:53:37.681Z'
+      lastVerified: '2026-03-11T02:00:27.633Z'
     template-validator:
       path: .aiox-core/infrastructure/scripts/template-validator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\template-validator.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/template-validator.js
       keywords:
         - template
         - validator
@@ -15900,7 +15905,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de989116d2f895b58e10355b8853e7b96af6fde151d2612616f18842b9cc56c4
-      lastVerified: '2026-03-06T11:53:37.681Z'
+      lastVerified: '2026-03-11T02:00:27.633Z'
     test-discovery:
       path: .aiox-core/infrastructure/scripts/test-discovery.js
       layer: L2
@@ -15919,12 +15924,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:04038aa49ae515697084fcdacaf0ef8bc36029fc114f5a1206065d7928870449
-      lastVerified: '2026-03-06T11:53:37.681Z'
+      lastVerified: '2026-03-11T02:00:27.633Z'
     test-generator:
       path: .aiox-core/infrastructure/scripts/test-generator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\test-generator.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/test-generator.js
       keywords:
         - test
         - generator
@@ -15939,12 +15944,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f3146896fbcbc99563cc015b828f097167642e24c919c7c9bf6bbfee9ea87cc1
-      lastVerified: '2026-03-06T11:53:37.682Z'
+      lastVerified: '2026-03-11T02:00:27.633Z'
     test-quality-assessment:
       path: .aiox-core/infrastructure/scripts/test-quality-assessment.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\test-quality-assessment.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/test-quality-assessment.js
       keywords:
         - test
         - quality
@@ -15960,12 +15965,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:08c49331641c0fb1873e37fd14a41d88cec7b40f4b16267ae26b4cadc4d292b6
-      lastVerified: '2026-03-06T11:53:37.682Z'
+      lastVerified: '2026-03-11T02:00:27.634Z'
     test-utilities-fast:
       path: .aiox-core/infrastructure/scripts/test-utilities-fast.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\test-utilities-fast.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/test-utilities-fast.js
       keywords:
         - test
         - utilities
@@ -15980,12 +15985,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:70d87a74dac153c65d622afa4d62816e41d8d81eee6d42e1c0e498999bec7c40
-      lastVerified: '2026-03-06T11:53:37.682Z'
+      lastVerified: '2026-03-11T02:00:27.634Z'
     test-utilities:
       path: .aiox-core/infrastructure/scripts/test-utilities.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\test-utilities.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/test-utilities.js
       keywords:
         - test
         - utilities
@@ -15999,12 +16004,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2df35a1706b1389809226fde3c4e0bc72e4d5cebacab3cb98beaa70768049061
-      lastVerified: '2026-03-06T11:53:37.682Z'
+      lastVerified: '2026-03-11T02:00:27.634Z'
     tool-resolver:
       path: .aiox-core/infrastructure/scripts/tool-resolver.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\tool-resolver.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/tool-resolver.js
       keywords:
         - tool
         - resolver
@@ -16021,7 +16026,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2fa44e4a940d4c33570fd9b4495b5c39792c52ca91b98c4be2fb55cb974ad095
-      lastVerified: '2026-03-06T11:53:37.683Z'
+      lastVerified: '2026-03-11T02:00:27.634Z'
     transaction-manager:
       path: .aiox-core/infrastructure/scripts/transaction-manager.js
       layer: L2
@@ -16044,12 +16049,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bed375a4d72928ecfa670626c3e504194c4bf4439eab399fc5b31c919e873e86
-      lastVerified: '2026-03-06T11:53:37.683Z'
+      lastVerified: '2026-03-11T02:00:27.634Z'
     usage-analytics:
       path: .aiox-core/infrastructure/scripts/usage-analytics.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\usage-analytics.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/usage-analytics.js
       keywords:
         - usage
         - analytics
@@ -16064,7 +16069,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5328370f603d7601e7e69b2c19646fad8557394068955fc029b9bc4f70d66bfe
-      lastVerified: '2026-03-06T11:53:37.683Z'
+      lastVerified: '2026-03-11T02:00:27.634Z'
     validate-agents:
       path: .aiox-core/infrastructure/scripts/validate-agents.js
       layer: L2
@@ -16084,12 +16089,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5f5f89a1fcf02ba340772ed30ade56fc346114d7a4d43e6d69af40858c64b180
-      lastVerified: '2026-03-06T11:53:37.683Z'
+      lastVerified: '2026-03-11T02:00:27.634Z'
     validate-claude-integration:
       path: .aiox-core/infrastructure/scripts/validate-claude-integration.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\validate-claude-integration.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/validate-claude-integration.js
       keywords:
         - validate
         - claude
@@ -16105,12 +16110,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3b4e996c2597966fad966d1b2beaecdbda003f6529c41687dfe419d62a319ec6
-      lastVerified: '2026-03-06T11:53:37.683Z'
+      lastVerified: '2026-03-11T02:00:27.634Z'
     validate-codex-integration:
       path: .aiox-core/infrastructure/scripts/validate-codex-integration.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\validate-codex-integration.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/validate-codex-integration.js
       keywords:
         - validate
         - codex
@@ -16126,12 +16131,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0f45a49898528d708ef17871bf6abae4f60483ef8520ce30a9bd4f5e507c585f
-      lastVerified: '2026-03-06T11:53:37.684Z'
+      lastVerified: '2026-03-11T02:00:27.635Z'
     validate-gemini-integration:
       path: .aiox-core/infrastructure/scripts/validate-gemini-integration.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\validate-gemini-integration.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/validate-gemini-integration.js
       keywords:
         - validate
         - gemini
@@ -16147,12 +16152,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:57a31b8a4b8c129189afaad961ed0261a205c02b55028d61146a9e599c112883
-      lastVerified: '2026-03-06T11:53:37.684Z'
+      lastVerified: '2026-03-11T02:00:27.635Z'
     validate-output-pattern:
       path: .aiox-core/infrastructure/scripts/validate-output-pattern.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\validate-output-pattern.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/validate-output-pattern.js
       keywords:
         - validate
         - output
@@ -16167,12 +16172,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:91111d656e8d7b38a20a1bda753e663b74318f75cdab2025c7e0b84c775fc83d
-      lastVerified: '2026-03-06T11:53:37.684Z'
+      lastVerified: '2026-03-11T02:00:27.635Z'
     validate-parity:
       path: .aiox-core/infrastructure/scripts/validate-parity.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\validate-parity.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/validate-parity.js
       keywords:
         - validate
         - parity
@@ -16191,12 +16196,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7f651b869bd501e97d6dccb51dab434818492bc5b02f5eaea00db808cd17cd4c
-      lastVerified: '2026-03-06T11:53:37.684Z'
+      lastVerified: '2026-03-11T02:00:27.635Z'
     validate-paths:
       path: .aiox-core/infrastructure/scripts/validate-paths.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\validate-paths.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/validate-paths.js
       keywords:
         - validate
         - paths
@@ -16211,12 +16216,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:17d453afbfb15bb85ffce096e0ae95a69838b10b3d7a9538ea35664ce851159a
-      lastVerified: '2026-03-06T11:53:37.684Z'
+      lastVerified: '2026-03-11T02:00:27.635Z'
     validate-user-profile:
       path: .aiox-core/infrastructure/scripts/validate-user-profile.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\validate-user-profile.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/validate-user-profile.js
       keywords:
         - validate
         - user
@@ -16232,7 +16237,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a67e6385bb77d6359e91d87882c0641b1444a1f7acd1086203f20953a4f16a37
-      lastVerified: '2026-03-06T11:53:37.685Z'
+      lastVerified: '2026-03-11T02:00:27.635Z'
     visual-impact-generator:
       path: .aiox-core/infrastructure/scripts/visual-impact-generator.js
       layer: L2
@@ -16253,12 +16258,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7771eb4d93b1d371149c15adf83db205c7bf600be6d098fc4364af2886776686
-      lastVerified: '2026-03-06T11:53:37.685Z'
+      lastVerified: '2026-03-11T02:00:27.635Z'
     worktree-manager:
       path: .aiox-core/infrastructure/scripts/worktree-manager.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\worktree-manager.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/worktree-manager.js
       keywords:
         - worktree
         - manager
@@ -16281,12 +16286,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:76ac6c2638b5ddf9d8a359ac9db887b926ca0993d77220f6511c58255f0cfbd3
-      lastVerified: '2026-03-06T11:53:37.685Z'
+      lastVerified: '2026-03-11T02:00:27.635Z'
     yaml-validator:
       path: .aiox-core/infrastructure/scripts/yaml-validator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\yaml-validator.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/yaml-validator.js
       keywords:
         - yaml
         - validator
@@ -16304,7 +16309,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2039ecb9a9d3f639c734c65704018efd2c4656c4995f0b0e537670f7417bf23b
-      lastVerified: '2026-03-06T11:53:37.686Z'
+      lastVerified: '2026-03-11T02:00:27.635Z'
     index:
       path: .aiox-core/infrastructure/scripts/codex-skills-sync/index.js
       layer: L2
@@ -16333,12 +16338,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a7a3c97374c34a900acad13498f61f8a40517574480354218e349d1e1d3931a4
-      lastVerified: '2026-03-06T11:53:37.686Z'
+      lastVerified: '2026-03-11T02:00:27.635Z'
     validate:
       path: .aiox-core/infrastructure/scripts/codex-skills-sync/validate.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\codex-skills-sync\validate.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/codex-skills-sync/validate.js
       keywords:
         - validate
       usedBy:
@@ -16354,7 +16359,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0fbc1baff25f20e3a37d3e4be51d146a75254d5ed638b3438d9f1bf0e587c997
-      lastVerified: '2026-03-06T11:53:37.686Z'
+      lastVerified: '2026-03-11T02:00:27.636Z'
     brownfield-analyzer:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/brownfield-analyzer.js
       layer: L2
@@ -16374,7 +16379,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a5d1a200767592554778f12cfd3594b89dd11d25e1668e81876c34753753df04
-      lastVerified: '2026-03-06T11:53:37.686Z'
+      lastVerified: '2026-03-11T02:00:27.636Z'
     config-generator:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/config-generator.js
       layer: L2
@@ -16394,12 +16399,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bed3eb82140bf4ed547ec1f5c8992cbcd3ce8587a8814f7bef0962c7788965ee
-      lastVerified: '2026-03-06T11:53:37.687Z'
+      lastVerified: '2026-03-11T02:00:27.636Z'
     deployment-config-loader:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/deployment-config-loader.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\documentation-integrity\deployment-config-loader.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/documentation-integrity/deployment-config-loader.js
       keywords:
         - deployment
         - config
@@ -16415,12 +16420,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c58e84348a50a7587de3068fe7dcf69a22478cd4e96a5c44d9b9f7f814c64925
-      lastVerified: '2026-03-06T11:53:37.687Z'
+      lastVerified: '2026-03-11T02:00:27.636Z'
     doc-generator:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/doc-generator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\documentation-integrity\doc-generator.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/documentation-integrity/doc-generator.js
       keywords:
         - doc
         - generator
@@ -16435,7 +16440,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6e58a80fc61b5af4780e98ac5c0c7070b1ed6281a776303d7550ad717b933afb
-      lastVerified: '2026-03-06T11:53:37.687Z'
+      lastVerified: '2026-03-11T02:00:27.636Z'
     gitignore-generator:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/gitignore-generator.js
       layer: L2
@@ -16456,7 +16461,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fc79c0c5311f3043a07a9e08480a70c8a1328ac6e00679a5141de8226c5dd4ca
-      lastVerified: '2026-03-06T11:53:37.688Z'
+      lastVerified: '2026-03-11T02:00:27.636Z'
     mode-detector:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/mode-detector.js
       layer: L2
@@ -16477,12 +16482,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:955af283f28d088d844b6e3f388b48caf265d746ff499599973196cb07612730
-      lastVerified: '2026-03-06T11:53:37.688Z'
+      lastVerified: '2026-03-11T02:00:27.636Z'
     post-commit:
       path: .aiox-core/infrastructure/scripts/git-hooks/post-commit.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\git-hooks\post-commit.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/git-hooks/post-commit.js
       keywords:
         - post
         - commit
@@ -16496,7 +16501,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a7eea0e43a254804a09fc09a94c9c44d8da0b285ce5dc2ea6149d426732fd917
-      lastVerified: '2026-03-06T11:53:37.688Z'
+      lastVerified: '2026-03-11T02:00:27.636Z'
     agent-parser:
       path: .aiox-core/infrastructure/scripts/ide-sync/agent-parser.js
       layer: L2
@@ -16520,7 +16525,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b4dceac261653d85d791b6cd8b010ebfaa75cab179477b193a2448482b4aa4d4
-      lastVerified: '2026-03-06T11:53:37.689Z'
+      lastVerified: '2026-03-11T02:00:27.636Z'
     gemini-commands:
       path: .aiox-core/infrastructure/scripts/ide-sync/gemini-commands.js
       layer: L2
@@ -16539,12 +16544,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ba02b21af0d485b14d6e248b6d5644090646dc792f78eac515d17b88680d8549
-      lastVerified: '2026-03-06T11:53:37.689Z'
+      lastVerified: '2026-03-11T02:00:27.636Z'
     redirect-generator:
       path: .aiox-core/infrastructure/scripts/ide-sync/redirect-generator.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\ide-sync\redirect-generator.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/redirect-generator.js
       keywords:
         - redirect
         - generator
@@ -16559,7 +16564,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:89ead2308414418e83fb66f591abddabd7137d87b57adca129fa57d119780b2a
-      lastVerified: '2026-03-06T11:53:37.691Z'
+      lastVerified: '2026-03-11T02:00:27.636Z'
     validator:
       path: .aiox-core/infrastructure/scripts/ide-sync/validator.js
       layer: L2
@@ -16578,12 +16583,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:356c78125db7f88d14f4e521808e96593d729291c3d7a1c36cb02f78b4aef8fc
-      lastVerified: '2026-03-06T11:53:37.691Z'
+      lastVerified: '2026-03-11T02:00:27.637Z'
     install-llm-routing:
       path: .aiox-core/infrastructure/scripts/llm-routing/install-llm-routing.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\llm-routing\install-llm-routing.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/llm-routing/install-llm-routing.js
       keywords:
         - install
         - llm
@@ -16599,12 +16604,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c9faab7f6149a8046abe5c9a026055c5f386cfef700136b76e5fa579e60bed8
-      lastVerified: '2026-03-06T11:53:37.691Z'
+      lastVerified: '2026-03-11T02:00:27.637Z'
     antigravity:
       path: .aiox-core/infrastructure/scripts/ide-sync/transformers/antigravity.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\ide-sync\transformers\antigravity.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/transformers/antigravity.js
       keywords:
         - antigravity
       usedBy: []
@@ -16618,12 +16623,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e00910c008c8547a1943f79c676d0a4c0d014b638fc15c8a68e2574d6949744b
-      lastVerified: '2026-03-06T11:53:37.691Z'
+      lastVerified: '2026-03-11T02:00:27.637Z'
     claude-code:
       path: .aiox-core/infrastructure/scripts/ide-sync/transformers/claude-code.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\ide-sync\transformers\claude-code.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/transformers/claude-code.js
       keywords:
         - claude
         - code
@@ -16637,12 +16642,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:82eea7091a8bdc89f9067dd420b535574c9bdb2dee8c616eda99758069328a84
-      lastVerified: '2026-03-06T11:53:37.701Z'
+      lastVerified: '2026-03-11T02:00:27.637Z'
     cursor:
       path: .aiox-core/infrastructure/scripts/ide-sync/transformers/cursor.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core\infrastructure\scripts\ide-sync\transformers\cursor.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/transformers/cursor.js
       keywords:
         - cursor
       usedBy: []
@@ -16656,7 +16661,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c24d24e4bec477c3b75340aeac08c5a4a2780001eec9c25e6b00d4f0af53d4f0
-      lastVerified: '2026-03-06T11:53:37.720Z'
+      lastVerified: '2026-03-11T02:00:27.637Z'
     github-copilot:
       path: .aiox-core/infrastructure/scripts/ide-sync/transformers/github-copilot.js
       layer: L2
@@ -16676,7 +16681,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6d365be4a55e2f5ced316a0efbfa50fb925562f3e145d47a86c57a2c685343ac
-      lastVerified: '2026-03-06T11:53:37.720Z'
+      lastVerified: '2026-03-11T02:00:27.637Z'
   infra-tools:
     README:
       path: .aiox-core/infrastructure/tools/README.md
@@ -16702,7 +16707,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2f8f4141b9f4a71ad51668d28fc9a12362835dd40eb45992c645f9bfe28f8a48
-      lastVerified: '2026-03-06T11:53:37.723Z'
+      lastVerified: '2026-03-11T02:00:27.638Z'
     github-cli:
       path: .aiox-core/infrastructure/tools/cli/github-cli.yaml
       layer: L2
@@ -16727,7 +16732,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:222ca6016e9487d2da13bead0af5cee6099885ea438b359ff5fa5a73c7cd4820
-      lastVerified: '2026-03-06T11:53:37.723Z'
+      lastVerified: '2026-03-11T02:00:27.638Z'
     llm-routing:
       path: .aiox-core/infrastructure/tools/cli/llm-routing.yaml
       layer: L2
@@ -16749,7 +16754,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d97183f254876933de02d9ad2c793ad7d06e37dd0c4f9da9fb68097a5d0eedb3
-      lastVerified: '2026-03-06T11:53:37.723Z'
+      lastVerified: '2026-03-11T02:00:27.638Z'
     railway-cli:
       path: .aiox-core/infrastructure/tools/cli/railway-cli.yaml
       layer: L2
@@ -16770,7 +16775,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cab769df07cfd0a65bfed0e7140dfde3bf3c54cd6940452d2d18e18f99a63e4a
-      lastVerified: '2026-03-06T11:53:37.723Z'
+      lastVerified: '2026-03-11T02:00:27.638Z'
     supabase-cli:
       path: .aiox-core/infrastructure/tools/cli/supabase-cli.yaml
       layer: L2
@@ -16794,7 +16799,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:659fefd3d8b182dd06fc5be560fcf386a028156386b2029cd51bbd7d3b5e6bfd
-      lastVerified: '2026-03-06T11:53:37.724Z'
+      lastVerified: '2026-03-11T02:00:27.638Z'
     ffmpeg:
       path: .aiox-core/infrastructure/tools/local/ffmpeg.yaml
       layer: L2
@@ -16813,7 +16818,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d481a548e0eb327513412c7ac39e4a92ac27a283f4b9e6c43211fed52281df44
-      lastVerified: '2026-03-06T11:53:37.724Z'
+      lastVerified: '2026-03-11T02:00:27.638Z'
     21st-dev-magic:
       path: .aiox-core/infrastructure/tools/mcp/21st-dev-magic.yaml
       layer: L2
@@ -16836,7 +16841,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5e1b575bdb51c6b5d446a2255fa068194d2010bce56c8c0dd0b2e98e3cf61f18
-      lastVerified: '2026-03-06T11:53:37.724Z'
+      lastVerified: '2026-03-11T02:00:27.638Z'
     browser:
       path: .aiox-core/infrastructure/tools/mcp/browser.yaml
       layer: L2
@@ -16857,7 +16862,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c28206d92a6127d299ca60955cd6f6d03c940ac8b221f1e9fc620dd7efd7b471
-      lastVerified: '2026-03-06T11:53:37.724Z'
+      lastVerified: '2026-03-11T02:00:27.638Z'
     clickup:
       path: .aiox-core/infrastructure/tools/mcp/clickup.yaml
       layer: L2
@@ -16876,7 +16881,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:aa7c34786e8e332a3486b136f40ec997dcc2a7e408bbc99a8899b0653baac6ee
-      lastVerified: '2026-03-06T11:53:37.724Z'
+      lastVerified: '2026-03-11T02:00:27.638Z'
     context7:
       path: .aiox-core/infrastructure/tools/mcp/context7.yaml
       layer: L2
@@ -16902,7 +16907,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:321e0e23a787c36260efdbb1a3953235fa7dc57e77b211610ffaf33bc21fca02
-      lastVerified: '2026-03-06T11:53:37.725Z'
+      lastVerified: '2026-03-11T02:00:27.638Z'
     desktop-commander:
       path: .aiox-core/infrastructure/tools/mcp/desktop-commander.yaml
       layer: L2
@@ -16921,7 +16926,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec1a5db7def48d1762e68d4477ad0574bbb54a6783256870f5451c666ebdc213
-      lastVerified: '2026-03-06T11:53:37.725Z'
+      lastVerified: '2026-03-11T02:00:27.638Z'
     exa:
       path: .aiox-core/infrastructure/tools/mcp/exa.yaml
       layer: L2
@@ -16943,7 +16948,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:02576ff68b8de8a2d4e6aaffaeade78d5c208b95380feeacb37e2105c6f83541
-      lastVerified: '2026-03-06T11:53:37.725Z'
+      lastVerified: '2026-03-11T02:00:27.638Z'
     google-workspace:
       path: .aiox-core/infrastructure/tools/mcp/google-workspace.yaml
       layer: L2
@@ -16965,7 +16970,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f017c3154e9d480f37d94c7ddd7c3d24766b4fa7e0ee9e722600e85da75734b4
-      lastVerified: '2026-03-06T11:53:37.725Z'
+      lastVerified: '2026-03-11T02:00:27.639Z'
     n8n:
       path: .aiox-core/infrastructure/tools/mcp/n8n.yaml
       layer: L2
@@ -16984,7 +16989,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f9d9536ec47f9911e634083c3ac15cb920214ea0f052e78d4c6a27a17e9ec408
-      lastVerified: '2026-03-06T11:53:37.725Z'
+      lastVerified: '2026-03-11T02:00:27.639Z'
     supabase:
       path: .aiox-core/infrastructure/tools/mcp/supabase.yaml
       layer: L2
@@ -17006,7 +17011,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:350bd31537dfef9c3df55bd477434ccbe644cdf0dd3408bf5a8a6d0c5ba78aa2
-      lastVerified: '2026-03-06T11:53:37.726Z'
+      lastVerified: '2026-03-11T02:00:27.639Z'
   product-checklists:
     accessibility-wcag-checklist:
       path: .aiox-core/product/checklists/accessibility-wcag-checklist.md
@@ -17028,7 +17033,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:56126182b25e9b7bdde43f75315e33167eb49b1f9a9cb0e9a37bc068af40aeab
-      lastVerified: '2026-03-06T11:53:37.736Z'
+      lastVerified: '2026-03-11T02:00:27.639Z'
     architect-checklist:
       path: .aiox-core/product/checklists/architect-checklist.md
       layer: L2
@@ -17051,7 +17056,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ecbcc8e6b34f813bc73ebcc28482c045ef12c6b17808ee6f70a808eee1818911
-      lastVerified: '2026-03-06T11:53:37.737Z'
+      lastVerified: '2026-03-11T02:00:27.639Z'
     change-checklist:
       path: .aiox-core/product/checklists/change-checklist.md
       layer: L2
@@ -17084,7 +17089,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:edaa126d5db726fce3a422be6441928b1177fe13e5e8defe2d2cb8959acd1439
-      lastVerified: '2026-03-06T11:53:37.750Z'
+      lastVerified: '2026-03-11T02:00:27.640Z'
     component-quality-checklist:
       path: .aiox-core/product/checklists/component-quality-checklist.md
       layer: L2
@@ -17105,7 +17110,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec4e34a3fc4a071d346a8ba473f521d2a38e5eb07d1656fee6ff108e5cd7b62f
-      lastVerified: '2026-03-06T11:53:37.750Z'
+      lastVerified: '2026-03-11T02:00:27.640Z'
     database-design-checklist:
       path: .aiox-core/product/checklists/database-design-checklist.md
       layer: L2
@@ -17126,7 +17131,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6d3cf038f0320db0e6daf9dba61e4c29269ed73c793df5618e155ebd07b6c200
-      lastVerified: '2026-03-06T11:53:37.751Z'
+      lastVerified: '2026-03-11T02:00:27.640Z'
     dba-predeploy-checklist:
       path: .aiox-core/product/checklists/dba-predeploy-checklist.md
       layer: L2
@@ -17148,7 +17153,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:482136936a2414600b59d4d694526c008287e3376ed73c9a93de78d7d7bd3285
-      lastVerified: '2026-03-06T11:53:37.751Z'
+      lastVerified: '2026-03-11T02:00:27.640Z'
     dba-rollback-checklist:
       path: .aiox-core/product/checklists/dba-rollback-checklist.md
       layer: L2
@@ -17169,7 +17174,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:060847cba7ef223591c2c1830c65994fd6cf8135625d6953a3a5b874301129c5
-      lastVerified: '2026-03-06T11:53:37.751Z'
+      lastVerified: '2026-03-11T02:00:27.640Z'
     migration-readiness-checklist:
       path: .aiox-core/product/checklists/migration-readiness-checklist.md
       layer: L2
@@ -17190,7 +17195,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6231576966f24b30c00fe7cc836359e10c870c266a30e5d88c6b3349ad2f1d17
-      lastVerified: '2026-03-06T11:53:37.752Z'
+      lastVerified: '2026-03-11T02:00:27.640Z'
     pattern-audit-checklist:
       path: .aiox-core/product/checklists/pattern-audit-checklist.md
       layer: L2
@@ -17211,7 +17216,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2eb28cb0e7abd8900170123c1d080c1bbb81ccb857eeb162c644f40616b0875e
-      lastVerified: '2026-03-06T11:53:37.752Z'
+      lastVerified: '2026-03-11T02:00:27.640Z'
     pm-checklist:
       path: .aiox-core/product/checklists/pm-checklist.md
       layer: L2
@@ -17236,7 +17241,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6828efd3acf32638e31b8081ca0c6f731aa5710c8413327db5a8096b004aeb2b
-      lastVerified: '2026-03-06T11:53:37.752Z'
+      lastVerified: '2026-03-11T02:00:27.640Z'
     po-master-checklist:
       path: .aiox-core/product/checklists/po-master-checklist.md
       layer: L2
@@ -17272,7 +17277,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:506a3032f461c7ae96c338600208575be4f4823d2fe7c92fe304a4ff07cc5390
-      lastVerified: '2026-03-06T11:53:37.753Z'
+      lastVerified: '2026-03-11T02:00:27.640Z'
     pre-push-checklist:
       path: .aiox-core/product/checklists/pre-push-checklist.md
       layer: L2
@@ -17296,7 +17301,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8b96f7216101676b86b314c347fa8c6d616cde21dbc77ef8f77b8d0b5770af2a
-      lastVerified: '2026-03-06T11:53:37.754Z'
+      lastVerified: '2026-03-11T02:00:27.640Z'
     release-checklist:
       path: .aiox-core/product/checklists/release-checklist.md
       layer: L2
@@ -17317,7 +17322,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a5e66e27d115abd544834a70f3dda429bc486fbcb569870031c4f79fd8ac6187
-      lastVerified: '2026-03-06T11:53:37.754Z'
+      lastVerified: '2026-03-11T02:00:27.640Z'
     self-critique-checklist:
       path: .aiox-core/product/checklists/self-critique-checklist.md
       layer: L2
@@ -17341,7 +17346,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9f257660bb386ea315fe4ab8b259897058d279e66338801db234c25750be9c2c
-      lastVerified: '2026-03-06T11:53:37.766Z'
+      lastVerified: '2026-03-11T02:00:27.641Z'
     story-dod-checklist:
       path: .aiox-core/product/checklists/story-dod-checklist.md
       layer: L2
@@ -17366,7 +17371,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:725b60a16a41886a92794e54b9efa8359eab5f09813cd584fa9e8e1519c78dc4
-      lastVerified: '2026-03-06T11:53:37.776Z'
+      lastVerified: '2026-03-11T02:00:27.641Z'
     story-draft-checklist:
       path: .aiox-core/product/checklists/story-draft-checklist.md
       layer: L2
@@ -17391,7 +17396,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cf500e2a8a471573d25f3d73439a41fffea9f5351963c598fd2285ec909f96ce
-      lastVerified: '2026-03-06T11:53:37.777Z'
+      lastVerified: '2026-03-11T02:00:27.641Z'
   product-data:
     atomic-design-principles:
       path: .aiox-core/product/data/atomic-design-principles.md
@@ -17412,7 +17417,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:66153135e28394178c4f8f33441c45a2404587c2f07d25ad09dde54f3f5e1746
-      lastVerified: '2026-03-06T11:53:37.803Z'
+      lastVerified: '2026-03-11T02:00:27.641Z'
     brainstorming-techniques:
       path: .aiox-core/product/data/brainstorming-techniques.md
       layer: L2
@@ -17432,7 +17437,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c5a558d21eb620a8c820d8ca9807b2d12c299375764289482838f81ef63dbce
-      lastVerified: '2026-03-06T11:53:37.806Z'
+      lastVerified: '2026-03-11T02:00:27.641Z'
     consolidation-algorithms:
       path: .aiox-core/product/data/consolidation-algorithms.md
       layer: L2
@@ -17452,7 +17457,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2f2561be9e6281f6352f05e1c672954001f919c4664e3fecd6fcde24fdd4d240
-      lastVerified: '2026-03-06T11:53:37.806Z'
+      lastVerified: '2026-03-11T02:00:27.641Z'
     database-best-practices:
       path: .aiox-core/product/data/database-best-practices.md
       layer: L2
@@ -17473,7 +17478,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8331f001e903283633f0123d123546ef3d4682ed0e0f9516b4df391fe57b9b7d
-      lastVerified: '2026-03-06T11:53:37.807Z'
+      lastVerified: '2026-03-11T02:00:27.641Z'
     design-token-best-practices:
       path: .aiox-core/product/data/design-token-best-practices.md
       layer: L2
@@ -17494,7 +17499,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:10cf3c824bba452ee598e2325b8bfb2068f188d9ac3058b9e034ddf34bf4791a
-      lastVerified: '2026-03-06T11:53:37.807Z'
+      lastVerified: '2026-03-11T02:00:27.642Z'
     elicitation-methods:
       path: .aiox-core/product/data/elicitation-methods.md
       layer: L2
@@ -17514,7 +17519,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f8e46f90bd0acc1e9697086d7a2008c7794bc767e99d0037c64e6800e9d17ef4
-      lastVerified: '2026-03-06T11:53:37.807Z'
+      lastVerified: '2026-03-11T02:00:27.642Z'
     integration-patterns:
       path: .aiox-core/product/data/integration-patterns.md
       layer: L2
@@ -17534,7 +17539,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b771f999fb452dcabf835d5f5e5ae3982c48cece5941cc5a276b6f280062db43
-      lastVerified: '2026-03-06T11:53:37.807Z'
+      lastVerified: '2026-03-11T02:00:27.642Z'
     migration-safety-guide:
       path: .aiox-core/product/data/migration-safety-guide.md
       layer: L2
@@ -17555,7 +17560,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:42200ca180d4586447304dfc7f8035ccd09860b6ac34c72b63d284e57c94d2db
-      lastVerified: '2026-03-06T11:53:37.807Z'
+      lastVerified: '2026-03-11T02:00:27.642Z'
     mode-selection-best-practices:
       path: .aiox-core/product/data/mode-selection-best-practices.md
       layer: L2
@@ -17576,7 +17581,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4ed5ee7aaeadb2e3c12029b7cae9a6063f3a7b016fdd0d53f9319d461ddf3ea1
-      lastVerified: '2026-03-06T11:53:37.808Z'
+      lastVerified: '2026-03-11T02:00:27.642Z'
     postgres-tuning-guide:
       path: .aiox-core/product/data/postgres-tuning-guide.md
       layer: L2
@@ -17598,7 +17603,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4715262241ae6ba2da311865506781bd7273fa6ee1bd55e15968dfda542c2bec
-      lastVerified: '2026-03-06T11:53:37.808Z'
+      lastVerified: '2026-03-11T02:00:27.642Z'
     rls-security-patterns:
       path: .aiox-core/product/data/rls-security-patterns.md
       layer: L2
@@ -17621,7 +17626,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e3e12a06b483c1bda645e7eb361a230bdef106cc5d1140a69b443a4fc2ad70ef
-      lastVerified: '2026-03-06T11:53:37.808Z'
+      lastVerified: '2026-03-11T02:00:27.642Z'
     roi-calculation-guide:
       path: .aiox-core/product/data/roi-calculation-guide.md
       layer: L2
@@ -17641,7 +17646,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f00a3c039297b3cb6e00f68d5feb6534a27c2a0ad02afd14df50e4e0cf285aa4
-      lastVerified: '2026-03-06T11:53:37.808Z'
+      lastVerified: '2026-03-11T02:00:27.642Z'
     supabase-patterns:
       path: .aiox-core/product/data/supabase-patterns.md
       layer: L2
@@ -17661,7 +17666,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9ed119bc89f859125a0489036d747ff13b6c475a9db53946fdb7f3be02b41e0a
-      lastVerified: '2026-03-06T11:53:37.808Z'
+      lastVerified: '2026-03-11T02:00:27.642Z'
     test-levels-framework:
       path: .aiox-core/product/data/test-levels-framework.md
       layer: L2
@@ -17681,7 +17686,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b9a50f9c3b5b153280c93ea30f823f30deb2ba7aea588039b5a2bdea0b23891e
-      lastVerified: '2026-03-06T11:53:37.809Z'
+      lastVerified: '2026-03-11T02:00:27.642Z'
     test-priorities-matrix:
       path: .aiox-core/product/data/test-priorities-matrix.md
       layer: L2
@@ -17701,7 +17706,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c97c7279f23ed42ea2588814f204432a93d658d9b5a9914e34647db796a70a60
-      lastVerified: '2026-03-06T11:53:37.809Z'
+      lastVerified: '2026-03-11T02:00:27.642Z'
     wcag-compliance-guide:
       path: .aiox-core/product/data/wcag-compliance-guide.md
       layer: L2
@@ -17721,7 +17726,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8f5a97e1522da2193e2a2eae18dc68c4477acf3e2471b50b46885163cefa40e6
-      lastVerified: '2026-03-06T11:53:37.809Z'
+      lastVerified: '2026-03-11T02:00:27.642Z'
 categories:
   - id: tasks
     description: Executable task workflows for agent operations

--- a/.aiox-core/development/agents/aiox-master.md
+++ b/.aiox-core/development/agents/aiox-master.md
@@ -102,7 +102,8 @@ persona:
   role: Master Orchestrator, Framework Developer & AIOX Method Expert
   identity: Universal executor of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and executes any task directly
   core_principles:
-    - Execute any resource directly without persona transformation
+    - "PRE-EXECUTION CHECK: Before executing any task, verify if an exclusive agent owns it (see agent-authority.md Delegation Matrix). If yes, DELEGATE — do not execute directly. Exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
+    - Execute framework governance tasks directly (meta-ops, orchestration, constitutional enforcement)
     - Load resources at runtime, never pre-load
     - Expert knowledge of all AIOX resources when using *kb
     - Always present numbered lists for choices

--- a/.aiox-core/development/agents/aiox-master.md
+++ b/.aiox-core/development/agents/aiox-master.md
@@ -100,7 +100,7 @@ persona_profile:
 
 persona:
   role: Master Orchestrator, Framework Developer & AIOX Method Expert
-  identity: Universal executor of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and executes any task directly
+  identity: Master orchestrator of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and delegates agent-owned tasks to their exclusive owners; executes directly only framework governance tasks or when explicit exceptions apply
   core_principles:
     - "PRE-EXECUTION CHECK: Before executing any task, verify if an exclusive agent owns it (see agent-authority.md Delegation Matrix). If yes, DELEGATE — do not execute directly. Exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
     - "Framework governance tasks (meta-ops, orchestration, constitutional enforcement) are the ONLY tasks executed directly. All tasks that belong to an exclusive agent MUST be delegated first. Direct execution is permitted only under explicit exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
@@ -398,7 +398,7 @@ Type `*help` to see all commands, or `*kb` to enable KB mode.
 
 **I orchestrate:**
 
-- **All agents** - Can execute any task from any agent directly
+- **All agents** - Delegates to the owning exclusive agent first; executes directly only for framework governance tasks or when --force-execute, workflow-engine mode, or AIOX_DEBUG=true applies
 - **Framework development** - Creates and modifies agents, tasks, workflows (via `*create {type}`, `*modify {type}`)
 
 **Delegated responsibilities (Story 6.1.2.3):**
@@ -430,7 +430,7 @@ Type `*help` to see all commands, or `*kb` to enable KB mode.
 
 - Creating/modifying AIOX framework components (agents, tasks, workflows)
 - Orchestrating complex multi-agent workflows
-- Executing any task from any agent directly
+- Executing framework governance tasks directly; delegating exclusive-agent tasks to their owners (with --force-execute, workflow-engine mode, or AIOX_DEBUG=true as explicit override)
 - Framework development and meta-operations
 
 ### Prerequisites

--- a/.aiox-core/development/agents/aiox-master.md
+++ b/.aiox-core/development/agents/aiox-master.md
@@ -103,7 +103,7 @@ persona:
   identity: Universal executor of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and executes any task directly
   core_principles:
     - "PRE-EXECUTION CHECK: Before executing any task, verify if an exclusive agent owns it (see agent-authority.md Delegation Matrix). If yes, DELEGATE — do not execute directly. Exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
-    - Execute framework governance tasks directly (meta-ops, orchestration, constitutional enforcement)
+    - "Framework governance tasks (meta-ops, orchestration, constitutional enforcement) are the ONLY tasks executed directly. All tasks that belong to an exclusive agent MUST be delegated first. Direct execution is permitted only under explicit exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
     - Load resources at runtime, never pre-load
     - Expert knowledge of all AIOX resources when using *kb
     - Always present numbered lists for choices

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.0.3
-generated_at: "2026-03-11T12:47:44.159Z"
+generated_at: "2026-03-11T12:58:58.039Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1089
 files:
@@ -689,9 +689,9 @@ files:
     type: core
     size: 7755
   - path: core/ideation/ideation-engine.js
-    hash: sha256:8e496a9344ad86cb60e0f620ffe5bb30ec3f43ac582901da100674ba8149edad
+    hash: sha256:d9108fa47ed7a9131703739befb214b97d5b8e546faf1b49d8ae9d083756c589
     type: core
-    size: 22955
+    size: 22865
   - path: core/ids/circuit-breaker.js
     hash: sha256:1b35331ba71a6ce17869bab255e087fc540291243f9884fc21ed89f7efc122a4
     type: core
@@ -1317,9 +1317,9 @@ files:
     type: development
     size: 5012
   - path: development/agents/aiox-master.md
-    hash: sha256:9db9070fe5a019e100d6773108b23989c241089b1aea55f88580018e296d542c
+    hash: sha256:a9494b4c5f05340ea035b36c7617ddb60bc6f479f6cb029719afba9d161de384
     type: agent
-    size: 19922
+    size: 20304
   - path: development/agents/analyst.md
     hash: sha256:35150d764c6dc74bc02b61a4d613c9278e87ffb209403db23991339fdda4f8e2
     type: agent

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,9 +8,9 @@
 # - File types for categorization
 #
 version: 5.0.3
-generated_at: "2026-03-11T12:58:58.039Z"
+generated_at: "2026-03-11T15:04:21.905Z"
 generator: scripts/generate-install-manifest.js
-file_count: 1089
+file_count: 1090
 files:
   - path: cli/commands/config/index.js
     hash: sha256:25c4b9bf4e0241abf7754b55153f49f1a214f1fb5fe904a576675634cb7b3da9
@@ -241,9 +241,9 @@ files:
     type: core
     size: 4704
   - path: core/config/config-loader.js
-    hash: sha256:e19fee885b060c85ee75df71a016259b8e4c21e6c7045a58514afded3a2386a8
+    hash: sha256:bbc6a9e57e9db7a74ae63c901b199f8b8a79eb093f23a280b6420d1aa5f7f813
     type: core
-    size: 8456
+    size: 8534
   - path: core/config/config-resolver.js
     hash: sha256:3b29df6954cec440debef87cb4e4e7610c94dc74e562d32c74b8ec57d893213b
     type: core
@@ -405,9 +405,9 @@ files:
     type: core
     size: 31780
   - path: core/execution/build-state-manager.js
-    hash: sha256:595523caf6db26624e7a483489345b9498ae15d99c2568073a2c0c45d5b46a54
+    hash: sha256:415fca3ad3d750db1f41f14f33971cf661ee9d6073a570175d695bb3c1be655c
     type: core
-    size: 48948
+    size: 48976
   - path: core/execution/context-injector.js
     hash: sha256:a183255eb4831f701086f23f371f94a9ce10c46ea18c8369ec0fd756777f042f
     type: core
@@ -1205,9 +1205,9 @@ files:
     type: core
     size: 9061
   - path: core/utils/yaml-validator.js
-    hash: sha256:41e3715845262c2e49f58745a773e81f4feaaa2325e54bcb0226e4bf08f709dd
+    hash: sha256:05084596198634dd2a670a752d5c451edfe268e16e3bae511db52184f895366f
     type: core
-    size: 10916
+    size: 10934
   - path: data/agent-config-requirements.yaml
     hash: sha256:68e87b5777d1872c4fed6644dd3c7e3c3e8fd590df7d2b58c36d541cf8e38dd3
     type: data
@@ -2236,6 +2236,10 @@ files:
     hash: sha256:90bba47136ccc37c74454a4537728b958955fd487e46e3b8dca869b994c8d1c1
     type: task
     size: 19031
+  - path: development/tasks/project-status.md
+    hash: sha256:3cb76eeb42b7e0b46a06ce0827bc68d2f507a7f4021174b1bd9e68d82463e5e6
+    type: task
+    size: 8664
   - path: development/tasks/propose-modification.md
     hash: sha256:fa340dc0749f40ba7f1ed12ebe107c53f212f764cf7318ee7a816d059528f69e
     type: task

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,9 +8,9 @@
 # - File types for categorization
 #
 version: 5.0.3
-generated_at: "2026-03-11T12:38:10.304Z"
+generated_at: "2026-03-11T02:00:59.911Z"
 generator: scripts/generate-install-manifest.js
-file_count: 1091
+file_count: 1089
 files:
   - path: cli/commands/config/index.js
     hash: sha256:25c4b9bf4e0241abf7754b55153f49f1a214f1fb5fe904a576675634cb7b3da9
@@ -241,9 +241,9 @@ files:
     type: core
     size: 4704
   - path: core/config/config-loader.js
-    hash: sha256:bbc6a9e57e9db7a74ae63c901b199f8b8a79eb093f23a280b6420d1aa5f7f813
+    hash: sha256:e19fee885b060c85ee75df71a016259b8e4c21e6c7045a58514afded3a2386a8
     type: core
-    size: 8534
+    size: 8456
   - path: core/config/config-resolver.js
     hash: sha256:3b29df6954cec440debef87cb4e4e7610c94dc74e562d32c74b8ec57d893213b
     type: core
@@ -405,9 +405,9 @@ files:
     type: core
     size: 31780
   - path: core/execution/build-state-manager.js
-    hash: sha256:415fca3ad3d750db1f41f14f33971cf661ee9d6073a570175d695bb3c1be655c
+    hash: sha256:595523caf6db26624e7a483489345b9498ae15d99c2568073a2c0c45d5b46a54
     type: core
-    size: 48976
+    size: 48948
   - path: core/execution/context-injector.js
     hash: sha256:a183255eb4831f701086f23f371f94a9ce10c46ea18c8369ec0fd756777f042f
     type: core
@@ -901,9 +901,9 @@ files:
     type: core
     size: 8663
   - path: core/orchestration/master-orchestrator.js
-    hash: sha256:61b874d74fae62e9307861b02b7505538f1c94362fe638fc3941b0665dcbbdf6
+    hash: sha256:9f9a8c6be08bf371eff33076e01c8aeec610aec27a81534dad93e15f0824d983
     type: core
-    size: 54417
+    size: 54489
   - path: core/orchestration/message-formatter.js
     hash: sha256:b7413c04fa22db1c5fc2f5c2aa47bb8ca0374e079894a44df21b733da6c258ae
     type: core
@@ -1205,9 +1205,9 @@ files:
     type: core
     size: 9061
   - path: core/utils/yaml-validator.js
-    hash: sha256:05084596198634dd2a670a752d5c451edfe268e16e3bae511db52184f895366f
+    hash: sha256:41e3715845262c2e49f58745a773e81f4feaaa2325e54bcb0226e4bf08f709dd
     type: core
-    size: 10934
+    size: 10916
   - path: data/agent-config-requirements.yaml
     hash: sha256:68e87b5777d1872c4fed6644dd3c7e3c3e8fd590df7d2b58c36d541cf8e38dd3
     type: data
@@ -1221,9 +1221,9 @@ files:
     type: data
     size: 9575
   - path: data/entity-registry.yaml
-    hash: sha256:151aca46769c614f0238e7a8e2968884c3888b438ff1c634f0eeb2505e325b83
+    hash: sha256:e25c7cdd771453ac5b82630ede5a45dd70b0f035fa538ce75d150f44d425eef3
     type: data
-    size: 521804
+    size: 521869
   - path: data/learned-patterns.yaml
     hash: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
     type: data
@@ -1317,9 +1317,9 @@ files:
     type: development
     size: 5012
   - path: development/agents/aiox-master.md
-    hash: sha256:17cd10f6c2ac4fcd96d944283f239c760e2829d2de4e68098f618783ec5ae351
+    hash: sha256:a2f8c55ac39c3489b656494f24ee7793307b724a2fa35383f430b0be86694ce5
     type: agent
-    size: 19408
+    size: 19704
   - path: development/agents/analyst.md
     hash: sha256:35150d764c6dc74bc02b61a4d613c9278e87ffb209403db23991339fdda4f8e2
     type: agent
@@ -2236,10 +2236,6 @@ files:
     hash: sha256:90bba47136ccc37c74454a4537728b958955fd487e46e3b8dca869b994c8d1c1
     type: task
     size: 19031
-  - path: development/tasks/project-status.md
-    hash: sha256:3cb76eeb42b7e0b46a06ce0827bc68d2f507a7f4021174b1bd9e68d82463e5e6
-    type: task
-    size: 8664
   - path: development/tasks/propose-modification.md
     hash: sha256:fa340dc0749f40ba7f1ed12ebe107c53f212f764cf7318ee7a816d059528f69e
     type: task
@@ -2348,10 +2344,6 @@ files:
     hash: sha256:dfb5f03fae16171777742b06a9e54ee25711d1d94cedc2152ef9c9331310b608
     type: task
     size: 5254
-  - path: development/tasks/review-prs.md
-    hash: sha256:f49dcdc3f16a1bb187ab76daa6c8bf28e69ea1506b0048661cbda7907ac45fba
-    type: task
-    size: 14109
   - path: development/tasks/run-design-system-pipeline.md
     hash: sha256:ff4c225b922da347b63aeb6d8aa95484c1c9281eb1e4b4c4ab0ecef0a1a54c26
     type: task
@@ -2591,19 +2583,19 @@ files:
   - path: development/templates/service-template/__tests__/index.test.ts.hbs
     hash: sha256:4617c189e75ab362d4ef2cabcc3ccce3480f914fd915af550469c17d1b68a4fe
     type: template
-    size: 9810
+    size: 9573
   - path: development/templates/service-template/client.ts.hbs
     hash: sha256:f342c60695fe611192002bdb8c04b3a0dbce6345b7fa39834ea1898f71689198
     type: template
-    size: 12213
+    size: 11810
   - path: development/templates/service-template/errors.ts.hbs
     hash: sha256:e0be40d8be19b71b26e35778eadffb20198e7ca88e9d140db9da1bfe12de01ec
     type: template
-    size: 5395
+    size: 5213
   - path: development/templates/service-template/index.ts.hbs
     hash: sha256:d44012d54b76ab98356c7163d257ca939f7fed122f10fecf896fe1e7e206d10a
     type: template
-    size: 3206
+    size: 3086
   - path: development/templates/service-template/jest.config.js
     hash: sha256:1681bfd7fbc0d330d3487d3427515847c4d57ef300833f573af59e0ad69ed159
     type: template
@@ -2611,11 +2603,11 @@ files:
   - path: development/templates/service-template/package.json.hbs
     hash: sha256:d89d35f56992ee95c2ceddf17fa1d455c18007a4d24af914ba83cf4abc38bca9
     type: template
-    size: 2314
+    size: 2227
   - path: development/templates/service-template/README.md.hbs
     hash: sha256:2c3dd4c2bf6df56b9b6db439977be7e1cc35820438c0e023140eccf6ccd227a0
     type: template
-    size: 3584
+    size: 3426
   - path: development/templates/service-template/tsconfig.json
     hash: sha256:8b465fcbdd45c4d6821ba99aea62f2bd7998b1bca8de80486a1525e77d43c9a1
     type: template
@@ -2623,7 +2615,7 @@ files:
   - path: development/templates/service-template/types.ts.hbs
     hash: sha256:3e52e0195003be8cd1225a3f27f4d040686c8b8c7762f71b41055f04cd1b841b
     type: template
-    size: 2661
+    size: 2516
   - path: development/templates/squad-template/agents/example-agent.yaml
     hash: sha256:824a1b349965e5d4ae85458c231b78260dc65497da75dada25b271f2cabbbe67
     type: agent
@@ -2631,7 +2623,7 @@ files:
   - path: development/templates/squad-template/LICENSE
     hash: sha256:ff7017aa403270cf2c440f5ccb4240d0b08e54d8bf8a0424d34166e8f3e10138
     type: template
-    size: 1092
+    size: 1071
   - path: development/templates/squad-template/package.json
     hash: sha256:8f68627a0d74e49f94ae382d0c2b56ecb5889d00f3095966c742fb5afaf363db
     type: template
@@ -3375,11 +3367,11 @@ files:
   - path: infrastructure/templates/aiox-sync.yaml.template
     hash: sha256:0040ad8a9e25716a28631b102c9448b72fd72e84f992c3926eb97e9e514744bb
     type: template
-    size: 8567
+    size: 8385
   - path: infrastructure/templates/coderabbit.yaml.template
     hash: sha256:91a4a76bbc40767a4072fb6a87c480902bb800cfb0a11e9fc1b3183d8f7f3a80
     type: template
-    size: 8321
+    size: 8042
   - path: infrastructure/templates/core-config/core-config-brownfield.tmpl.yaml
     hash: sha256:9bdb0c0e09c765c991f9f142921f7f8e2c0d0ada717f41254161465dc0622d02
     type: template
@@ -3391,11 +3383,11 @@ files:
   - path: infrastructure/templates/github-workflows/ci.yml.template
     hash: sha256:acbfa2a8a84141fd6a6b205eac74719772f01c221c0afe22ce951356f06a605d
     type: template
-    size: 5089
+    size: 4920
   - path: infrastructure/templates/github-workflows/pr-automation.yml.template
     hash: sha256:c236077b4567965a917e48df9a91cc42153ff97b00a9021c41a7e28179be9d0f
     type: template
-    size: 10939
+    size: 10609
   - path: infrastructure/templates/github-workflows/README.md
     hash: sha256:6b7b5cb32c28b3e562c81a96e2573ea61849b138c93ccac6e93c3adac26cadb5
     type: template
@@ -3403,23 +3395,23 @@ files:
   - path: infrastructure/templates/github-workflows/release.yml.template
     hash: sha256:b771145e61a254a88dc6cca07869e4ece8229ce18be87132f59489cdf9a66ec6
     type: template
-    size: 6791
+    size: 6595
   - path: infrastructure/templates/gitignore/gitignore-aiox-base.tmpl
     hash: sha256:9088975ee2bf4d88e23db6ac3ea5d27cccdc72b03db44450300e2f872b02e935
     type: template
-    size: 851
+    size: 788
   - path: infrastructure/templates/gitignore/gitignore-brownfield-merge.tmpl
     hash: sha256:ce4291a3cf5677050c9dafa320809e6b0ca5db7e7f7da0382d2396e32016a989
     type: template
-    size: 506
+    size: 488
   - path: infrastructure/templates/gitignore/gitignore-node.tmpl
     hash: sha256:5179f78de7483274f5d7182569229088c71934db1fd37a63a40b3c6b815c9c8e
     type: template
-    size: 1036
+    size: 951
   - path: infrastructure/templates/gitignore/gitignore-python.tmpl
     hash: sha256:d7aac0b1e6e340b774a372a9102b4379722588449ca82ac468cf77804bbc1e55
     type: template
-    size: 1725
+    size: 1580
   - path: infrastructure/templates/project-docs/coding-standards-tmpl.md
     hash: sha256:377acf85463df8ac9923fc59d7cfeba68a82f8353b99948ea1d28688e88bc4a9
     type: template
@@ -3515,43 +3507,43 @@ files:
   - path: monitor/hooks/lib/__init__.py
     hash: sha256:bfab6ee249c52f412c02502479da649b69d044938acaa6ab0aa39dafe6dee9bf
     type: monitor
-    size: 30
+    size: 29
   - path: monitor/hooks/lib/enrich.py
     hash: sha256:20dfa73b4b20d7a767e52c3ec90919709c4447c6e230902ba797833fc6ddc22c
     type: monitor
-    size: 1702
+    size: 1644
   - path: monitor/hooks/lib/send_event.py
     hash: sha256:59d61311f718fb373a5cf85fd7a01c23a4fd727e8e022ad6930bba533ef4615d
     type: monitor
-    size: 1237
+    size: 1190
   - path: monitor/hooks/notification.py
     hash: sha256:8a1a6ce0ff2b542014de177006093b9caec9b594e938a343dc6bd62df2504f22
     type: monitor
-    size: 528
+    size: 499
   - path: monitor/hooks/post_tool_use.py
     hash: sha256:47dbe37073d432c55657647fc5b907ddb56efa859d5c3205e8362aa916d55434
     type: monitor
-    size: 1185
+    size: 1140
   - path: monitor/hooks/pre_compact.py
     hash: sha256:f287cf45e83deed6f1bc0e30bd9348dfa1bf08ad770c5e58bb34e3feb210b30b
     type: monitor
-    size: 529
+    size: 500
   - path: monitor/hooks/pre_tool_use.py
     hash: sha256:a4d1d3ffdae9349e26a383c67c9137effff7d164ac45b2c87eea9fa1ab0d6d98
     type: monitor
-    size: 1021
+    size: 981
   - path: monitor/hooks/stop.py
     hash: sha256:edb382f0cf46281a11a8588bc20eafa7aa2b5cc3f4ad775d71b3d20a7cfab385
     type: monitor
-    size: 519
+    size: 490
   - path: monitor/hooks/subagent_stop.py
     hash: sha256:fa5357309247c71551dba0a19f28dd09bebde749db033d6657203b50929c0a42
     type: monitor
-    size: 541
+    size: 512
   - path: monitor/hooks/user_prompt_submit.py
     hash: sha256:af57dca79ef55cdf274432f4abb4c20a9778b95e107ca148f47ace14782c5828
     type: monitor
-    size: 856
+    size: 818
   - path: package.json
     hash: sha256:9fdf0dcee2dcec6c0643634ee384ba181ad077dcff1267d8807434d4cb4809c7
     type: other
@@ -3699,7 +3691,7 @@ files:
   - path: product/templates/adr.hbs
     hash: sha256:d68653cae9e64414ad4f58ea941b6c6e337c5324c2c7247043eca1461a652d10
     type: template
-    size: 2337
+    size: 2212
   - path: product/templates/agent-template.yaml
     hash: sha256:98676fcc493c0d5f09264dcc52fcc2cf1129f9a195824ecb4c2ec035c2515121
     type: template
@@ -3751,7 +3743,7 @@ files:
   - path: product/templates/dbdr.hbs
     hash: sha256:5a2781ffaa3da9fc663667b5a63a70b7edfc478ed14cad02fc6ed237ff216315
     type: template
-    size: 4380
+    size: 4139
   - path: product/templates/design-story-tmpl.yaml
     hash: sha256:2bfefc11ae2bcfc679dbd924c58f8b764fa23538c14cb25344d6edef41968f29
     type: template
@@ -3815,7 +3807,7 @@ files:
   - path: product/templates/epic.hbs
     hash: sha256:dcbcc26f6dd8f3782b3ef17aee049b689f1d6d92931615c3df9513eca0de2ef7
     type: template
-    size: 4080
+    size: 3868
   - path: product/templates/eslintrc-security.json
     hash: sha256:657d40117261d6a52083984d29f9f88e79040926a64aa4c2058a602bfe91e0d5
     type: template
@@ -3923,7 +3915,7 @@ files:
   - path: product/templates/pmdr.hbs
     hash: sha256:d529cebbb562faa82c70477ece70de7cda871eaa6896f2962b48b2a8b67b1cbe
     type: template
-    size: 3425
+    size: 3239
   - path: product/templates/prd-tmpl.yaml
     hash: sha256:25c239f40e05f24aee1986601a98865188dbe3ea00a705028efc3adad6d420f3
     type: template
@@ -3931,11 +3923,11 @@ files:
   - path: product/templates/prd-v2.0.hbs
     hash: sha256:21a20ef5333a85a11f5326d35714e7939b51bab22bd6e28d49bacab755763bea
     type: template
-    size: 4728
+    size: 4512
   - path: product/templates/prd.hbs
     hash: sha256:4a1a030a5388c6a8bf2ce6ea85e54cae6cf1fe64f1bb2af7f17d349d3c24bf1d
     type: template
-    size: 3626
+    size: 3425
   - path: product/templates/project-brief-tmpl.yaml
     hash: sha256:b8d388268c24dc5018f48a87036d591b11cb122fafe9b59c17809b06ea5d9d58
     type: template
@@ -3983,7 +3975,7 @@ files:
   - path: product/templates/story.hbs
     hash: sha256:3f0ac8b39907634a2b53f43079afc33663eee76f46e680d318ff253e0befc2c4
     type: template
-    size: 5846
+    size: 5583
   - path: product/templates/task-execution-report.md
     hash: sha256:e0f08a3e199234f3d2207ba8f435786b7d8e1b36174f46cb82fc3666b9a9309e
     type: template
@@ -3995,67 +3987,67 @@ files:
   - path: product/templates/task.hbs
     hash: sha256:621e987e142c455cd290dc85d990ab860faa0221f66cf1f57ac296b076889ea5
     type: template
-    size: 2875
+    size: 2705
   - path: product/templates/tmpl-comment-on-examples.sql
     hash: sha256:254002c3fbc63cfcc5848b1d4b15822ce240bf5f57e6a1c8bb984e797edc2691
     type: template
-    size: 6373
+    size: 6215
   - path: product/templates/tmpl-migration-script.sql
     hash: sha256:44ef63ea475526d21a11e3c667c9fdb78a9fddace80fdbaa2312b7f2724fbbb5
     type: template
-    size: 3038
+    size: 2947
   - path: product/templates/tmpl-rls-granular-policies.sql
     hash: sha256:36c2fd8c6d9eebb5d164acb0fb0c87bc384d389264b4429ce21e77e06318f5f3
     type: template
-    size: 3426
+    size: 3322
   - path: product/templates/tmpl-rls-kiss-policy.sql
     hash: sha256:5210d37fce62e5a9a00e8d5366f5f75653cd518be73fbf96333ed8a6712453c7
     type: template
-    size: 309
+    size: 299
   - path: product/templates/tmpl-rls-roles.sql
     hash: sha256:2d032a608a8e87440c3a430c7d69ddf9393d8813d8d4129270f640dd847425c3
     type: template
-    size: 4727
+    size: 4592
   - path: product/templates/tmpl-rls-simple.sql
     hash: sha256:f67af0fa1cdd2f2af9eab31575ac3656d82457421208fd9ccb8b57ca9785275e
     type: template
-    size: 2992
+    size: 2915
   - path: product/templates/tmpl-rls-tenant.sql
     hash: sha256:36629ed87a2c72311809cc3fb96298b6f38716bba35bc56c550ac39d3321757a
     type: template
-    size: 5130
+    size: 4978
   - path: product/templates/tmpl-rollback-script.sql
     hash: sha256:8b84046a98f1163faf7350322f43831447617c5a63a94c88c1a71b49804e022b
     type: template
-    size: 2734
+    size: 2657
   - path: product/templates/tmpl-seed-data.sql
     hash: sha256:a65e73298f46cd6a8e700f29b9d8d26e769e12a57751a943a63fd0fe15768615
     type: template
-    size: 5716
+    size: 5576
   - path: product/templates/tmpl-smoke-test.sql
     hash: sha256:aee7e48bb6d9c093769dee215cacc9769939501914e20e5ea8435b25fad10f3c
     type: template
-    size: 739
+    size: 723
   - path: product/templates/tmpl-staging-copy-merge.sql
     hash: sha256:55988caeb47cc04261665ba7a37f4caa2aa5fac2e776fdbc5964e0587af24450
     type: template
-    size: 4220
+    size: 4081
   - path: product/templates/tmpl-stored-proc.sql
     hash: sha256:2b205ff99dc0adfade6047a4d79f5b50109e50ceb45386e5c886437692c7a2a3
     type: template
-    size: 3979
+    size: 3839
   - path: product/templates/tmpl-trigger.sql
     hash: sha256:93abdc92e1b475d1370094e69a9d1b18afd804da6acb768b878355c798bd8e0e
     type: template
-    size: 5424
+    size: 5272
   - path: product/templates/tmpl-view-materialized.sql
     hash: sha256:47935510f03d4ad9b2200748e65441ce6c2d6a7c74750395eca6831d77c48e91
     type: template
-    size: 4496
+    size: 4363
   - path: product/templates/tmpl-view.sql
     hash: sha256:22557b076003a856b32397f05fa44245a126521de907058a95e14dd02da67aff
     type: template
-    size: 5093
+    size: 4916
   - path: product/templates/token-exports-css-tmpl.css
     hash: sha256:d937b8d61cdc9e5b10fdff871c6cb41c9f756004d060d671e0ae26624a047f62
     type: template

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.0.3
-generated_at: "2026-03-11T02:00:59.911Z"
+generated_at: "2026-03-11T02:01:06.997Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1089
 files:
@@ -1221,7 +1221,7 @@ files:
     type: data
     size: 9575
   - path: data/entity-registry.yaml
-    hash: sha256:e25c7cdd771453ac5b82630ede5a45dd70b0f035fa538ce75d150f44d425eef3
+    hash: sha256:ef60bef3098d04b215dbfb5e3ab6e76097b750e5a1077455988da282747da1bf
     type: data
     size: 521869
   - path: data/learned-patterns.yaml

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.0.3
-generated_at: "2026-03-11T02:03:45.995Z"
+generated_at: "2026-03-11T12:47:44.159Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1089
 files:
@@ -689,9 +689,9 @@ files:
     type: core
     size: 7755
   - path: core/ideation/ideation-engine.js
-    hash: sha256:d9108fa47ed7a9131703739befb214b97d5b8e546faf1b49d8ae9d083756c589
+    hash: sha256:8e496a9344ad86cb60e0f620ffe5bb30ec3f43ac582901da100674ba8149edad
     type: core
-    size: 22865
+    size: 22955
   - path: core/ids/circuit-breaker.js
     hash: sha256:1b35331ba71a6ce17869bab255e087fc540291243f9884fc21ed89f7efc122a4
     type: core
@@ -1317,9 +1317,9 @@ files:
     type: development
     size: 5012
   - path: development/agents/aiox-master.md
-    hash: sha256:a2f8c55ac39c3489b656494f24ee7793307b724a2fa35383f430b0be86694ce5
+    hash: sha256:9db9070fe5a019e100d6773108b23989c241089b1aea55f88580018e296d542c
     type: agent
-    size: 19704
+    size: 19922
   - path: development/agents/analyst.md
     hash: sha256:35150d764c6dc74bc02b61a4d613c9278e87ffb209403db23991339fdda4f8e2
     type: agent

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.0.3
-generated_at: "2026-03-11T02:01:06.997Z"
+generated_at: "2026-03-11T02:03:45.995Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1089
 files:

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.0.3
-generated_at: "2026-03-11T15:04:21.905Z"
+generated_at: "2026-03-11T15:18:54.491Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1090
 files:

--- a/.claude/commands/AIOX/agents/aiox-master.md
+++ b/.claude/commands/AIOX/agents/aiox-master.md
@@ -102,7 +102,8 @@ persona:
   role: Master Orchestrator, Framework Developer & AIOX Method Expert
   identity: Universal executor of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and executes any task directly
   core_principles:
-    - Execute any resource directly without persona transformation
+    - "PRE-EXECUTION CHECK: Before executing any task, verify if an exclusive agent owns it (see agent-authority.md Delegation Matrix). If yes, DELEGATE — do not execute directly. Exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
+    - Execute framework governance tasks directly (meta-ops, orchestration, constitutional enforcement)
     - Load resources at runtime, never pre-load
     - Expert knowledge of all AIOX resources when using *kb
     - Always present numbered lists for choices

--- a/.claude/commands/AIOX/agents/aiox-master.md
+++ b/.claude/commands/AIOX/agents/aiox-master.md
@@ -100,7 +100,7 @@ persona_profile:
 
 persona:
   role: Master Orchestrator, Framework Developer & AIOX Method Expert
-  identity: Universal executor of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and executes any task directly
+  identity: Master orchestrator of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and delegates agent-owned tasks to their exclusive owners; executes directly only framework governance tasks or when explicit exceptions apply
   core_principles:
     - "PRE-EXECUTION CHECK: Before executing any task, verify if an exclusive agent owns it (see agent-authority.md Delegation Matrix). If yes, DELEGATE — do not execute directly. Exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
     - Execute framework governance tasks directly (meta-ops, orchestration, constitutional enforcement)
@@ -398,7 +398,7 @@ Type `*help` to see all commands, or `*kb` to enable KB mode.
 
 **I orchestrate:**
 
-- **All agents** - Can execute any task from any agent directly
+- **All agents** - Delegates to the owning exclusive agent first; executes directly only for framework governance tasks or when --force-execute, workflow-engine mode, or AIOX_DEBUG=true applies
 - **Framework development** - Creates and modifies agents, tasks, workflows (via `*create {type}`, `*modify {type}`)
 
 **Delegated responsibilities (Story 6.1.2.3):**
@@ -430,7 +430,7 @@ Type `*help` to see all commands, or `*kb` to enable KB mode.
 
 - Creating/modifying AIOX framework components (agents, tasks, workflows)
 - Orchestrating complex multi-agent workflows
-- Executing any task from any agent directly
+- Executing framework governance tasks directly; delegating exclusive-agent tasks to their owners (with --force-execute, workflow-engine mode, or AIOX_DEBUG=true as explicit override)
 - Framework development and meta-operations
 
 ### Prerequisites

--- a/.claude/commands/AIOX/agents/aiox-master.md
+++ b/.claude/commands/AIOX/agents/aiox-master.md
@@ -103,7 +103,7 @@ persona:
   identity: Master orchestrator of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and delegates agent-owned tasks to their exclusive owners; executes directly only framework governance tasks or when explicit exceptions apply
   core_principles:
     - "PRE-EXECUTION CHECK: Before executing any task, verify if an exclusive agent owns it (see agent-authority.md Delegation Matrix). If yes, DELEGATE — do not execute directly. Exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
-    - Execute framework governance tasks directly (meta-ops, orchestration, constitutional enforcement)
+    - "Framework governance tasks (meta-ops, orchestration, constitutional enforcement) are the ONLY tasks executed directly. All tasks that belong to an exclusive agent MUST be delegated first. Direct execution is permitted only under explicit exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
     - Load resources at runtime, never pre-load
     - Expert knowledge of all AIOX resources when using *kb
     - Always present numbered lists for choices

--- a/.claude/rules/agent-authority.md
+++ b/.claude/rules/agent-authority.md
@@ -69,11 +69,25 @@
 
 ### @aiox-master — Framework Governance
 
+**Default behavior: DELEGATE to the exclusive agent when one exists.**
+
 | Capability | Details |
 |-----------|---------|
-| Execute ANY task directly | No restrictions |
-| Framework governance | Constitutional enforcement |
-| Override agent boundaries | When necessary for framework health |
+| Framework governance tasks | Execute directly (meta-ops, orchestration, framework health) |
+| Tasks with a mapped exclusive agent | **DELEGATE by default** — route to the owning agent |
+| Override agent boundaries | Only with explicit `--force-execute` flag or workflow-engine mode |
+| Constitutional enforcement | Execute directly |
+
+**Pre-Execution Check (MANDATORY):** Before executing any task, @aiox-master MUST check the Delegation Matrix above. If an exclusive agent owns the operation, @aiox-master MUST delegate — not execute directly. The only exceptions are:
+1. User explicitly requests `--force-execute`
+2. Running in workflow-engine mode (automated pipeline)
+3. Framework debugging with `AIOX_DEBUG=true`
+
+**Rejection Script:** When @aiox-master cannot execute a task due to agent authority:
+```
+⚠️ This task belongs to @{agent} ({persona}).
+Delegating: → @{agent} | task: {task-file}
+```
 
 ## Cross-Agent Delegation Patterns
 

--- a/.claude/rules/agent-authority.md
+++ b/.claude/rules/agent-authority.md
@@ -75,7 +75,7 @@
 |-----------|---------|
 | Framework governance tasks | Execute directly (meta-ops, orchestration, framework health) |
 | Tasks with a mapped exclusive agent | **DELEGATE by default** — route to the owning agent |
-| Override agent boundaries | Only with explicit `--force-execute` flag or workflow-engine mode |
+| Override agent boundaries | Only with explicit `--force-execute` flag, workflow-engine mode, or `AIOX_DEBUG=true` |
 | Constitutional enforcement | Execute directly |
 
 **Pre-Execution Check (MANDATORY):** Before executing any task, @aiox-master MUST check the Delegation Matrix above. If an exclusive agent owns the operation, @aiox-master MUST delegate — not execute directly. The only exceptions are:
@@ -88,6 +88,18 @@
 ⚠️ This task belongs to @{agent} ({persona}).
 Delegating: → @{agent} | task: {task-file}
 ```
+
+**Self-Correction Protocol:** When @aiox-master has already begun executing a task that belongs to an exclusive agent, it MUST:
+1. **Revert improper artifacts** — Remove or undo any files, outputs, or side effects created during the unauthorized execution. Artifact naming follows the owning agent's conventions (e.g., story files follow `{epicNum}.{storyNum}.story.md`; git operations leave no remote state).
+2. **Delegate and hand off** — Emit the delegation message above and explicitly pass the task to `@{agent}` with the original context intact.
+3. **Log the incident** — Append a structured entry to `.aiox/logs/agent-authority-incidents.log`:
+   ```
+   [timestamp] AUTHORITY_VIOLATION: @aiox-master attempted {task-file}
+   owned_by: @{agent} ({persona})
+   actions_taken: [list of actions performed before detection]
+   reverted: [list of artifacts removed/undone]
+   delegated_to: @{agent}
+   ```
 
 ## Cross-Agent Delegation Patterns
 

--- a/.claude/rules/agent-authority.md
+++ b/.claude/rules/agent-authority.md
@@ -67,6 +67,16 @@
 | Index strategy execution | Frontend/UI |
 | Migration planning & execution | — |
 
+### @qa (Quinn) — Quality Assurance
+
+| Operation | Exclusive? | Details |
+|-----------|-----------|---------|
+| `*qa-gate` | YES | PASS/CONCERNS/FAIL/WAIVED gate decisions |
+| `*qa-loop` / `*qa-loop-review` | YES | Iterative review-fix cycle (max 5 iterations) |
+| Test validation & coverage review | YES | Acceptance criteria traceability |
+| Spec critique (spec pipeline Phase 5) | YES | `critique.json` output |
+| Story QA Results section updates | YES | Only authorized to edit QA Results section |
+
 ### @aiox-master — Framework Governance
 
 **Default behavior: DELEGATE to the exclusive agent when one exists.**
@@ -100,6 +110,8 @@ Delegating: → @{agent} | task: {task-file}
    reverted: [list of artifacts removed/undone]
    delegated_to: @{agent}
    ```
+
+> **Note:** Runtime enforcement via `agent-invoker.js` consulting the Delegation Matrix is tracked as a follow-up improvement. This protocol is currently policy-level; automated enforcement is planned separately.
 
 ## Cross-Agent Delegation Patterns
 

--- a/.codex/agents/aiox-master.md
+++ b/.codex/agents/aiox-master.md
@@ -102,7 +102,8 @@ persona:
   role: Master Orchestrator, Framework Developer & AIOX Method Expert
   identity: Universal executor of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and executes any task directly
   core_principles:
-    - Execute any resource directly without persona transformation
+    - "PRE-EXECUTION CHECK: Before executing any task, verify if an exclusive agent owns it (see agent-authority.md Delegation Matrix). If yes, DELEGATE — do not execute directly. Exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
+    - Execute framework governance tasks directly (meta-ops, orchestration, constitutional enforcement)
     - Load resources at runtime, never pre-load
     - Expert knowledge of all AIOX resources when using *kb
     - Always present numbered lists for choices

--- a/.codex/agents/aiox-master.md
+++ b/.codex/agents/aiox-master.md
@@ -100,7 +100,7 @@ persona_profile:
 
 persona:
   role: Master Orchestrator, Framework Developer & AIOX Method Expert
-  identity: Universal executor of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and executes any task directly
+  identity: Master orchestrator of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and delegates agent-owned tasks to their exclusive owners; executes directly only framework governance tasks or when explicit exceptions apply
   core_principles:
     - "PRE-EXECUTION CHECK: Before executing any task, verify if an exclusive agent owns it (see agent-authority.md Delegation Matrix). If yes, DELEGATE — do not execute directly. Exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
     - Execute framework governance tasks directly (meta-ops, orchestration, constitutional enforcement)
@@ -398,7 +398,7 @@ Type `*help` to see all commands, or `*kb` to enable KB mode.
 
 **I orchestrate:**
 
-- **All agents** - Can execute any task from any agent directly
+- **All agents** - Delegates to the owning exclusive agent first; executes directly only for framework governance tasks or when --force-execute, workflow-engine mode, or AIOX_DEBUG=true applies
 - **Framework development** - Creates and modifies agents, tasks, workflows (via `*create {type}`, `*modify {type}`)
 
 **Delegated responsibilities (Story 6.1.2.3):**
@@ -430,7 +430,7 @@ Type `*help` to see all commands, or `*kb` to enable KB mode.
 
 - Creating/modifying AIOX framework components (agents, tasks, workflows)
 - Orchestrating complex multi-agent workflows
-- Executing any task from any agent directly
+- Executing framework governance tasks directly; delegating exclusive-agent tasks to their owners (with --force-execute, workflow-engine mode, or AIOX_DEBUG=true as explicit override)
 - Framework development and meta-operations
 
 ### Prerequisites

--- a/.codex/agents/aiox-master.md
+++ b/.codex/agents/aiox-master.md
@@ -103,7 +103,7 @@ persona:
   identity: Master orchestrator of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and delegates agent-owned tasks to their exclusive owners; executes directly only framework governance tasks or when explicit exceptions apply
   core_principles:
     - "PRE-EXECUTION CHECK: Before executing any task, verify if an exclusive agent owns it (see agent-authority.md Delegation Matrix). If yes, DELEGATE — do not execute directly. Exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
-    - Execute framework governance tasks directly (meta-ops, orchestration, constitutional enforcement)
+    - "Framework governance tasks (meta-ops, orchestration, constitutional enforcement) are the ONLY tasks executed directly. All tasks that belong to an exclusive agent MUST be delegated first. Direct execution is permitted only under explicit exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
     - Load resources at runtime, never pre-load
     - Expert knowledge of all AIOX resources when using *kb
     - Always present numbered lists for choices

--- a/.gemini/rules/AIOX/agents/aiox-master.md
+++ b/.gemini/rules/AIOX/agents/aiox-master.md
@@ -102,7 +102,8 @@ persona:
   role: Master Orchestrator, Framework Developer & AIOX Method Expert
   identity: Universal executor of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and executes any task directly
   core_principles:
-    - Execute any resource directly without persona transformation
+    - "PRE-EXECUTION CHECK: Before executing any task, verify if an exclusive agent owns it (see agent-authority.md Delegation Matrix). If yes, DELEGATE — do not execute directly. Exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
+    - Execute framework governance tasks directly (meta-ops, orchestration, constitutional enforcement)
     - Load resources at runtime, never pre-load
     - Expert knowledge of all AIOX resources when using *kb
     - Always present numbered lists for choices

--- a/.gemini/rules/AIOX/agents/aiox-master.md
+++ b/.gemini/rules/AIOX/agents/aiox-master.md
@@ -100,7 +100,7 @@ persona_profile:
 
 persona:
   role: Master Orchestrator, Framework Developer & AIOX Method Expert
-  identity: Universal executor of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and executes any task directly
+  identity: Master orchestrator of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and delegates agent-owned tasks to their exclusive owners; executes directly only framework governance tasks or when explicit exceptions apply
   core_principles:
     - "PRE-EXECUTION CHECK: Before executing any task, verify if an exclusive agent owns it (see agent-authority.md Delegation Matrix). If yes, DELEGATE — do not execute directly. Exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
     - "Framework governance tasks (meta-ops, orchestration, constitutional enforcement) are the ONLY tasks executed directly. All tasks that belong to an exclusive agent MUST be delegated first. Direct execution is permitted only under explicit exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
@@ -398,7 +398,7 @@ Type `*help` to see all commands, or `*kb` to enable KB mode.
 
 **I orchestrate:**
 
-- **All agents** - Can execute any task from any agent directly
+- **All agents** - Delegates to the owning exclusive agent first; executes directly only for framework governance tasks or when --force-execute, workflow-engine mode, or AIOX_DEBUG=true applies
 - **Framework development** - Creates and modifies agents, tasks, workflows (via `*create {type}`, `*modify {type}`)
 
 **Delegated responsibilities (Story 6.1.2.3):**
@@ -430,7 +430,7 @@ Type `*help` to see all commands, or `*kb` to enable KB mode.
 
 - Creating/modifying AIOX framework components (agents, tasks, workflows)
 - Orchestrating complex multi-agent workflows
-- Executing any task from any agent directly
+- Executing framework governance tasks directly; delegating exclusive-agent tasks to their owners (with --force-execute, workflow-engine mode, or AIOX_DEBUG=true as explicit override)
 - Framework development and meta-operations
 
 ### Prerequisites

--- a/.gemini/rules/AIOX/agents/aiox-master.md
+++ b/.gemini/rules/AIOX/agents/aiox-master.md
@@ -103,7 +103,7 @@ persona:
   identity: Universal executor of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and executes any task directly
   core_principles:
     - "PRE-EXECUTION CHECK: Before executing any task, verify if an exclusive agent owns it (see agent-authority.md Delegation Matrix). If yes, DELEGATE — do not execute directly. Exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
-    - Execute framework governance tasks directly (meta-ops, orchestration, constitutional enforcement)
+    - "Framework governance tasks (meta-ops, orchestration, constitutional enforcement) are the ONLY tasks executed directly. All tasks that belong to an exclusive agent MUST be delegated first. Direct execution is permitted only under explicit exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true."
     - Load resources at runtime, never pre-load
     - Expert knowledge of all AIOX resources when using *kb
     - Always present numbered lists for choices

--- a/.github/agents/aiox-master.agent.md
+++ b/.github/agents/aiox-master.agent.md
@@ -10,7 +10,8 @@ You are an expert Master Orchestrator, Framework Developer & AIOX Method Expert.
 
 ## Core Principles
 
-- Execute any resource directly without persona transformation
+- PRE-EXECUTION CHECK: Before executing any task, verify if an exclusive agent owns it (see agent-authority.md Delegation Matrix). If yes, DELEGATE — do not execute directly. Exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true.
+- Execute framework governance tasks directly (meta-ops, orchestration, constitutional enforcement)
 - Load resources at runtime, never pre-load
 - Expert knowledge of all AIOX resources when using *kb
 - Always present numbered lists for choices

--- a/.github/agents/aiox-master.agent.md
+++ b/.github/agents/aiox-master.agent.md
@@ -11,7 +11,7 @@ You are an expert Master Orchestrator, Framework Developer & AIOX Method Expert.
 ## Core Principles
 
 - PRE-EXECUTION CHECK: Before executing any task, verify if an exclusive agent owns it (see agent-authority.md Delegation Matrix). If yes, DELEGATE — do not execute directly. Exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true.
-- Execute framework governance tasks directly (meta-ops, orchestration, constitutional enforcement)
+- Framework governance tasks (meta-ops, orchestration, constitutional enforcement) are the ONLY tasks executed directly. All tasks that belong to an exclusive agent MUST be delegated first. Direct execution is permitted only under explicit exceptions: --force-execute flag, workflow-engine mode, or AIOX_DEBUG=true.
 - Load resources at runtime, never pre-load
 - Expert knowledge of all AIOX resources when using *kb
 - Always present numbered lists for choices


### PR DESCRIPTION
## Summary

Fixes two critical bugs:

- **#532** — `_calculateProgressFromState()` and `getProgressPercentage()` in `master-orchestrator.js` divide by `totalEpics` without zero-check. When all epics have `onDemand: true`, this produces `NaN` that propagates to dashboard, logs, and status. Added `if (totalEpics === 0) return 0;` guard to both methods.

- **#527** — `@aiox-master`'s authority entry read "Execute ANY task directly | No restrictions", which LLMs interpret as blanket permission to bypass agent authority (Constitution Article II violation). Fixed by:
  - Replacing "No restrictions" with explicit delegation-by-default table in `agent-authority.md`
  - Adding **PRE-EXECUTION CHECK** as first `core_principle` in the aiox-master agent definition
  - Defining rejection script format for out-of-scope tasks
  - Preserving `--force-execute`, workflow-engine, and debug overrides as explicit exceptions
  - Synced across all IDE copies (Claude, Gemini, Codex)

## Test plan

- [x] All 303 test suites pass (7690 tests)
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — passes
- [x] Division-by-zero guard returns 0 when all epics are onDemand
- [x] Agent authority table now explicitly requires delegation as default
- [x] All 4 IDE agent copies synchronized

Closes #532
Closes #527

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented division-by-zero in orchestration progress calculations so progress displays remain stable.

* **Behavior Changes**
  * Introduced a delegation-first pre-execution ownership check: tasks owned by exclusive agents are delegated by default; explicit overrides allow direct execution. Framework governance tasks still execute directly.

* **Chores**
  * Updated generated manifests, templates, and public-facing agent guidance to reflect delegation semantics and metadata updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->