### PR TITLE
fix(installer): install Claude hooks by tier

### DIFF
--- a/packages/installer/src/wizard/ide-config-generator.js
+++ b/packages/installer/src/wizard/ide-config-generator.js
@@ -543,7 +543,7 @@ async function generateIDEConfigs(selectedIDEs, wizardState, options = {}) {
 
           // BUG-3 fix (INS-1): Copy .claude/hooks/ folder (SYNAPSE engine + precompact)
           spinner.start('Copying Claude Code hooks...');
-          const hookFiles = await copyClaudeHooksFolder(projectRoot);
+          const hookFiles = await copyClaudeHooksFolder(projectRoot, wizardState);
           createdFiles.push(...hookFiles);
           if (hookFiles.length > 0) {
             createdFolders.push(path.join(projectRoot, '.claude', 'hooks'));
@@ -661,9 +661,10 @@ function showSuccessSummary(result) {
  * BUG-3 fix (INS-1): Copy .claude/hooks/ folder during installation
  * Only copies JS hooks that work without external dependencies (Python, etc.)
  * @param {string} projectRoot - Project root directory
+ * @param {Object} [wizardState={}] - Current wizard state
  * @returns {Promise<string[]>} List of copied files
  */
-async function copyClaudeHooksFolder(projectRoot) {
+async function copyClaudeHooksFolder(projectRoot, wizardState = {}) {
   const sourceDir = path.join(__dirname, '..', '..', '..', '..', '.claude', 'hooks');
   const targetDir = path.join(projectRoot, '.claude', 'hooks');
   const copiedFiles = [];
@@ -679,13 +680,17 @@ async function copyClaudeHooksFolder(projectRoot) {
 
   await fs.ensureDir(targetDir);
 
-  // Only copy JS hooks that work standalone (no Python/shell deps)
-  const HOOKS_TO_COPY = [
+  const HOOKS_FREE = [
     'synapse-engine.cjs',
     'code-intel-pretool.cjs',
-    'precompact-session-digest.cjs',
     'README.md',
   ];
+  const HOOKS_PRO_ONLY = [
+    'precompact-session-digest.cjs',
+  ];
+  const HOOKS_TO_COPY = shouldCopyProHooks(wizardState)
+    ? [...HOOKS_FREE, ...HOOKS_PRO_ONLY]
+    : HOOKS_FREE;
 
   const files = await fs.readdir(sourceDir);
 
@@ -705,6 +710,31 @@ async function copyClaudeHooksFolder(projectRoot) {
   }
 
   return copiedFiles;
+}
+
+/**
+ * Decide whether Pro-only hooks should be copied.
+ * Explicit wizard tier wins; otherwise fall back to runtime Pro detection.
+ * Supports wizardState.proTier as a legacy alias from older Pro setup state.
+ *
+ * @param {Object} [wizardState={}] - Current wizard state
+ * @returns {boolean} true when Pro-only hooks should be installed
+ */
+function shouldCopyProHooks(wizardState = {}) {
+  const tier = String(wizardState.tier || wizardState.proTier || '').toLowerCase();
+  if (tier === 'pro') return true;
+  if (['free', 'community', 'core'].includes(tier)) return false;
+
+  if (wizardState.pro && typeof wizardState.pro.enabled === 'boolean') {
+    return wizardState.pro.enabled;
+  }
+
+  try {
+    const { isProAvailable } = require('../../../../bin/utils/pro-detector');
+    return isProAvailable();
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -1208,6 +1238,7 @@ module.exports = {
   promptFileExists,
   generateTemplateVariables,
   copyClaudeHooksFolder,
+  shouldCopyProHooks,
   createClaudeSettingsLocal,
   copySkillFiles,
   generateCodexSkills,

--- a/packages/installer/tests/unit/artifact-copy-pipeline/artifact-copy-pipeline.test.js
+++ b/packages/installer/tests/unit/artifact-copy-pipeline/artifact-copy-pipeline.test.js
@@ -7,7 +7,9 @@ const os = require('os');
 const {
   copySkillFiles,
   copyExtraCommandFiles,
+  copyClaudeHooksFolder,
   createClaudeSettingsLocal,
+  shouldCopyProHooks,
   HOOK_EVENT_MAP,
   DEFAULT_HOOK_CONFIG,
 } = require('../../../../../packages/installer/src/wizard/ide-config-generator');
@@ -18,6 +20,15 @@ function createTempDir() {
 
 function cleanup(dir) {
   fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function expectedAvailableHooks(...fileNames) {
+  const hooksDir = path.join(__dirname, '../../../../../.claude/hooks');
+  if (!fs.existsSync(hooksDir)) {
+    throw new Error(`Expected Claude hooks source directory at ${hooksDir}`);
+  }
+  const available = new Set(fs.readdirSync(hooksDir));
+  return fileNames.filter(file => available.has(file)).sort();
 }
 
 describe('artifact-copy-pipeline (Story INS-4.3)', () => {
@@ -165,6 +176,78 @@ describe('artifact-copy-pipeline (Story INS-4.3)', () => {
         cleanup(sourceRoot);
         cleanup(targetRoot);
       }
+    });
+  });
+
+  describe('copyClaudeHooksFolder tier selection (Issue #544)', () => {
+    test('free tier copies only free hooks and does not register PreCompact', async () => {
+      const targetRoot = createTempDir();
+
+      try {
+        const copied = await copyClaudeHooksFolder(targetRoot, { tier: 'free' });
+        const fileNames = copied.map(file => path.basename(file)).sort();
+
+        expect(fileNames).toEqual(expectedAvailableHooks(
+          'README.md',
+          'code-intel-pretool.cjs',
+          'synapse-engine.cjs',
+        ));
+
+        const settingsPath = await createClaudeSettingsLocal(targetRoot);
+        expect(settingsPath).toEqual(expect.any(String));
+        const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+
+        expect(settings.hooks.UserPromptSubmit).toHaveLength(1);
+        if (fileNames.includes('code-intel-pretool.cjs')) {
+          expect(settings.hooks.PreToolUse).toHaveLength(1);
+        } else {
+          expect(settings.hooks.PreToolUse).toBeUndefined();
+        }
+        expect(settings.hooks.PreCompact).toBeUndefined();
+      } finally {
+        cleanup(targetRoot);
+      }
+    });
+
+    test('pro tier copies free hooks plus PreCompact session digest hook', async () => {
+      const targetRoot = createTempDir();
+
+      try {
+        const copied = await copyClaudeHooksFolder(targetRoot, { tier: 'pro' });
+        const fileNames = copied.map(file => path.basename(file)).sort();
+
+        expect(fileNames).toEqual(expectedAvailableHooks(
+          'README.md',
+          'code-intel-pretool.cjs',
+          'precompact-session-digest.cjs',
+          'synapse-engine.cjs',
+        ));
+
+        const settingsPath = await createClaudeSettingsLocal(targetRoot);
+        expect(settingsPath).toEqual(expect.any(String));
+        const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+
+        expect(settings.hooks.UserPromptSubmit).toHaveLength(1);
+        if (fileNames.includes('code-intel-pretool.cjs')) {
+          expect(settings.hooks.PreToolUse).toHaveLength(1);
+        } else {
+          expect(settings.hooks.PreToolUse).toBeUndefined();
+        }
+        expect(settings.hooks.PreCompact).toHaveLength(1);
+      } finally {
+        cleanup(targetRoot);
+      }
+    });
+
+    test('explicit wizard tier controls Pro hook selection', () => {
+      expect(shouldCopyProHooks({ tier: 'pro' })).toBe(true);
+      expect(shouldCopyProHooks({ tier: 'free' })).toBe(false);
+      expect(shouldCopyProHooks({ tier: 'community' })).toBe(false);
+      expect(shouldCopyProHooks({ tier: 'core' })).toBe(false);
+      expect(shouldCopyProHooks({ proTier: 'pro' })).toBe(true);
+      expect(shouldCopyProHooks({ tier: 'free', proTier: 'pro' })).toBe(false);
+      expect(shouldCopyProHooks({ pro: { enabled: true } })).toBe(true);
+      expect(shouldCopyProHooks({ pro: { enabled: false } })).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Recut for issue #544 after validating the existing PRs #597 and #551 against current main.

This PR keeps the already-fixed command-hook runtime intact and makes the installer tier-aware:
- passes wizard state into Claude Code hook installation
- installs only Free-safe hooks for free/community/core tiers
- installs the Pro-only PreCompact digest hook only for Pro tier or explicit Pro detection
- keeps dynamic settings registration unchanged, so only copied hooks are registered
- adds exact regression coverage for Free vs Pro hook output against the package's actual hook source files

Fixes #544.
Supersedes #597 and #551 for the #544 merge path.

## Validation

Local QA on isolated worktree:
- npm test -- --runInBand packages/installer/tests/unit/artifact-copy-pipeline/artifact-copy-pipeline.test.js
- npm run lint
- npm run typecheck
- npm run validate:manifest
- npm run validate:semantic-lint
- npm run validate:parity
- git diff --check origin/main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * IDE hook installation now respects Pro tier selection, ensuring the correct hook set is installed based on your chosen tier during setup.
* **Tests**
  * Added unit tests validating tier-based hook installation and the Pro-detection logic across configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->