### PR TITLE
fix: symlink node_modules so squad scripts can resolve framework deps

### DIFF
--- a/bin/aiox-init.js
+++ b/bin/aiox-init.js
@@ -175,27 +175,6 @@ async function main() {
       console.log(chalk.green('✓') + ' package.json created');
     }
 
-    // Ensure node_modules symlink so squads/ scripts can resolve framework dependencies
-    const projectNodeModules = path.join(projectRoot, 'node_modules');
-    const frameworkNodeModules = path.join(projectRoot, '.aiox-core', 'node_modules');
-    if (!fs.existsSync(projectNodeModules) && fs.existsSync(frameworkNodeModules)) {
-      try {
-        await fse.symlink(
-          path.relative(projectRoot, frameworkNodeModules),
-          projectNodeModules,
-          'junction',
-        );
-        console.log(chalk.green('✓') + ' node_modules linked to .aiox-core/node_modules');
-      } catch (symlinkError) {
-        // Non-fatal: squads scripts will need explicit paths
-        console.log(
-          chalk.yellow('⚠') +
-            ' Could not create node_modules symlink: ' +
-            symlinkError.message,
-        );
-      }
-    }
-
     console.log(chalk.green('✓') + ' Prerequisites ready\n');
 
     // Try to detect context again
@@ -538,6 +517,27 @@ async function main() {
       'AIOX Core files installed ' +
         chalk.gray('(11 agents, 68 tasks, 23 templates)')
     );
+
+    // Ensure node_modules symlink so squads/ scripts can resolve framework dependencies
+    const projectNodeModules = path.join(context.projectRoot, 'node_modules');
+    const frameworkNodeModules = path.join(targetCoreDir, 'node_modules');
+    if (!fs.existsSync(projectNodeModules) && fs.existsSync(frameworkNodeModules)) {
+      try {
+        await fse.symlink(
+          path.relative(context.projectRoot, frameworkNodeModules),
+          projectNodeModules,
+          'junction',
+        );
+        console.log(chalk.green('✓') + ' node_modules linked to .aiox-core/node_modules');
+      } catch (symlinkError) {
+        // Non-fatal: squads scripts will need explicit paths
+        console.log(
+          chalk.yellow('⚠') +
+            ' Could not create node_modules symlink: ' +
+            symlinkError.message,
+        );
+      }
+    }
 
     // Create installed manifest for brownfield upgrades (Story 6.18)
     if (brownfieldUpgrader) {

--- a/bin/aiox-init.js
+++ b/bin/aiox-init.js
@@ -175,6 +175,27 @@ async function main() {
       console.log(chalk.green('✓') + ' package.json created');
     }
 
+    // Ensure node_modules symlink so squads/ scripts can resolve framework dependencies
+    const projectNodeModules = path.join(projectRoot, 'node_modules');
+    const frameworkNodeModules = path.join(projectRoot, '.aiox-core', 'node_modules');
+    if (!fs.existsSync(projectNodeModules) && fs.existsSync(frameworkNodeModules)) {
+      try {
+        await fse.symlink(
+          path.relative(projectRoot, frameworkNodeModules),
+          projectNodeModules,
+          'junction',
+        );
+        console.log(chalk.green('✓') + ' node_modules linked to .aiox-core/node_modules');
+      } catch (symlinkError) {
+        // Non-fatal: squads scripts will need explicit paths
+        console.log(
+          chalk.yellow('⚠') +
+            ' Could not create node_modules symlink: ' +
+            symlinkError.message,
+        );
+      }
+    }
+
     console.log(chalk.green('✓') + ' Prerequisites ready\n');
 
     // Try to detect context again


### PR DESCRIPTION
## Summary
- Scripts in `squads/` (e.g. `squad-creator-pro`) fail with `Cannot find module 'js-yaml'` because `node_modules` only exists inside `.aiox-core/`
- Node.js module resolution walks up from `squads/.../scripts/` to the project root and never finds `js-yaml`
- This fix creates a symlink `<project>/node_modules` → `.aiox-core/node_modules/` during `aiox init`, so standard `require()` calls work from any directory in the project tree

## Root Cause
`aiox-init.js` creates a `package.json` at the project root but never installs dependencies or links to `.aiox-core/node_modules/`. Any script outside `.aiox-core/` that does `require('js-yaml')` (or any other framework dependency) fails.

## Error Reproduced
```
Error: Cannot find module 'js-yaml'
Require stack:
- squads/squad-creator-pro/scripts/generate-squad-greeting.js
```

## Fix
After `package.json` creation in `checkPrerequisites()`, add a symlink step:
- If `<project>/node_modules` doesn't exist AND `.aiox-core/node_modules` exists
- Create a symlink (junction on Windows) pointing to the framework's node_modules
- Non-fatal: if symlink fails, just warn (scripts can still use explicit relative paths)

## Test plan
- [ ] Run `aiox init` on a fresh project — verify symlink is created
- [ ] Run `node squads/squad-creator-pro/scripts/generate-squad-greeting.js` — verify no `Cannot find module` error
- [ ] Run `aiox init` on existing project with `node_modules/` — verify symlink is skipped (no overwrite)
- [ ] Verify framework scripts in `.aiox-core/` still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Installer now ensures project can access framework dependencies automatically by linking to existing bundled modules when needed.
  * Provides a clear success message when linking completes and a non-blocking warning with details if linking fails, allowing installation to continue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->