### PR TITLE
fix(circuit-breaker): preserve recovery timeout when OPEN (#469)

### DIFF
--- a/.aiox-core/core/ids/circuit-breaker.js
+++ b/.aiox-core/core/ids/circuit-breaker.js
@@ -94,6 +94,14 @@ class CircuitBreaker {
    */
   recordFailure() {
     this._failureCount++;
+
+    if (this._state === STATE_OPEN) {
+      // Do not reset the recovery timeout while already OPEN.
+      // Subsequent failures are counted but must not push back the
+      // moment the circuit transitions to HALF_OPEN — fixes #469.
+      return;
+    }
+
     this._lastFailureTime = Date.now();
 
     if (this._state === STATE_HALF_OPEN) {


### PR DESCRIPTION
## Problem

`recordFailure()` was unconditionally updating `this._lastFailureTime = Date.now()` on every call, including when the circuit was already in `OPEN` state.

This caused `isAllowed()` to never find `elapsed >= resetTimeoutMs` as long as failures kept arriving — the circuit would stay stuck in `OPEN` indefinitely and never transition to `HALF_OPEN`.

## Fix

Added an early return in `recordFailure()` when `state === OPEN`. Failures are still counted (for stats), but the recovery timer is preserved so the circuit correctly transitions to `HALF_OPEN` after the configured timeout.

```js
// Before (bug): _lastFailureTime was always overwritten
recordFailure() {
  this._failureCount++;
  this._lastFailureTime = Date.now(); // ← reset timer even in OPEN state
  ...
}

// After (fix): skip timer reset when already OPEN
recordFailure() {
  this._failureCount++;
  if (this._state === STATE_OPEN) {
    return; // preserve recovery timeout
  }
  this._lastFailureTime = Date.now();
  ...
}
```

## Testing

- CLOSED → failures reach threshold → OPEN ✓
- OPEN → `recordFailure()` called → timer NOT reset, circuit transitions to HALF_OPEN after timeout ✓
- HALF_OPEN → failure → back to OPEN ✓

Closes #469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved circuit breaker reliability by correctly preserving the original failure timestamp when in open state, ensuring accurate recovery timing and more predictable system behavior during failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->