### PR TITLE
fix(synapse): dynamic context window from model registry

### DIFF
--- a/.aiox-core/core-config.yaml
+++ b/.aiox-core/core-config.yaml
@@ -386,4 +386,17 @@ boundary:
     - .aiox-core/core/config/schemas/**
     - .aiox-core/core/config/template-overrides.js
 
-# Memory Intelligence System (Epic MIS) configuration placeholder — MIS-2+
+# Context-tracker dynamic model registry (Issue #605).
+# Consumed by .aiox-core/core/synapse/context/context-tracker.js.
+models:
+  active: claude-sonnet-4-6
+  registry:
+    claude-opus-4-6:
+      contextWindow: 1000000
+      avgTokensPerPrompt: 1500
+    claude-sonnet-4-6:
+      contextWindow: 200000
+      avgTokensPerPrompt: 1500
+    claude-haiku-4-5:
+      contextWindow: 200000
+      avgTokensPerPrompt: 1200

--- a/.aiox-core/core/synapse/context/context-tracker.js
+++ b/.aiox-core/core/synapse/context/context-tracker.js
@@ -5,12 +5,15 @@
  * based on estimated token usage. Provides token budgets and layer filtering
  * per bracket for the SynapseEngine orchestrator.
  *
- * Pure arithmetic module — zero I/O, zero external dependencies.
+ * Reads model context window from core-config.yaml → models.registry.
  *
  * @module core/synapse/context/context-tracker
- * @version 1.0.0
+ * @version 1.1.0
  * @created Story SYN-3 - Context Bracket Tracker
  */
+
+const fs = require('fs');
+const path = require('path');
 
 /**
  * Bracket definitions with thresholds and token budgets.
@@ -51,11 +54,87 @@ const XML_SAFETY_MULTIPLIER = 1.2;
 
 /**
  * Default configuration values.
+ * maxContext is the fallback when core-config.yaml is unavailable.
  */
