### PR TITLE
fix(scripts): add agent reference repair runtime

### DIFF
--- a/.aiox-core/infrastructure/scripts/codex-skills-sync/index.js
+++ b/.aiox-core/infrastructure/scripts/codex-skills-sync/index.js
@@ -43,6 +43,13 @@ function getSkillId(agentId) {
   return `aiox-${id}`;
 }
 
+function getLegacySkillId(agentId) {
+  const id = String(agentId || '').trim();
+  if (!id) return 'aios-unknown';
+  if (id.startsWith('aiox-')) return id.replace(/^aiox-/, 'aios-');
+  return `aios-${id}`;
+}
+
 function buildSkillContent(agentData) {
   const agent = agentData.agent || {};
   const name = agent.name || agentData.id;
@@ -179,4 +186,5 @@ module.exports = {
   parseArgs,
   getCodexHome,
   getSkillId,
+  getLegacySkillId,
 };

--- a/.aiox-core/infrastructure/scripts/codex-skills-sync/validate.js
+++ b/.aiox-core/infrastructure/scripts/codex-skills-sync/validate.js
@@ -5,7 +5,7 @@ const fs = require('fs');
 const path = require('path');
 
 const { parseAllAgents } = require('../ide-sync/agent-parser');
-const { getSkillId } = require('./index');
+const { getSkillId, getLegacySkillId } = require('./index');
 
 function getDefaultOptions() {
   const projectRoot = process.cwd();
@@ -14,6 +14,7 @@ function getDefaultOptions() {
     sourceDir: path.join(projectRoot, '.aiox-core', 'development', 'agents'),
     skillsDir: path.join(projectRoot, '.codex', 'skills'),
     strict: false,
+    allowOrphaned: false,
     quiet: false,
     json: false,
   };
@@ -74,6 +75,7 @@ function validateCodexSkills(options = {}) {
     agentId: agent.id,
     filename: agent.filename,
     skillId: getSkillId(agent.id),
+    legacySkillId: getLegacySkillId(agent.id),
   }));
 
   const missing = [];
@@ -99,13 +101,23 @@ function validateCodexSkills(options = {}) {
   }
 
   const expectedIds = new Set(expected.map(item => item.skillId));
+  const legacyIds = new Set(expected.map(item => item.legacySkillId));
   const orphaned = [];
