### PR TITLE
feat(license): sync stable machine id to core [Story PRO-13.2]

### DIFF
--- a/.aiox-core/development/scripts/unified-activation-pipeline.js
+++ b/.aiox-core/development/scripts/unified-activation-pipeline.js
@@ -209,7 +209,7 @@ class UnifiedActivationPipeline {
     const metrics = { loaders: {} };
 
     // --- Tier 1: Critical (AgentConfig) ---
-    const tier1Budget = LOADER_TIERS.critical.timeout;
+    const tier1Budget = this._resolveLoaderTimeout('critical', LOADER_TIERS.critical.timeout);
     const agentComplete = await this._profileLoader('agentConfig', metrics, tier1Budget, () => {
       const loader = new AgentConfigLoader(agentId);
       return loader.loadComplete(coreConfig);
@@ -231,7 +231,7 @@ class UnifiedActivationPipeline {
     }
 
     // --- Tier 2: High (PermissionMode + GitConfig) — parallel ---
-    const tier2Budget = LOADER_TIERS.high.timeout;
+    const tier2Budget = this._resolveLoaderTimeout('high', LOADER_TIERS.high.timeout);
     const elapsedAfterT1 = Date.now() - pipelineStart;
     const tier2Remaining = Math.max(tier2Budget - elapsedAfterT1, 20);
 
@@ -277,7 +277,7 @@ class UnifiedActivationPipeline {
     }
 
     // --- Tier 3: Best-effort (SessionContext + ProjectStatus) — parallel ---
-    const tier3Budget = LOADER_TIERS.bestEffort.timeout;
+    const tier3Budget = this._resolveLoaderTimeout('bestEffort', LOADER_TIERS.bestEffort.timeout);
     const elapsedAfterT2 = Date.now() - pipelineStart;
     const tier3Remaining = Math.max(tier3Budget - elapsedAfterT2, 20);
 
@@ -465,6 +465,32 @@ class UnifiedActivationPipeline {
     }
 
     return DEFAULT_PIPELINE_TIMEOUT_MS;
+  }
+
+  /**
+   * Resolve per-tier loader timeout.
+   *
+   * Intended mainly for constrained CI/test environments where cold filesystem
+   * reads can exceed the production performance budget without indicating a
+   * functional activation failure.
+   *
+   * @private
+   * @param {'critical'|'high'|'bestEffort'} tierName
+   * @param {number} defaultTimeout
+   * @returns {number}
+   */
+  _resolveLoaderTimeout(tierName, defaultTimeout) {
+    const envKey = `AIOX_LOADER_TIMEOUT_${tierName.replace(/([A-Z])/g, '_$1').toUpperCase()}`;
+    const envTimeout = process.env[envKey];
+
+    if (envTimeout) {
+      const parsed = parseInt(envTimeout, 10);
+      if (!isNaN(parsed) && parsed > 0) {
+        return parsed;
+      }
+    }
+
+    return defaultTimeout;
   }
 
   /**

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -7,8 +7,8 @@
 # - SHA256 hashes for change detection
 # - File types for categorization
 #
-version: 5.0.4
-generated_at: "2026-05-06T18:44:13.394Z"
+version: 5.0.8
+generated_at: "2026-05-06T19:40:38.959Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1103
 files:

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -7,8 +7,8 @@
 # - SHA256 hashes for change detection
 # - File types for categorization
 #
-version: 5.0.3
-generated_at: "2026-05-05T23:14:42.150Z"
+version: 5.0.4
+generated_at: "2026-05-06T18:32:29.951Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1103
 files:
@@ -1229,9 +1229,9 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:cc1bf74d3ef4e90b7a396d5b77259e540b2f9bd4a5b4b1da4977fe49ae83525d
+    hash: sha256:655a7e607d6d77f07f8f24447d6cc3ba00e497c37e508dc618b5b62fb22a644e
     type: data
-    size: 521869
+    size: 530908
   - path: data/learned-patterns.yaml
     hash: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
     type: data
@@ -1689,9 +1689,9 @@ files:
     type: script
     size: 17607
   - path: development/scripts/unified-activation-pipeline.js
-    hash: sha256:de2d4a10b01da32d31c1f810feed429804da6869bb958d5a5ebe626589d0a2f6
+    hash: sha256:6910a7f6b0cef65a0886e0b29bbcb0ee401ca4fb444eb255a7a368cb67327aa7
     type: script
-    size: 30125
+    size: 30996
   - path: development/scripts/usage-tracker.js
     hash: sha256:6057623755bf0ee1d9e0fb36740fc41914a5f8ca8ad994d40edec260e273744b
     type: script

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.0.4
-generated_at: "2026-05-06T18:32:29.951Z"
+generated_at: "2026-05-06T18:44:13.394Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1103
 files:
@@ -1229,9 +1229,9 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:655a7e607d6d77f07f8f24447d6cc3ba00e497c37e508dc618b5b62fb22a644e
+    hash: sha256:cc1bf74d3ef4e90b7a396d5b77259e540b2f9bd4a5b4b1da4977fe49ae83525d
     type: data
-    size: 530908
+    size: 521869
   - path: data/learned-patterns.yaml
     hash: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
     type: data

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,36 @@ jobs:
           fail_ci_if_error: false
         continue-on-error: true
 
+  pro-machine-id-stability:
+    name: Pro Machine ID Stability (${{ matrix.os }})
+    needs: changes
+    if: ${{ needs.changes.outputs.tests == 'true' || needs.changes.outputs.config == 'true' }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout code with Pro submodule
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run machine ID stability tests
+        run: npx jest --runTestsByPath tests/license/machine-id-stability.test.js --runInBand --testPathIgnorePatterns=/node_modules/
+
   story-validation:
     name: Story Checkbox Validation
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,10 +200,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - name: Checkout code with Pro submodule
+      - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -215,8 +213,28 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Detect Pro submodule availability
+        id: pro
+        shell: pwsh
+        run: |
+          if (Test-Path "pro/license/license-crypto.js") {
+            "available=true" >> $env:GITHUB_OUTPUT
+          } else {
+            "available=false" >> $env:GITHUB_OUTPUT
+            Write-Host "pro/ submodule is not available with the default CI token."
+            Write-Host "Cross-platform Pro runtime validation runs in the aiox-pro CI matrix."
+          }
+
       - name: Run machine ID stability tests
+        if: steps.pro.outputs.available == 'true'
         run: npx jest --runTestsByPath tests/license/machine-id-stability.test.js --runInBand --testPathIgnorePatterns=/node_modules/
+
+      - name: Record private submodule skip
+        if: steps.pro.outputs.available != 'true'
+        shell: pwsh
+        run: |
+          Write-Host "Skipping aiox-core Pro machine ID job because pro/ is private in default-token CI."
+          Write-Host "See https://github.com/SynkraAI/aiox-pro/pull/11 for the cross-platform Pro runtime matrix."
 
   story-validation:
     name: Story Checkbox Validation

--- a/README.md
+++ b/README.md
@@ -614,6 +614,12 @@ O **AIOX Pro** é o módulo premium do AIOX, oferecendo funcionalidades avançad
 npx aiox-pro install
 ```
 
+### Atualização 5.0.4
+
+O AIOX Pro agora usa o UUID nativo do sistema operacional para gerar `machineId`, preservando o hash SHA-256 e evitando consumo extra de assentos quando o macOS, VPNs ou redes Wi-Fi alteram o MAC/interface ativa.
+
+Caches locais de licença criados pelo algoritmo antigo são migrados automaticamente na próxima leitura. A janela de fallback legacy é de 90 dias; depois disso, instalações antigas precisam reativar online.
+
 ### Features Premium
 
 - **Squads Avançados** - Squads especializados com capacidades expandidas

--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ O **AIOX Pro** é o módulo premium do AIOX, oferecendo funcionalidades avançad
 npx aiox-pro install
 ```
 
-### Atualização 5.0.8
+### Identificação Estável de Máquina (>= 5.0.8)
 
 O AIOX Pro agora usa o UUID nativo do sistema operacional para gerar `machineId`, preservando o hash SHA-256 e evitando consumo extra de assentos quando o macOS, VPNs ou redes Wi-Fi alteram o MAC/interface ativa.
 

--- a/README.md
+++ b/README.md
@@ -614,7 +614,7 @@ O **AIOX Pro** é o módulo premium do AIOX, oferecendo funcionalidades avançad
 npx aiox-pro install
 ```
 
-### Atualização 5.0.4
+### Atualização 5.0.8
 
 O AIOX Pro agora usa o UUID nativo do sistema operacional para gerar `machineId`, preservando o hash SHA-256 e evitando consumo extra de assentos quando o macOS, VPNs ou redes Wi-Fi alteram o MAC/interface ativa.
 

--- a/bin/utils/validate-publish.js
+++ b/bin/utils/validate-publish.js
@@ -23,6 +23,7 @@ const PROJECT_ROOT = path.join(__dirname, '..', '..');
 const PRO_DIR = path.join(PROJECT_ROOT, 'pro');
 const CRITICAL_FILE = path.join(PRO_DIR, 'license', 'license-api.js');
 const MIN_FILE_COUNT = 50;
+const PACK_DRY_RUN_TIMEOUT_MS = 120000;
 
 // CI environments may not have access to the private pro submodule
 const IS_CI = process.env.CI === 'true' || process.env.GITHUB_ACTIONS === 'true';
@@ -75,7 +76,7 @@ try {
   const packOutput = execSync('npm pack --dry-run 2>&1', {
     encoding: 'utf8',
     cwd: PROJECT_ROOT,
-    timeout: 30000,
+    timeout: PACK_DRY_RUN_TIMEOUT_MS,
   });
   // npm pack --dry-run outputs lines starting with "npm notice" for each file
   const fileLines = packOutput.split('\n').filter(line =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiox-core",
-  "version": "5.0.4",
+  "version": "5.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiox-core",
-      "version": "5.0.4",
+      "version": "5.0.8",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aiox-core",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aiox-core",
-      "version": "5.0.3",
+      "version": "5.0.4",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -29,6 +29,7 @@
         "handlebars": "^4.7.8",
         "inquirer": "^8.2.6",
         "js-yaml": "^4.1.0",
+        "node-machine-id": "^1.1.12",
         "ora": "^5.4.1",
         "picocolors": "^1.1.1",
         "proper-lockfile": "^4.1.2",
@@ -9081,6 +9082,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-machine-id": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/node-machine-id/-/node-machine-id-1.1.12.tgz",
+      "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ==",
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -9299,25 +9306,6 @@
       "license": "MIT",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
@@ -9881,15 +9869,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/npm/node_modules/encoding": {
-      "version": "0.1.13",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
       "dev": true,
@@ -9898,11 +9877,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.3",
@@ -10025,14 +9999,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
       }
     },
     "node_modules/npm/node_modules/ini": {
@@ -10765,18 +10731,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/promzard": {
       "version": "3.0.1",
       "dev": true,
@@ -10816,14 +10770,6 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/npm/node_modules/safer-buffer": {
@@ -10910,24 +10856,6 @@
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
@@ -11072,51 +11000,11 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/unique-filename": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-slug": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/npm/node_modules/validate-npm-package-license": {
-      "version": "3.0.4",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
-      }
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiox-core",
-  "version": "5.0.4",
+  "version": "5.0.8",
   "description": "Synkra AIOX: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aiox": "bin/aiox.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiox-core",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Synkra AIOX: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aiox": "bin/aiox.js",
@@ -113,6 +113,7 @@
     "handlebars": "^4.7.8",
     "inquirer": "^8.2.6",
     "js-yaml": "^4.1.0",
+    "node-machine-id": "^1.1.12",
     "ora": "^5.4.1",
     "picocolors": "^1.1.1",
     "proper-lockfile": "^4.1.2",

--- a/tests/cli/validate-publish.test.js
+++ b/tests/cli/validate-publish.test.js
@@ -121,7 +121,7 @@ describe('Publish Safety Gate (Story INS-4.10)', () => {
       const result = execSync(`node "${SCRIPT_PATH}" 2>&1`, {
         encoding: 'utf8',
         cwd: path.join(__dirname, '..', '..'),
-        timeout: 60000,
+        timeout: 180000,
       });
       expect(result).toContain('PUBLISH SAFETY GATE: PASS');
     });

--- a/tests/integration/pipeline-memory-integration.test.js
+++ b/tests/integration/pipeline-memory-integration.test.js
@@ -28,10 +28,16 @@ describe('UnifiedActivationPipeline Memory Integration (MIS-6)', () => {
 
   // Store original env to restore after tests
   const originalPipelineTimeout = process.env.AIOX_PIPELINE_TIMEOUT;
+  const originalCriticalLoaderTimeout = process.env.AIOX_LOADER_TIMEOUT_CRITICAL;
+  const originalHighLoaderTimeout = process.env.AIOX_LOADER_TIMEOUT_HIGH;
+  const originalBestEffortLoaderTimeout = process.env.AIOX_LOADER_TIMEOUT_BEST_EFFORT;
 
   beforeEach(() => {
     // Increase pipeline timeout so tests don't fail under heavy load (full suite)
     process.env.AIOX_PIPELINE_TIMEOUT = '5000';
+    process.env.AIOX_LOADER_TIMEOUT_CRITICAL = '5000';
+    process.env.AIOX_LOADER_TIMEOUT_HIGH = '5000';
+    process.env.AIOX_LOADER_TIMEOUT_BEST_EFFORT = '5000';
     pipeline = new UnifiedActivationPipeline(testProjectRoot);
     jest.clearAllMocks();
   });
@@ -42,6 +48,21 @@ describe('UnifiedActivationPipeline Memory Integration (MIS-6)', () => {
       process.env.AIOX_PIPELINE_TIMEOUT = originalPipelineTimeout;
     } else {
       delete process.env.AIOX_PIPELINE_TIMEOUT;
+    }
+    if (originalCriticalLoaderTimeout !== undefined) {
+      process.env.AIOX_LOADER_TIMEOUT_CRITICAL = originalCriticalLoaderTimeout;
+    } else {
+      delete process.env.AIOX_LOADER_TIMEOUT_CRITICAL;
+    }
+    if (originalHighLoaderTimeout !== undefined) {
+      process.env.AIOX_LOADER_TIMEOUT_HIGH = originalHighLoaderTimeout;
+    } else {
+      delete process.env.AIOX_LOADER_TIMEOUT_HIGH;
+    }
+    if (originalBestEffortLoaderTimeout !== undefined) {
+      process.env.AIOX_LOADER_TIMEOUT_BEST_EFFORT = originalBestEffortLoaderTimeout;
+    } else {
+      delete process.env.AIOX_LOADER_TIMEOUT_BEST_EFFORT;
     }
 
     // Cleanup test data

--- a/tests/license/machine-id-stability.test.js
+++ b/tests/license/machine-id-stability.test.js
@@ -1,0 +1,150 @@
+/**
+ * Machine ID stability and cache migration tests.
+ *
+ * @see Story PRO-13.2 - Stable machine_id via OS native UUID
+ */
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+function loadProLicense(nativeId = 'stable-native-os-uuid') {
+  jest.resetModules();
+  jest.doMock('node-machine-id', () => ({
+    machineIdSync: jest.fn(() => nativeId),
+  }));
+
+  return {
+    cache: require('../../pro/license/license-cache'),
+    crypto: require('../../pro/license/license-crypto'),
+  };
+}
+
+function createTestCacheData(overrides = {}) {
+  return {
+    key: 'PRO-ABCD-EFGH-IJKL-MNOP',
+    activatedAt: new Date().toISOString(),
+    expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+    features: ['pro.squads.*', 'pro.memory.*'],
+    seats: { used: 1, max: 5 },
+    cacheValidDays: 30,
+    gracePeriodDays: 7,
+    ...overrides,
+  };
+}
+
+function writeLegacyCache(cacheModule, cryptoModule, baseDir, data) {
+  fs.mkdirSync(cacheModule.getAioxDir(baseDir), { recursive: true });
+
+  const legacyMachineId = cryptoModule.generateMachineIdLegacy();
+  const salt = cryptoModule.generateSalt();
+  const key = cryptoModule.deriveCacheKey(legacyMachineId, salt);
+  const cacheData = {
+    ...data,
+    machineId: legacyMachineId,
+    cacheValidDays: data.cacheValidDays || cacheModule._CONFIG.DEFAULT_CACHE_VALID_DAYS,
+    gracePeriodDays: data.gracePeriodDays || cacheModule._CONFIG.DEFAULT_GRACE_PERIOD_DAYS,
+    version: cacheModule._CONFIG.CACHE_VERSION,
+  };
+  const encrypted = cryptoModule.encrypt(cacheData, key);
+  const hmacData = JSON.stringify({
+    ciphertext: encrypted.ciphertext,
+    iv: encrypted.iv,
+    tag: encrypted.tag,
+  });
+
+  fs.writeFileSync(
+    cacheModule.getCachePath(baseDir),
+    JSON.stringify(
+      {
+        encrypted: encrypted.ciphertext,
+        iv: encrypted.iv,
+        tag: encrypted.tag,
+        hmac: cryptoModule.computeHMAC(hmacData, key),
+        salt: salt.toString('hex'),
+        version: cacheModule._CONFIG.CACHE_VERSION,
+      },
+      null,
+      2,
+    ),
+    'utf8',
+  );
+
+  return legacyMachineId;
+}
+
+describe('machine-id stability', () => {
+  let testDir;
+
+  beforeEach(() => {
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aiox-machine-id-test-'));
+  });
+
+  afterEach(() => {
+    jest.dontMock('node-machine-id');
+    jest.restoreAllMocks();
+    fs.rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('keeps generateMachineId stable when MAC addresses rotate', () => {
+    const { crypto: cryptoModule } = loadProLicense();
+    const networkInterfacesSpy = jest.spyOn(os, 'networkInterfaces')
+      .mockReturnValueOnce({
+        en0: [{ internal: false, mac: 'aa:bb:cc:dd:ee:ff' }],
+      })
+      .mockReturnValueOnce({
+        en0: [{ internal: false, mac: '11:22:33:44:55:66' }],
+      });
+
+    const first = cryptoModule.generateMachineId();
+    cryptoModule._resetMachineIdCacheForTests();
+    const second = cryptoModule.generateMachineId();
+
+    expect(first).toBe(second);
+    expect(first).toMatch(/^[a-f0-9]{64}$/);
+    expect(networkInterfacesSpy).not.toHaveBeenCalled();
+  });
+
+  it('migrates a legacy hostname CPU MAC cache to the native machine ID key', () => {
+    const { cache: cacheModule, crypto: cryptoModule } = loadProLicense();
+    const consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    const data = createTestCacheData();
+
+    const legacyMachineId = writeLegacyCache(cacheModule, cryptoModule, testDir, data);
+    const nativeMachineId = cryptoModule.generateMachineId();
+
+    expect(legacyMachineId).not.toBe(nativeMachineId);
+
+    const cache = cacheModule.readLicenseCache(testDir);
+
+    expect(cache).not.toBeNull();
+    expect(cache.key).toBe(data.key);
+    expect(cache.machineId).toBe(nativeMachineId);
+    expect(consoleInfoSpy).toHaveBeenCalledWith('[aiox-pro] Cache migrated to new machine_id format');
+
+    consoleInfoSpy.mockClear();
+    const migratedCache = cacheModule.readLicenseCache(testDir);
+
+    expect(migratedCache).not.toBeNull();
+    expect(migratedCache.machineId).toBe(nativeMachineId);
+    expect(consoleInfoSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects legacy caches after the 90 day fallback window', () => {
+    const { cache: cacheModule, crypto: cryptoModule } = loadProLicense();
+    const consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    const oldActivatedAt = new Date(Date.now() - 91 * 24 * 60 * 60 * 1000).toISOString();
+
+    writeLegacyCache(
+      cacheModule,
+      cryptoModule,
+      testDir,
+      createTestCacheData({ activatedAt: oldActivatedAt }),
+    );
+
+    expect(cacheModule.readLicenseCache(testDir)).toBeNull();
+    expect(consoleInfoSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/synapse/synapse-memory-provider.test.js
+++ b/tests/synapse/synapse-memory-provider.test.js
@@ -8,6 +8,9 @@
  * @migrated INS-4.11 AC9 - Moved to open-source, removed feature gate
  */
 
+const fs = require('fs');
+const path = require('path');
+
 jest.setTimeout(10000);
 
 let mockQueryMemories;
@@ -20,11 +23,18 @@ function loadProviderModule() {
   jest.resetModules();
   mockQueryMemories = jest.fn(() => Promise.resolve([]));
 
-  jest.doMock('../../pro/memory/memory-loader', () => ({
+  const mockFactory = () => ({
     MemoryLoader: jest.fn().mockImplementation(() => ({
       queryMemories: mockQueryMemories,
     })),
-  }), { virtual: true });
+  });
+  const memoryLoaderExists = fs.existsSync(path.join(__dirname, '../../pro/memory/memory-loader.js'));
+
+  if (memoryLoaderExists) {
+    jest.doMock('../../pro/memory/memory-loader', mockFactory);
+  } else {
+    jest.doMock('../../pro/memory/memory-loader', mockFactory, { virtual: true });
+  }
 
   let loadedModule;
   jest.isolateModules(() => {


### PR DESCRIPTION
## Summary
- bump aiox-core to 5.0.4 and add node-machine-id dependency
- point pro submodule to aiox-pro stable-machine-id commit 524b615
- add machine ID stability/cache migration tests and cross-platform CI job
- harden publish and memory integration tests exposed by populated pro submodule

## Validation
- npm run typecheck
- npm run lint
- npm run validate:publish
- npx jest --runTestsByPath tests/license/machine-id-stability.test.js tests/synapse/synapse-memory-provider.test.js tests/integration/pipeline-memory-integration.test.js tests/cli/validate-publish.test.js --runInBand --testPathIgnorePatterns=/node_modules/ --forceExit
- npm test -- --runInBand --forceExit (310 suites passed, 11 skipped; 7797 tests passed, 149 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-tier configurable loader timeouts for finer-grained performance tuning
  * Improved machine ID stability for Pro using OS-native UUIDs and automatic license-cache migration

* **Documentation**
  * Installation notes updated (Atualização 5.0.8) with 90-day legacy license fallback and migration behavior

* **Tests**
  * Added cross-platform machine-id stability tests; expanded memory/timeout integration and mocking improvements

* **Chores**
  * Bumped release to v5.0.8, added runtime dependency, CI job for machine-id stability, and publish/pack timeout updates
<!-- end of auto-generated comment: release notes by coderabbit.ai -->