-const DEFAULTS = {
+const DEFAULTS = Object.freeze({
   avgTokensPerPrompt: 1500,
   maxContext: 200000,
-};
+});
+
+/** Cache for model config by project root (read once per root per process). */
+const _modelConfigCache = new Map();
+
+function cloneModelConfig(config) {
+  return { ...config };
+}
+
+function cacheModelConfig(root, config) {
+  const cachedConfig = Object.freeze(cloneModelConfig(config));
+  _modelConfigCache.set(root, cachedConfig);
+  return cloneModelConfig(cachedConfig);
+}
+
+function isPositiveFiniteNumber(value) {
+  return Number.isFinite(value) && value > 0;
+}
+
+/**
+ * Resolve the project root used for model config lookup.
+ *
+ * @param {string|null} basePath - Optional project root override
+ * @returns {string}
+ */
+function resolveConfigRoot(basePath) {
+  return path.resolve(basePath || path.resolve(__dirname, '..', '..', '..', '..'));
+}
+
+/**
+ * Read model configuration from core-config.yaml → models section.
+ * Returns { contextWindow, avgTokensPerPrompt } for the active model.
+ * Falls back to DEFAULTS if config is missing or malformed.
+ *
+ * @param {string|null} [basePath=null] - Project root override (defaults to __dirname-based resolution)
+ * @returns {{ maxContext: number, avgTokensPerPrompt: number }}
+ */
+function getModelConfig(basePath = null) {
+  const root = resolveConfigRoot(basePath);
+  if (_modelConfigCache.has(root)) return cloneModelConfig(_modelConfigCache.get(root));
+
+  try {
+    const yaml = require('js-yaml');
+    let configPath = path.join(root, '.aios-core', 'core-config.yaml');
+    if (!fs.existsSync(configPath)) {
+      configPath = path.join(root, '.aiox-core', 'core-config.yaml');
+    }
+    if (!fs.existsSync(configPath)) {
+      return cacheModelConfig(root, DEFAULTS);
+    }
+
+    const config = yaml.load(fs.readFileSync(configPath, 'utf8'));
+    const models = config && config.models;
+    if (!models || !models.registry || !models.active) {
+      return cacheModelConfig(root, DEFAULTS);
+    }
+
+    const activeModel = models.registry[models.active];
+    if (!activeModel || !isPositiveFiniteNumber(activeModel.contextWindow)) {
+      return cacheModelConfig(root, DEFAULTS);
+    }
+
+    const modelConfig = {
+      maxContext: activeModel.contextWindow,
+      avgTokensPerPrompt: isPositiveFiniteNumber(activeModel.avgTokensPerPrompt)
+        ? activeModel.avgTokensPerPrompt
+        : DEFAULTS.avgTokensPerPrompt,
+    };
+    return cacheModelConfig(root, modelConfig);
+  } catch (err) {
+    if (process.env.DEBUG || process.env.AIOX_DEBUG) {
+      console.warn('[context-tracker] Failed to load model config, using defaults:', err.message);
+    }
+    return cacheModelConfig(root, DEFAULTS);
+  }
+}
 
 /**
  * Layer configurations per bracket.
@@ -101,16 +180,20 @@ function calculateBracket(contextPercent) {
  * Formula: 100 - ((promptCount * avgTokensPerPrompt) / maxContext * 100)
  * Result is clamped to 0-100 range.
  *
+ * Reads maxContext and avgTokensPerPrompt from core-config.yaml → models.registry
+ * for the active model. Options parameter can override for testing.
+ *
  * @param {number} promptCount - Number of prompts in current session
- * @param {Object} [options={}] - Configuration options
- * @param {number} [options.avgTokensPerPrompt=1500] - Average tokens per prompt
- * @param {number} [options.maxContext=200000] - Maximum context window size in tokens
+ * @param {Object} [options={}] - Configuration options (override config values)
+ * @param {number} [options.avgTokensPerPrompt] - Average tokens per prompt
+ * @param {number} [options.maxContext] - Maximum context window size in tokens
  * @returns {number} Percentage of context remaining (0.0 to 100.0)
  */
 function estimateContextPercent(promptCount, options = {}) {
+  const modelConfig = getModelConfig();
   const {
-    avgTokensPerPrompt = DEFAULTS.avgTokensPerPrompt,
-    maxContext = DEFAULTS.maxContext,
+    avgTokensPerPrompt = modelConfig.avgTokensPerPrompt,
+    maxContext = modelConfig.maxContext,
   } = options;
 
   if (typeof promptCount !== 'number' || isNaN(promptCount) || promptCount < 0) {
@@ -184,6 +267,19 @@ function needsMemoryHints(bracket) {
   return bracket === 'DEPLETED' || bracket === 'CRITICAL';
 }
 
+/**
+ * Reset the model config cache. Useful for tests or after config changes.
+ *
+ * @param {string|null} [basePath=null] - Optional project root override
+ */
+function resetModelConfigCache(basePath = null) {
+  if (basePath === null) {
+    _modelConfigCache.clear();
+    return;
+  }
+  _modelConfigCache.delete(resolveConfigRoot(basePath));
+}
+
 module.exports = {
   calculateBracket,
   estimateContextPercent,
@@ -191,6 +287,8 @@ module.exports = {
   getActiveLayers,
   needsHandoffWarning,
   needsMemoryHints,
+  getModelConfig,
+  resetModelConfigCache,
   BRACKETS,
   TOKEN_BUDGETS,
   DEFAULTS,

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.0.8
-generated_at: "2026-05-06T19:40:38.959Z"
+generated_at: "2026-05-06T23:23:59.783Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1103
 files:
@@ -181,9 +181,9 @@ files:
     type: cli
     size: 5907
   - path: core-config.yaml
-    hash: sha256:08471a9bf736776c15e72695f373fc3a203caf139412d3ec5c78a977796c1208
+    hash: sha256:9ddfc19a58ca25ca628925ec2ba2afab720c89d80817dfc2e0b03c3fcfcfecc2
     type: config
-    size: 11032
+    size: 11368
   - path: core/code-intel/code-intel-client.js
     hash: sha256:6c9a08a37775acf90397aa079a4ad2c5edcc47f2cfd592b26ae9f3d154d1deb8
     type: core
@@ -1057,9 +1057,9 @@ files:
     type: core
     size: 1013
   - path: core/synapse/context/context-tracker.js
-    hash: sha256:48e94db7b1778dedecc8eae829139579ad7778ff47668597ebe766610696553f
+    hash: sha256:5a54a15fbbbd4b6095e7e78297cb87e4a123a7c1d714a7c7916272ef6fd680f1
     type: core
-    size: 5839
+    size: 9144
   - path: core/synapse/diagnostics/collectors/consistency-collector.js
     hash: sha256:65f4255f87c9900400649dc8b9aedaac4851b5939d93e127778bd93cee99db12
     type: core

--- a/tests/synapse/context-tracker.test.js
+++ b/tests/synapse/context-tracker.test.js
@@ -5,6 +5,10 @@
  * @story SYN-3 - Context Bracket Tracker
  */
 
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
 const {
   calculateBracket,
   estimateContextPercent,
@@ -12,6 +16,8 @@ const {
   getActiveLayers,
   needsHandoffWarning,
   needsMemoryHints,
+  getModelConfig,
+  resetModelConfigCache,
   BRACKETS,
   TOKEN_BUDGETS,
   DEFAULTS,
@@ -361,6 +367,125 @@ describe('DEFAULTS constant', () => {
   test('should have maxContext = 200000', () => {
     expect(DEFAULTS.maxContext).toBe(200000);
   });
+
+  test('should be immutable', () => {
+    expect(Object.isFrozen(DEFAULTS)).toBe(true);
+  });
+});
+
+// =============================================================================
+// getModelConfig
+// =============================================================================
+
+describe('getModelConfig', () => {
+  beforeEach(() => {
+    resetModelConfigCache();
+  });
+
+  afterEach(() => {
+    resetModelConfigCache();
+  });
+
+  function createProjectConfig(contents) {
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aiox-context-tracker-'));
+    const configDir = path.join(projectDir, '.aiox-core');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'core-config.yaml'), contents, 'utf8');
+    return projectDir;
+  }
+
+  test('reads active model context window from core-config.yaml', () => {
+    const projectDir = createProjectConfig(`
+models:
+  active: claude-opus-4-6
+  registry:
+    claude-opus-4-6:
+      contextWindow: 1000000
+      avgTokensPerPrompt: 1500
+`);
+
+    expect(getModelConfig(projectDir)).toEqual({
+      maxContext: 1000000,
+      avgTokensPerPrompt: 1500,
+    });
+  });
+
+  test('falls back to DEFAULTS when models section is missing', () => {
+    const projectDir = createProjectConfig('boundary:\n  frameworkProtection: true\n');
+
+    expect(getModelConfig(projectDir)).toEqual(DEFAULTS);
+    expect(getModelConfig(projectDir)).not.toBe(DEFAULTS);
+  });
+
+  test('falls back to DEFAULTS when active model context window is invalid', () => {
+    const projectDir = createProjectConfig(`
+models:
+  active: invalid-model
+  registry:
+    invalid-model:
+      contextWindow: 0
+      avgTokensPerPrompt: 1500
+`);
+
+    expect(getModelConfig(projectDir)).toEqual(DEFAULTS);
+  });
+
+  test('returns copies so callers cannot mutate cached defaults', () => {
+    const projectDir = createProjectConfig('boundary:\n  frameworkProtection: true\n');
+    const fallbackConfig = getModelConfig(projectDir);
+
+    fallbackConfig.maxContext = 1;
+    fallbackConfig.avgTokensPerPrompt = 1;
+
+    expect(getModelConfig(projectDir)).toEqual(DEFAULTS);
+  });
+
+  test('uses default average tokens when active model omits avgTokensPerPrompt', () => {
+    const projectDir = createProjectConfig(`
+models:
+  active: custom-model
+  registry:
+    custom-model:
+      contextWindow: 750000
+`);
+
+    expect(getModelConfig(projectDir)).toEqual({
+      maxContext: 750000,
+      avgTokensPerPrompt: DEFAULTS.avgTokensPerPrompt,
+    });
+  });
+
+  test('caches model config separately per project root', () => {
+    const opusDir = createProjectConfig(`
+models:
+  active: claude-opus-4-6
+  registry:
+    claude-opus-4-6:
+      contextWindow: 1000000
+      avgTokensPerPrompt: 1500
+`);
+    const smallDir = createProjectConfig(`
+models:
+  active: local-test-model
+  registry:
+    local-test-model:
+      contextWindow: 50000
+      avgTokensPerPrompt: 1000
+`);
+
+    expect(getModelConfig(opusDir)).toEqual({
+      maxContext: 1000000,
+      avgTokensPerPrompt: 1500,
+    });
+    expect(getModelConfig(smallDir)).toEqual({
+      maxContext: 50000,
+      avgTokensPerPrompt: 1000,
+    });
+    expect(getModelConfig(opusDir)).toEqual({
+      maxContext: 1000000,
+      avgTokensPerPrompt: 1500,
+    });
+  });
 });
 
 // =============================================================================
@@ -447,19 +572,17 @@ describe('XML_SAFETY_MULTIPLIER (QW-3)', () => {
 });
 
 // =============================================================================
-// AC8: Zero External Dependencies
+// AC8: Dynamic Configuration
 // =============================================================================
 
-describe('AC8: zero external dependencies', () => {
-  test('module source should not contain require statements', () => {
-    const fs = require('fs');
-    const path = require('path');
+describe('AC8: dynamic configuration', () => {
+  test('module source should expose config loading and cache reset helpers', () => {
     const source = fs.readFileSync(
       path.join(__dirname, '../../.aiox-core/core/synapse/context/context-tracker.js'),
       'utf8',
     );
-    // Should not have any require() calls (only module.exports)
-    const requireMatches = source.match(/\brequire\s*\(/g);
-    expect(requireMatches).toBeNull();
+    expect(source).toContain('function getModelConfig');
+    expect(source).toContain('function resetModelConfigCache');
+    expect(source).toContain('core-config.yaml');
   });
 });


### PR DESCRIPTION
## Summary

Recut of #606 for issue #605 after the existing PR could not be updated from this DevOps run.

- Reads `models.active` / `models.registry` from `.aiox-core/core-config.yaml` instead of relying only on the hardcoded 200K context fallback.
- Keeps graceful fallback to 200K when config is missing or malformed.
- Adds focused tests for dynamic config loading, fallback behavior, and cache reset.
- Regenerates install manifest and clarifies the model registry comment.

Fixes #605. Supersedes #606 for merge purposes.

## Validation

- `git diff --check origin/main..HEAD` PASS
- `npm run lint` PASS
- `npm run typecheck` PASS
- `npm test -- --runInBand tests/synapse/context-tracker.test.js tests/synapse/diagnostics/qa-issues-validation.test.js` PASS: 84/84

## Notes

Full-suite Jest on this goal-run has pre-existing `tests/pro-wizard.test.js` failures that reproduce on clean `origin/main`; this PR was validated with focused Synapse tests plus lint/typecheck.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Runtime model configuration: choose an active model and per-model parameters (context window, avg tokens) that drive context estimation.
  * Per-project model registry with fallbacks and a public cache-reset capability.

* **Tests**
  * Added tests for dynamic configuration loading, cache isolation/reset, parameter resolution, and protection against mutating cached results.

* **Chores**
  * Regenerated install manifest metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->