+  const legacy = [];
   if (resolved.strict) {
     const dirs = fs.readdirSync(resolved.skillsDir, { withFileTypes: true })
-      .filter(entry => entry.isDirectory() && entry.name.startsWith('aiox-'))
+      .filter(entry => entry.isDirectory() && (entry.name.startsWith('aiox-') || entry.name.startsWith('aios-')))
       .map(entry => entry.name);
     for (const dir of dirs) {
-      if (!expectedIds.has(dir)) {
+      if (legacyIds.has(dir)) {
+        legacy.push(dir);
+        errors.push(`Legacy skill alias directory: ${path.join(path.relative(resolved.projectRoot, resolved.skillsDir), dir)}`);
+        continue;
+      }
+      if (dir.startsWith('aiox-') && !expectedIds.has(dir)) {
+        if (resolved.allowOrphaned) {
+          continue;
+        }
         orphaned.push(dir);
         errors.push(`Orphaned skill directory: ${path.join(path.relative(resolved.projectRoot, resolved.skillsDir), dir)}`);
       }
@@ -124,6 +136,7 @@ function validateCodexSkills(options = {}) {
     warnings,
     missing,
     orphaned,
+    legacy,
   };
 }
 

--- a/.aiox-core/infrastructure/scripts/ide-sync/index.js
+++ b/.aiox-core/infrastructure/scripts/ide-sync/index.js
@@ -211,7 +211,7 @@ function syncIde(agents, ideConfig, ideName, projectRoot, options) {
  * @param {object} options - Command options
  */
 async function commandSync(options) {
-  const projectRoot = process.cwd();
+  const projectRoot = options.projectRoot || process.cwd();
   const config = loadConfig(projectRoot);
 
   if (!config.enabled) {

--- a/.aiox-core/infrastructure/scripts/repair-agent-references.js
+++ b/.aiox-core/infrastructure/scripts/repair-agent-references.js
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs-extra');
+const path = require('path');
+
+const { parseAllAgents } = require('./ide-sync/agent-parser');
+const { commandSync } = require('./ide-sync/index');
+const {
+  syncSkills,
+  getCodexHome,
+  getSkillId,
+  getLegacySkillId,
+} = require('./codex-skills-sync/index');
+const { validateCodexSkills } = require('./codex-skills-sync/validate');
+
+function getDefaultOptions() {
+  const projectRoot = process.cwd();
+  return {
+    projectRoot,
+    sourceDir: path.join(projectRoot, '.aiox-core', 'development', 'agents'),
+    localSkillsDir: path.join(projectRoot, '.codex', 'skills'),
+    globalSkillsDir: path.join(getCodexHome(), 'skills'),
+    geminiCommandsDir: path.join(projectRoot, '.gemini', 'commands'),
+    includeGlobal: true,
+    dryRun: false,
+    quiet: false,
+    json: false,
+  };
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const args = new Set(argv);
+  return {
+    includeGlobal: !args.has('--no-global'),
+    dryRun: args.has('--dry-run'),
+    quiet: args.has('--quiet') || args.has('-q'),
+    json: args.has('--json'),
+  };
+}
+
+function isParsableAgent(agent) {
+  return !agent.error || agent.error === 'YAML parse failed, using fallback extraction';
+}
+
+function buildLegacyArtifacts(agents, options) {
+  const artifacts = [];
+
+  for (const agent of agents) {
+    const canonicalSkillId = getSkillId(agent.id);
+    const legacySkillId = getLegacySkillId(agent.id);
+
+    artifacts.push({
+      kind: 'skill-dir',
+      scope: 'local',
+      canonicalId: canonicalSkillId,
+      legacyId: legacySkillId,
+      path: path.join(options.localSkillsDir, legacySkillId),
+    });
+
+    if (options.includeGlobal) {
+      artifacts.push({
+        kind: 'skill-dir',
+        scope: 'global',
+        canonicalId: canonicalSkillId,
+        legacyId: legacySkillId,
+        path: path.join(options.globalSkillsDir, legacySkillId),
+      });
+    }
+
+    artifacts.push({
+      kind: 'gemini-command',
+      scope: 'project',
+      canonicalId: canonicalSkillId,
+      legacyId: legacySkillId,
+      path: path.join(options.geminiCommandsDir, `${legacySkillId}.toml`),
+    });
+  }
+
+  artifacts.push({
+    kind: 'gemini-menu',
+    scope: 'project',
+    canonicalId: 'aiox-menu',
+    legacyId: 'aios-menu',
+    path: path.join(options.geminiCommandsDir, 'aios-menu.toml'),
+  });
+
+  return artifacts;
+}
+
+function removeLegacyArtifacts(artifacts, options) {
+  const removed = [];
+  const skipped = [];
+
+  for (const artifact of artifacts) {
+    if (!fs.existsSync(artifact.path)) {
+      skipped.push({ ...artifact, reason: 'not-found' });
+      continue;
+    }
+
+    if (!options.dryRun) {
+      fs.removeSync(artifact.path);
+    }
+
+    removed.push(artifact);
+  }
+
+  return { removed, skipped };
+}
+
+function validateGeminiCommands(agents, commandsDir) {
+  const errors = [];
+  const checked = [];
+
+  const menuPath = path.join(commandsDir, 'aiox-menu.toml');
+  checked.push(menuPath);
+  if (!fs.existsSync(menuPath)) {
+    errors.push(`Missing Gemini launcher: ${menuPath}`);
+  }
+
+  const legacyMenuPath = path.join(commandsDir, 'aios-menu.toml');
+  if (fs.existsSync(legacyMenuPath)) {
+    errors.push(`Legacy Gemini launcher still present: ${legacyMenuPath}`);
+  }
+
+  for (const agent of agents) {
+    const canonicalId = getSkillId(agent.id);
+    const legacyId = getLegacySkillId(agent.id);
+    const canonicalPath = path.join(commandsDir, `${canonicalId}.toml`);
+    const legacyPath = path.join(commandsDir, `${legacyId}.toml`);
+
+    checked.push(canonicalPath);
+    if (!fs.existsSync(canonicalPath)) {
+      errors.push(`Missing Gemini command: ${canonicalPath}`);
+    }
+    if (fs.existsSync(legacyPath)) {
+      errors.push(`Legacy Gemini command still present: ${legacyPath}`);
+    }
+  }
+
+  return {
+    ok: errors.length === 0,
+    checked: checked.length,
+    errors,
+  };
+}
+
+async function repairAgentReferences(options = {}) {
+  const resolved = { ...getDefaultOptions(), ...options };
+  const agents = parseAllAgents(resolved.sourceDir).filter(isParsableAgent);
+  const legacyArtifacts = buildLegacyArtifacts(agents, resolved);
+  const cleanup = removeLegacyArtifacts(legacyArtifacts, resolved);
+
+  const skillSync = syncSkills({
+    sourceDir: resolved.sourceDir,
+    localSkillsDir: resolved.localSkillsDir,
+    globalSkillsDir: resolved.globalSkillsDir,
+    global: resolved.includeGlobal,
+    dryRun: resolved.dryRun,
+    quiet: true,
+  });
+
+  await commandSync({
+    projectRoot: resolved.projectRoot,
+    ide: null,
+    dryRun: resolved.dryRun,
+    verbose: false,
+    quiet: true,
+  });
+
+  const localValidation = validateCodexSkills({
+    projectRoot: resolved.projectRoot,
+    sourceDir: resolved.sourceDir,
+    skillsDir: resolved.localSkillsDir,
+    strict: true,
+    quiet: true,
+  });
+
+  const globalValidation = resolved.includeGlobal
+    ? validateCodexSkills({
+      projectRoot: resolved.projectRoot,
+      sourceDir: resolved.sourceDir,
+      skillsDir: resolved.globalSkillsDir,
+      strict: true,
+      allowOrphaned: true,
+      quiet: true,
+    })
+    : null;
+
+  const geminiValidation = validateGeminiCommands(agents, resolved.geminiCommandsDir);
+
+  return {
+    ok: localValidation.ok && (globalValidation ? globalValidation.ok : true) && geminiValidation.ok,
+    agentsChecked: agents.length,
+    removed: cleanup.removed,
+    skipped: cleanup.skipped,
+    skillSync,
+    validations: {
+      localCodex: localValidation,
+      globalCodex: globalValidation,
+      gemini: geminiValidation,
+    },
+  };
+}
+
+function formatHumanReport(result) {
+  const lines = [
+    result.ok
+      ? `✅ Agent/skill reference repair completed (${result.agentsChecked} core agents checked)`
+      : `❌ Agent/skill reference repair found issues (${result.agentsChecked} core agents checked)`,
+    `- Removed legacy artifacts: ${result.removed.length}`,
+    `- Skipped missing legacy artifacts: ${result.skipped.length}`,
+    `- Local Codex validation: ${result.validations.localCodex.ok ? 'pass' : 'fail'}`,
+    `- Global Codex validation: ${result.validations.globalCodex ? (result.validations.globalCodex.ok ? 'pass' : 'fail') : 'skipped'}`,
+    `- Gemini validation: ${result.validations.gemini.ok ? 'pass' : 'fail'}`,
+  ];
+
+  const detailErrors = [
+    ...result.validations.localCodex.errors,
+    ...(result.validations.globalCodex ? result.validations.globalCodex.errors : []),
+    ...result.validations.gemini.errors,
+  ];
+
+  if (detailErrors.length > 0) {
+    lines.push(...detailErrors.map(error => `  • ${error}`));
+  }
+
+  return lines.join('\n');
+}
+
+async function main() {
+  const options = parseArgs();
+  const result = await repairAgentReferences(options);
+
+  if (!options.quiet) {
+    if (options.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(formatHumanReport(result));
+    }
+  }
+
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`❌ ${error.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  buildLegacyArtifacts,
+  removeLegacyArtifacts,
+  validateGeminiCommands,
+  repairAgentReferences,
+  parseArgs,
+  getDefaultOptions,
+  formatHumanReport,
+};

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,9 +8,9 @@
 # - File types for categorization
 #
 version: 5.0.3
-generated_at: "2026-03-11T15:04:09.395Z"
+generated_at: "2026-04-16T19:02:22.011Z"
 generator: scripts/generate-install-manifest.js
-file_count: 1090
+file_count: 1091
 files:
   - path: cli/commands/config/index.js
     hash: sha256:25c4b9bf4e0241abf7754b55153f49f1a214f1fb5fe904a576675634cb7b3da9
@@ -1221,9 +1221,9 @@ files:
     type: data
     size: 9575
   - path: data/entity-registry.yaml
-    hash: sha256:cc1bf74d3ef4e90b7a396d5b77259e540b2f9bd4a5b4b1da4977fe49ae83525d
+    hash: sha256:3042dc897084f7a7511504e27b7ad8afdfb7037c2887c7609d7b18e3fcb754b4
     type: data
-    size: 521869
+    size: 523573
   - path: data/learned-patterns.yaml
     hash: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
     type: data
@@ -2957,13 +2957,13 @@ files:
     type: script
     size: 40724
   - path: infrastructure/scripts/codex-skills-sync/index.js
-    hash: sha256:a7a3c97374c34a900acad13498f61f8a40517574480354218e349d1e1d3931a4
+    hash: sha256:e587b49a997e7fab5a12441a63663fb882b9daced606d274cf365dfb04aaf10d
     type: script
-    size: 5246
+    size: 5474
   - path: infrastructure/scripts/codex-skills-sync/validate.js
-    hash: sha256:0fbc1baff25f20e3a37d3e4be51d146a75254d5ed638b3438d9f1bf0e587c997
+    hash: sha256:591ce1dc3d4a7de883d05677eb29fedf0b8b46bfe977390248731de38043e32c
     type: script
-    size: 4572
+    size: 5111
   - path: infrastructure/scripts/collect-tool-usage.js
     hash: sha256:8a739b79182dc41e28b7e02aeb9ec1dde5ec49f3ca534399acc59711b3b92bbf
     type: script
@@ -3085,9 +3085,9 @@ files:
     type: script
     size: 5534
   - path: infrastructure/scripts/ide-sync/index.js
-    hash: sha256:2f48896307b1fc3839f13169cab554c0a9a34f9d0e3961f1ccc07a2bbfaebdb2
+    hash: sha256:34377b67d0099aa68611ecff15b5fbe7d0073b86acf16edea0fa4a87ff51d6e4
     type: script
-    size: 14906
+    size: 14929
   - path: infrastructure/scripts/ide-sync/README.md
     hash: sha256:c18c2563b2ca64580a4814edd3c20a79c96f33fa8b953ee02206ef0faad53d35
     type: script
@@ -3248,6 +3248,10 @@ files:
     hash: sha256:118d4cdbc64cf3238065f2fb98958305ae81e1384bc68f5a6c7b768f1232cd1e
     type: script
     size: 34686
+  - path: infrastructure/scripts/repair-agent-references.js
+    hash: sha256:63b5f580b783d5098c3ab3d8da11af9871306b3a1fc0f986f25c813eb4c4dd75
+    type: script
+    size: 7200
   - path: infrastructure/scripts/repository-detector.js
     hash: sha256:10ffca7f57d24d3729c71a9104a154500a3c72328d67884e26e38d22199af332
     type: script

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.0.3
-generated_at: "2026-04-16T19:02:22.011Z"
+generated_at: "2026-04-16T19:05:53.557Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1091
 files:
@@ -1221,9 +1221,9 @@ files:
     type: data
     size: 9575
   - path: data/entity-registry.yaml
-    hash: sha256:3042dc897084f7a7511504e27b7ad8afdfb7037c2887c7609d7b18e3fcb754b4
+    hash: sha256:cc1bf74d3ef4e90b7a396d5b77259e540b2f9bd4a5b4b1da4977fe49ae83525d
     type: data
-    size: 523573
+    size: 521869
   - path: data/learned-patterns.yaml
     hash: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
     type: data

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "sync:skills:codex": "node .aiox-core/infrastructure/scripts/codex-skills-sync/index.js",
     "sync:skills:codex:global": "node .aiox-core/infrastructure/scripts/codex-skills-sync/index.js --global --global-only",
     "validate:codex-skills": "node .aiox-core/infrastructure/scripts/codex-skills-sync/validate.js --strict",
+    "repair:agent-references": "node .aiox-core/infrastructure/scripts/repair-agent-references.js",
     "validate:paths": "node .aiox-core/infrastructure/scripts/validate-paths.js",
     "validate:parity": "node .aiox-core/infrastructure/scripts/validate-parity.js",
     "validate:semantic-lint": "node scripts/semantic-lint.js",


### PR DESCRIPTION
Runtime-only publish for the agent-reference repair flow.

Scope is intentionally limited to five runtime files:
- .aiox-core/infrastructure/scripts/repair-agent-references.js
- .aiox-core/infrastructure/scripts/codex-skills-sync/index.js
- .aiox-core/infrastructure/scripts/codex-skills-sync/validate.js
- .aiox-core/infrastructure/scripts/ide-sync/index.js
- package.json

Intent:
- remove legacy `aios-*` aliases for core agents
- regenerate canonical `aiox-*` Codex/Gemini artifacts
- expose `npm run repair:agent-references`

Validation:
- `git apply --check` on the runtime-only patch: pass
- `npm run lint`: pass with existing repo baseline of 236 warnings, 0 errors
- `npm run typecheck`: pass
- `npm test`: 1 failing test in `tests/integration/onboarding-smoke.test.js` that expects the legacy greeting `Agent dev loaded`; the branch now produces the canonical Dex greeting. This is outside the runtime-only publish scope and was not included in the remote diff.

Unrelated dirty files were intentionally excluded from this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a repair command to detect, remove, and regenerate legacy agent/skill artifacts and emit human or JSON reports.
  * Validation now recognizes and normalizes legacy skill IDs and reports legacy alias directories alongside missing/orphaned entries.
  * Sync operations now accept an explicit project-root option for more predictable config and output resolution.
* **Chores**
  * Added an npm script to invoke the repair command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->