### PR TITLE
fix(tasks): enforce story status transitions after QA

### DIFF
--- a/.aiox-core/development/tasks/dev-develop-story.md
+++ b/.aiox-core/development/tasks/dev-develop-story.md
@@ -370,7 +370,7 @@ const {
    - All tasks complete
    - All tests pass
    - Execute story-dod-checklist
-   - Set status: "Ready for Review"
+   - Set status: "InReview" (see Status Transitions section)
    - **Generate decision log**:
      ```javascript
      const logPath = await completeDecisionLogging(storyId, 'completed');
@@ -416,7 +416,7 @@ const {
    - All tests pass
    - Execute story-dod-checklist
    - Present completion summary to user
-   - Set status: "Ready for Review"
+   - Set status: "InReview" (see Status Transitions section)
 
 **User Prompts**: 5-10 (balanced for control and speed)
 
@@ -467,7 +467,7 @@ const {
    - All tests pass
    - Execute story-dod-checklist
    - Present execution summary vs. plan
-   - Set status: "Ready for Review"
+   - Set status: "InReview" (see Status Transitions section)
 
 **User Prompts**: All upfront (questionnaire phase), then 0 during execution
 
@@ -501,7 +501,7 @@ const {
 - Completion Notes List
 - File List
 - Change Log (add entry on completion)
-- Status (set to "Ready for Review" when complete)
+- Status (set to "InReview" when complete — see Status Transitions section)
 
 **DO NOT modify**: Story, Acceptance Criteria, Dev Notes, Testing sections
 
@@ -514,7 +514,7 @@ const {
 - Missing configuration
 - Failing regression tests
 
-### Ready for Review Criteria (All Modes)
+### InReview Criteria (All Modes)
 
 - Code matches all requirements
 - All validations pass
@@ -530,7 +530,7 @@ const {
 5. File List is complete
 6. **Execute CodeRabbit Self-Healing Loop** (see below)
 7. Execute `.aiox-core/product/checklists/story-dod-checklist.md`
-8. Set story status: "Ready for Review"
+8. Set story status: "InReview" (see Status Transitions section)
 9. HALT (do not proceed further)
 
 ---
@@ -915,10 +915,49 @@ Found 5 technical decisions needed.
 - **Educational Value**: Interactive mode explanations help developers learn framework patterns
 - **Scope Drift Prevention**: Pre-flight mode eliminates mid-development ambiguity
 
+## Status Transitions (MANDATORY — All Modes)
+
+**Reference:** `.claude/rules/story-lifecycle.md` — @dev owns Ready → InProgress and InProgress → InReview transitions.
+
+**These steps MUST be executed at the specified points, regardless of execution mode.**
+
+**Change Log format:** Use `{date: YYYY-MM-DD}` and `{version: MAJOR.MINOR.PATCH}`. Version MUST follow semantic bump rules: major for breaking changes, minor for features, patch for fixes/process updates. HALT if either value cannot be resolved deterministically.
+
+### On Development Start (before first task):
+
+0. **Pre-check (blocking):**
+   - If current Status is `**InProgress**`, skip to first uncompleted task (resume scenario — no status change needed).
+   - If current Status is not `**Ready**` and not `**InProgress**`, HALT and log: "Cannot start development: expected Ready or InProgress, found {current status}."
+   - If Change Log section is missing, HALT and request user to restore template structure.
+1. **Update story Status field:** change `**Ready**` to `**InProgress**` (skip if already InProgress)
+2. **Add Change Log entry:**
+   ```text
+   | {date: YYYY-MM-DD} | {version: MAJOR.MINOR.PATCH} | Development started ({mode} mode) — Status: Ready → InProgress | @dev |
+   ```
+3. **Log:** "🚀 Story status updated: Ready → InProgress"
+
+### On Development Complete (after DOD checklist, before HALT):
+
+0. **Pre-check (blocking):**
+   - If current Status is not `**InProgress**`, HALT and log: "Cannot mark for review: expected InProgress, found {current status}."
+   - If Change Log section is missing, HALT and request user to restore template structure.
+1. **Update story Status field:** change `**InProgress**` to `**InReview**`
+2. **Add Change Log entry:**
+   ```text
+   | {date: YYYY-MM-DD} | {version: MAJOR.MINOR.PATCH} | Development complete — Status: InProgress → InReview | @dev |
+   ```
+3. **Log:** "✅ Story status updated: InProgress → InReview"
+
+### Rationale
+
+Status transitions defined in `story-lifecycle.md` are advisory (contextual rules). These steps make them imperative (procedural), ensuring agents always execute the transitions as part of the workflow rather than relying on contextual rule awareness.
+
+---
+
 ## Handoff
 next_agent: @qa
 next_command: *review {story-id}
-condition: Story status is Ready for Review
+condition: Story status is InReview (updated in Status Transitions above)
 alternatives:
   - agent: @qa, command: *gate {story-id}, condition: Quick gate decision needed
   - agent: @dev, command: *apply-qa-fixes, condition: Self-identified issues during dev

--- a/.aiox-core/development/tasks/qa-gate.md
+++ b/.aiox-core/development/tasks/qa-gate.md
@@ -420,11 +420,61 @@ Gate: CONCERNS → qa.qaLocation/gates/{epic}.{story}-{slug}.yml
 - Always update story with gate reference
 - Clear, actionable findings
 
+## Post-Gate Status Update (MANDATORY)
+
+**Reference:** `.claude/rules/story-lifecycle.md` — Status transitions are @qa responsibility during QA gate.
+
+**This step MUST be executed before presenting results to user.**
+
+**Change Log format:** Use `{date: YYYY-MM-DD}` and `{version: MAJOR.MINOR.PATCH}`. Version MUST follow semantic bump rules: major for breaking changes, minor for features, patch for fixes/process updates. HALT if either value cannot be resolved deterministically.
+
+### IF verdict is PASS or CONCERNS:
+
+0. **Pre-check (blocking):**
+   - If current Status is not `**InReview**`, HALT and log: "Cannot apply PASS/CONCERNS transition: expected InReview, found {current status}."
+   - If Change Log section is missing, HALT and request user to restore template structure.
+1. **Update story Status field** in the story file: change `**InReview**` to `**Done**`
+2. **Add Change Log entry:**
+   ```text
+   | {date: YYYY-MM-DD} | {version: MAJOR.MINOR.PATCH} | QA Gate {PASS|CONCERNS} — Status: InReview → Done | @qa |
+   ```
+3. **Log:** "✅ Story status updated: InReview → Done"
+
+### IF verdict is FAIL:
+
+0. **Pre-check (blocking):**
+   - If current Status is not `**InReview**`, HALT and log: "Cannot apply FAIL transition: expected InReview, found {current status}."
+   - If Change Log section is missing, HALT and request user to restore template structure.
+1. **Update story Status field** in the story file: change `**InReview**` to `**InProgress**`
+2. **Add Change Log entry:**
+   ```text
+   | {date: YYYY-MM-DD} | {version: MAJOR.MINOR.PATCH} | QA Gate FAIL — Status: InReview → InProgress — {reason} | @qa |
+   ```
+3. **Log:** "❌ Story returned to InProgress — fixes required"
+
+### IF verdict is WAIVED:
+
+0. **Pre-check (blocking):**
+   - If current Status is not `**InReview**`, HALT and log: "Cannot apply WAIVED transition: expected InReview, found {current status}."
+   - If Change Log section is missing, HALT and request user to restore template structure.
+1. **Update story Status field** in the story file: change `**InReview**` to `**Done**`
+2. **Add Change Log entry:**
+   ```text
+   | {date: YYYY-MM-DD} | {version: MAJOR.MINOR.PATCH} | QA Gate WAIVED — Status: InReview → Done — {waiver reason} | @qa |
+   ```
+3. **Log:** "⚠️ Story status updated: InReview → Done (waived)"
+
+### Rationale
+
+Status transitions defined in `story-lifecycle.md` are advisory (contextual rules). This step makes them imperative (procedural), ensuring agents always execute the transition as part of the workflow rather than relying on contextual rule awareness.
+
+---
+
 ## Handoff
 next_agent: @devops
 next_command: *push
-condition: QA gate verdict is PASS
+condition: QA gate verdict is PASS or CONCERNS (status updated to Done)
 alternatives:
-  - agent: @dev, command: *apply-qa-fixes, condition: QA gate verdict is FAIL or CONCERNS
-  - agent: @po, command: *close-story {story-id}, condition: QA gate verdict is WAIVED
- 
+  - agent: @po, command: *review-concerns {story-id}, condition: QA gate verdict is CONCERNS (status updated to Done, has non-blocking issues)
+  - agent: @dev, command: *apply-qa-fixes, condition: QA gate verdict is FAIL (status updated to InProgress)
+  - agent: @po, command: *close-story {story-id}, condition: QA gate verdict is WAIVED (status updated to Done)

--- a/.aiox-core/development/tasks/validate-next-story.md
+++ b/.aiox-core/development/tasks/validate-next-story.md
@@ -463,10 +463,47 @@ Provide a structured validation report including:
 - **Implementation Readiness Score**: 1-10 scale
 - **Confidence Level**: High/Medium/Low for successful implementation
 
+### 12. Post-Validation Status Update (MANDATORY)
+
+**Reference:** `.claude/rules/story-lifecycle.md` — Draft → Ready transition is @po responsibility.
+
+**This step MUST be executed before presenting results to user.**
+
+**Change Log format:** Use `{date: YYYY-MM-DD}` and `{version: MAJOR.MINOR.PATCH}`. Version MUST follow semantic bump rules: major for breaking changes, minor for features, patch for fixes/process updates. HALT if either value cannot be resolved deterministically.
+
+#### IF verdict is GO (score >= 7):
+
+0. **Pre-check (blocking):**
+   - If current Status is not `**Draft**`, HALT and log: "Cannot apply GO transition: expected Draft, found {current status}."
+   - If Change Log section is missing, HALT and request user to restore template structure.
+1. **Update story Status field** in the story file: change `**Draft**` to `**Ready**`
+2. **Add Change Log entry:**
+   ```text
+   | {date: YYYY-MM-DD} | {version: MAJOR.MINOR.PATCH} | Validated GO ({score}/10) — Status: Draft → Ready | @po |
+   ```
+3. **Log:** "✅ Story status updated: Draft → Ready"
+
+#### IF verdict is NO-GO (score < 7):
+
+0. **Pre-check (blocking):**
+   - If current Status is not `**Draft**`, HALT and log: "Cannot apply NO-GO outcome: expected Draft, found {current status}."
+   - If Change Log section is missing, HALT and request user to restore template structure.
+1. **Keep** story Status as `**Draft**`
+2. **Add Change Log entry:**
+   ```text
+   | {date: YYYY-MM-DD} | {version: MAJOR.MINOR.PATCH} | Validation NO-GO — {reason summary} | @po |
+   ```
+3. **Log:** "❌ Story remains Draft — fixes required before re-validation"
+
+#### Rationale
+
+Status transitions defined in `story-lifecycle.md` are advisory (contextual rules). This step makes them imperative (procedural), ensuring agents always execute the transition as part of the workflow rather than relying on contextual rule awareness.
+
+---
+
 ## Handoff
 next_agent: @dev
 next_command: *develop {story-id}
-condition: Story status is Approved (GO decision)
+condition: Story status is Ready (GO decision, status updated in Step 12)
 alternatives:
   - agent: @sm, command: *draft, condition: Story rejected (NO-GO), needs rework
- 

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.0.8
-generated_at: "2026-05-06T19:40:38.959Z"
+generated_at: "2026-05-06T23:17:09.144Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1103
 files:
@@ -2001,9 +2001,9 @@ files:
     type: task
     size: 11021
   - path: development/tasks/dev-develop-story.md
-    hash: sha256:24ef3f76f37f82c8caa0bfaec4ac1ccf14ebd1cd60c6f0fe5c355d63b113784c
+    hash: sha256:be8924aa0de759ca92a177b0ea12a5b076a3095ee2a9f530b74b3de19e996954
     type: task
-    size: 27355
+    size: 29737
   - path: development/tasks/dev-improve-code-quality.md
     hash: sha256:6cf78aed6cca48bf13cc1f677f2cde86aea591785f428f9f56733de478107e2f
     type: task
@@ -2317,9 +2317,9 @@ files:
     type: task
     size: 15785
   - path: development/tasks/qa-gate.md
-    hash: sha256:25fc098d7c71554836925632c4a3f99aff9ade392e1ab1c669ae0983f49c6070
+    hash: sha256:b151ea672e7ad0e9229807f86430e4f3483395ee4beae40f2f17d7f6228aee24
     type: task
-    size: 10759
+    size: 13591
   - path: development/tasks/qa-generate-tests.md
     hash: sha256:245885950328b086ffbe9320bba2e814b3f6b5e3e5342bac904ccd814d4e8519
     type: task
@@ -2573,9 +2573,9 @@ files:
     type: task
     size: 3595
   - path: development/tasks/validate-next-story.md
-    hash: sha256:a7e0dbd89753d72248a6171d6bd4aa88d97e9c5051a5889d566c509d048d113c
+    hash: sha256:f121211b1fbe915e181399d10bd30c435aec55c0af9b49d99c533473574a4907
     type: task
-    size: 16914
+    size: 18848
   - path: development/tasks/validate-tech-preset.md
     hash: sha256:50a65289c223c1a79b0bebe4120f3f703df45d42522309e658f6d0f5c9fdb54e
     type: task


### PR DESCRIPTION
## Summary

Canonical recut for issue #636 after validating PR #550 against current main.

The original PR #550 is still open but behind the base branch and fork-bound, so this PR reapplies the validated task-workflow correction on top of current `origin/main` and adds the required install-manifest update.

Changes:
- makes task workflow status transitions imperative instead of advisory
- updates QA gate post-verdict story status handling
- updates validate-next-story and dev-develop-story lifecycle guards
- updates install manifest hashes for the changed task files

Fixes #636.
Supersedes #550 for the merge path.

## Validation

Local QA on isolated worktree:
- npm install --no-audit --no-fund, then restored npm v11 lockfile churn
- npm run lint
- npm run typecheck
- npm run validate:manifest
- npm run validate:semantic-lint
- git diff --check origin/main


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Workflow updates: story status renamed to "InReview", review criteria headers revised, added mandatory status-transition steps with required Change Log entries and console logs; QA handoff now requires InReview.
* **Chores**
  * QA gate and validation flows updated to enforce post-gate/validation status changes (PASS/CONCERNS/FAIL/WAIVED paths and routing), added mandatory validation step for Draft→Ready, and updated manifest metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->