### PR TITLE
fix: align Pro package release gates

### DIFF
--- a/.aiox-core/cli/commands/pro/buyer.js
+++ b/.aiox-core/cli/commands/pro/buyer.js
@@ -28,12 +28,13 @@ const path = require('path');
 //
 // Resolution order (matches pro/index.js and pro-setup.js):
 //   1. Bundled pro/ (framework-dev / npx context with submodule)
-//   2. npm canonical scope (@aiox-fullstack/pro) — preferred future state
-//   3. npm legacy scope (@aios-fullstack/pro) — fallback while npm rename in flight
+//   2. npm canonical scope (@aiox-squads/pro)
+//   3. npm legacy scopes (@aiox-fullstack/pro, @aios-fullstack/pro)
 //   4. cwd node_modules under either scope
-const PRO_PACKAGE_CANONICAL = '@aiox-fullstack/pro';
-const PRO_PACKAGE_FALLBACK = '@aios-fullstack/pro';
-const PRO_PACKAGES = [PRO_PACKAGE_CANONICAL, PRO_PACKAGE_FALLBACK];
+const PRO_PACKAGE_CANONICAL = '@aiox-squads/pro';
+const PRO_PACKAGE_FALLBACK = '@aiox-fullstack/pro';
+const PRO_PACKAGE_LEGACY = '@aios-fullstack/pro';
+const PRO_PACKAGES = [PRO_PACKAGE_CANONICAL, PRO_PACKAGE_FALLBACK, PRO_PACKAGE_LEGACY];
 
 function resolveLicensePath() {
   const relativePath = path.resolve(__dirname, '..', '..', '..', '..', 'pro', 'license');
@@ -76,7 +77,7 @@ function loadClient() {
   } catch (error) {
     console.error('Erro: módulo AIOX Pro license não disponível.');
     console.error(`Instale: npm install ${PRO_PACKAGE_CANONICAL}`);
-    console.error(`(ou fallback: npm install ${PRO_PACKAGE_FALLBACK})`);
+    console.error(`(ou fallback: npm install ${PRO_PACKAGE_FALLBACK} / ${PRO_PACKAGE_LEGACY})`);
     console.error(`Detalhe: ${error.message}`);
     process.exit(2);
   }

--- a/.aiox-core/cli/commands/pro/index.js
+++ b/.aiox-core/cli/commands/pro/index.js
@@ -26,7 +26,7 @@ const { createBuyerCommand } = require('./buyer');
 
 // BUG-6 fix (INS-1): Dynamic licensePath resolution
 // In framework-dev: __dirname = aiox-core/.aiox-core/cli/commands/pro → ../../../../pro/license
-// In project-dev: pro is installed via npm as @aiox-fullstack/pro or @aios-fullstack/pro
+// In project-dev: pro is installed via npm as @aiox-squads/pro or a legacy scope.
 function resolveLicensePath() {
   // 1. Try relative path (framework-dev mode)
   const relativePath = path.resolve(__dirname, '..', '..', '..', '..', 'pro', 'license');
@@ -36,6 +36,7 @@ function resolveLicensePath() {
 
   // 2. Try npm packages — canonical then fallback
   const npmCandidates = [
+    '@aiox-squads/pro',
     '@aiox-fullstack/pro',
     '@aios-fullstack/pro',
   ];
@@ -56,6 +57,7 @@ function resolveLicensePath() {
   // 3. Try project root node_modules (both scopes)
   const projectRoot = process.cwd();
   const scopePaths = [
+    path.join(projectRoot, 'node_modules', '@aiox-squads', 'pro', 'license'),
     path.join(projectRoot, 'node_modules', '@aiox-fullstack', 'pro', 'license'),
     path.join(projectRoot, 'node_modules', '@aios-fullstack', 'pro', 'license'),
   ];
@@ -592,13 +594,13 @@ async function validateAction() {
 /**
  * Setup and verify AIOX Pro installation.
  *
- * Tries canonical @aiox-fullstack/pro first, falls back to @aios-fullstack/pro.
+ * Tries canonical @aiox-squads/pro first, then legacy fallbacks.
  *
  * @param {object} options - Command options
  * @param {boolean} options.verify - Only verify without installing
  */
 async function setupAction(options) {
-  const PRO_PACKAGES = ['@aiox-fullstack/pro', '@aios-fullstack/pro'];
+  const PRO_PACKAGES = ['@aiox-squads/pro', '@aiox-fullstack/pro', '@aios-fullstack/pro'];
 
   console.log('\nAIOX Pro - Setup\n');
 

--- a/.aiox-core/core/pro/pro-updater.js
+++ b/.aiox-core/core/pro/pro-updater.js
@@ -1,5 +1,5 @@
 /**
- * Pro Updater — update @aiox-fullstack/pro (or fallback @aios-fullstack/pro)
+ * Pro Updater — update @aiox-squads/pro with legacy package fallbacks.
  *
  * Handles:
  * - Detecting installed Pro version and source
@@ -21,7 +21,7 @@ const { createRequire } = require('module');
 const semver = require('semver');
 const { execSync } = require('child_process');
 
-const PRO_PACKAGES = ['@aiox-fullstack/pro', '@aios-fullstack/pro'];
+const PRO_PACKAGES = ['@aiox-squads/pro', '@aiox-fullstack/pro', '@aios-fullstack/pro'];
 const CORE_PACKAGES = ['@synkra/aiox-core', 'aiox-core'];
 const DEPENDENCY_FIELDS = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'];
 const CORE_PACKAGE_ROOT = path.resolve(__dirname, '..', '..', '..');

--- a/.aiox-core/data/entity-registry.yaml
+++ b/.aiox-core/data/entity-registry.yaml
@@ -1,7 +1,7 @@
 metadata:
   version: 1.0.0
-  lastUpdated: '2026-03-11T00:48:55.982Z'
-  entityCount: 745
+  lastUpdated: '2026-05-07T00:08:59.095Z'
+  entityCount: 746
   checksumAlgorithm: sha256
   resolutionRate: 100
 entities:
@@ -12778,6 +12778,22 @@ entities:
         extensionPoints: []
       checksum: sha256:dd025894f8f0d3bd22a147dbc0debef8b83e96f3c59483653404b3cd5a01d5aa
       lastVerified: '2026-03-11T00:48:55.903Z'
+    pro-updater:
+      path: .aiox-core/core/pro/pro-updater.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/pro/pro-updater.js
+      keywords:
+        - pro
+        - updater
+      usedBy: []
+      dependencies: []
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:4fbdf590f1685d835fa5bef8e2307708ab1eeb49f5ea177d4f79c1629e35670a
+      lastVerified: '2026-05-07T00:08:58.904Z'
   agents:
     aiox-master:
       path: .aiox-core/development/agents/aiox-master.md

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.0.8
-generated_at: "2026-05-06T23:55:26.981Z"
+generated_at: "2026-05-07T00:14:42.841Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1103
 files:
@@ -101,13 +101,13 @@ files:
     type: cli
     size: 12326
   - path: cli/commands/pro/buyer.js
-    hash: sha256:e71066fefb12fd9da0cd2078f2a8c70a378322428a6a0422c8821a1024084057
+    hash: sha256:b866132041f28ab473e5b9df41e636ded1ba96ae278de02b1233993ee527ada9
     type: cli
-    size: 12292
+    size: 12335
   - path: cli/commands/pro/index.js
-    hash: sha256:c7fc2899b44b6ee69bf3851db5c9fe3d51e448a4ad0727020daeefe3ee8429c7
+    hash: sha256:d22457253ad517114883d38e2d8ddc2de6257fd2f9222c299b56f55eb6ad2ba9
     type: cli
-    size: 26195
+    size: 26295
   - path: cli/commands/qa/index.js
     hash: sha256:3a9e30419a66e56781f9b5dcddc8f4dd0ed24dabf8fe8c3005cd26f5cb02558f
     type: cli
@@ -973,9 +973,9 @@ files:
     type: core
     size: 7193
   - path: core/pro/pro-updater.js
-    hash: sha256:f4f2ec9bfe06921f559003e8e21a79d2ed9e9283488e3cceab7c6eb199f7f5d0
+    hash: sha256:4fbdf590f1685d835fa5bef8e2307708ab1eeb49f5ea177d4f79c1629e35670a
     type: core
-    size: 17473
+    size: 17487
   - path: core/quality-gates/base-layer.js
     hash: sha256:9a9a3921da08176b0bd44f338a59abc1f5107f3b1ee56571e840bf4e8ed233f4
     type: core
@@ -1229,9 +1229,9 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:cc1bf74d3ef4e90b7a396d5b77259e540b2f9bd4a5b4b1da4977fe49ae83525d
+    hash: sha256:cb4f48b524af2cd998929cb203ba76b1938d960d5a052dbffbe4166d67eb9080
     type: data
-    size: 521869
+    size: 522342
   - path: data/learned-patterns.yaml
     hash: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
     type: data

--- a/bin/utils/pro-detector.js
+++ b/bin/utils/pro-detector.js
@@ -31,25 +31,35 @@ const PRO_DIR = path.join(PROJECT_ROOT, 'pro');
 const PRO_PACKAGE_PATH = path.join(PRO_DIR, 'package.json');
 
 /**
- * Canonical npm package name (future, after org rename).
+ * Canonical npm package name.
  */
-const PRO_PACKAGE_CANONICAL = '@aiox-fullstack/pro';
+const PRO_PACKAGE_CANONICAL = '@aiox-squads/pro';
 
 /**
- * Fallback npm package name (active until org rename).
+ * Legacy npm package name kept as a fallback for installs created during the
+ * unpublished @aiox-fullstack/pro transition.
  */
-const PRO_PACKAGE_FALLBACK = '@aios-fullstack/pro';
+const PRO_PACKAGE_FALLBACK = '@aiox-fullstack/pro';
+
+/**
+ * Original AIOS npm package name, retained for backward compatibility.
+ */
+const PRO_PACKAGE_LEGACY = '@aios-fullstack/pro';
+
+const PRO_PACKAGES = [
+  PRO_PACKAGE_CANONICAL,
+  PRO_PACKAGE_FALLBACK,
+  PRO_PACKAGE_LEGACY,
+];
 
 /**
  * Resolve the installed npm Pro package path.
- * Tries canonical name first, then fallback.
+ * Tries canonical name first, then legacy fallbacks.
  *
  * @returns {{ packagePath: string, packageName: string } | null}
  */
 function resolveNpmProPackage() {
-  const candidates = [PRO_PACKAGE_CANONICAL, PRO_PACKAGE_FALLBACK];
-
-  for (const packageName of candidates) {
+  for (const packageName of PRO_PACKAGES) {
     try {
       const pkgJson = require.resolve(`${packageName}/package.json`, {
         paths: [process.cwd()],
@@ -67,7 +77,7 @@ function resolveNpmProPackage() {
  * Check if the AIOX Pro is available via any source.
  *
  * Detection priority:
- * 1. npm package (canonical @aiox-fullstack/pro or fallback @aios-fullstack/pro)
+ * 1. npm package (canonical @aiox-squads/pro or legacy fallbacks)
  * 2. pro/ submodule directory
  *
  * @returns {boolean} true if Pro is available
@@ -186,6 +196,8 @@ module.exports = {
   resolveNpmProPackage,
   PRO_PACKAGE_CANONICAL,
   PRO_PACKAGE_FALLBACK,
+  PRO_PACKAGE_LEGACY,
+  PRO_PACKAGES,
   // Exported for testing
   _PRO_DIR: PRO_DIR,
   _PRO_PACKAGE_PATH: PRO_PACKAGE_PATH,

--- a/packages/aiox-pro-cli/bin/aiox-pro.js
+++ b/packages/aiox-pro-cli/bin/aiox-pro.js
@@ -23,9 +23,10 @@ const path = require('path');
 const fs = require('fs');
 const { recoverLicense } = require('../src/recover');
 
-const PRO_PACKAGE_CANONICAL = '@aiox-fullstack/pro';
-const PRO_PACKAGE_FALLBACK = '@aios-fullstack/pro';
-const PRO_PACKAGES = [PRO_PACKAGE_CANONICAL, PRO_PACKAGE_FALLBACK];
+const PRO_PACKAGE_CANONICAL = '@aiox-squads/pro';
+const PRO_PACKAGE_FALLBACK = '@aiox-fullstack/pro';
+const PRO_PACKAGE_LEGACY = '@aios-fullstack/pro';
+const PRO_PACKAGES = [PRO_PACKAGE_CANONICAL, PRO_PACKAGE_FALLBACK, PRO_PACKAGE_LEGACY];
 const VERSION = require('../package.json').version;
 
 const args = process.argv.slice(2);

--- a/packages/installer/src/pro/pro-scaffolder.js
+++ b/packages/installer/src/pro/pro-scaffolder.js
@@ -2,7 +2,7 @@
  * Pro Content Scaffolder
  *
  * Copies premium content (squads, configs, feature registry) from
- * node_modules/@aiox-fullstack/pro/ (or @aios-fullstack/pro/) into the user's project after
+ * node_modules/@aiox-squads/pro/ (or a legacy Pro scope) into the user's project after
  * license activation.
  *
  * @module packages/installer/src/pro/pro-scaffolder
@@ -55,7 +55,7 @@ const SCAFFOLD_ITEMS = [
  * Scaffold pro content into user project.
  *
  * @param {string} targetDir - Project root directory
- * @param {string} proSourceDir - Path to pro package content (node_modules/@aiox-fullstack/pro or @aios-fullstack/pro)
+ * @param {string} proSourceDir - Path to pro package content (node_modules/@aiox-squads/pro or legacy scopes)
  * @param {Object} [options={}] - Scaffold options
  * @param {Function} [options.onProgress] - Progress callback ({item, status, message})
  * @param {boolean} [options.force=false] - Force overwrite even if content exists

--- a/packages/installer/src/wizard/pro-setup.js
+++ b/packages/installer/src/wizard/pro-setup.js
@@ -39,7 +39,7 @@ const LICENSE_SERVER_URL = process.env.AIOX_LICENSE_API_URL || 'https://aiox-lic
 /**
  * Inline License Client — lightweight HTTP client for pre-bootstrap license checks.
  *
- * Used when @aiox-fullstack/pro is not yet installed (first install scenario).
+ * Used when @aiox-squads/pro is not yet installed (first install scenario).
  * Implements the same interface subset as LicenseApiClient using Node.js native https.
  */
 class InlineLicenseClient {
@@ -351,14 +351,14 @@ function showStep(current, total, label) {
  *
  * Resolution order:
  * 1. Relative path (framework-dev mode: ../../../../pro/license/{name})
- * 2. @aiox-fullstack/pro package (brownfield: node_modules/@aiox-fullstack/pro/license/{name})
+ * 2. @aiox-squads/pro package (brownfield: node_modules/@aiox-squads/pro/license/{name})
  * 3. Absolute path via aiox-core in node_modules (brownfield upgrade)
- * 4. Absolute path via @aiox-fullstack/pro in user project (npx context)
+ * 4. Absolute path via @aiox-squads/pro in user project (npx context)
  *
  * Path 4 is critical for npx execution: when running `npx aiox-core install`,
  * require() resolves from the npx temp directory, not process.cwd(). After
- * bootstrap installs @aiox-fullstack/pro in the user's project, only an
- * absolute path to process.cwd()/node_modules/@aiox-fullstack/pro/... works.
+ * bootstrap installs @aiox-squads/pro in the user's project, only an
+ * absolute path to process.cwd()/node_modules/@aiox-squads/pro/... works.
  *
  * @param {string} moduleName - Module filename without extension (e.g., 'license-api')
  * @returns {Object|null} Loaded module or null
@@ -387,8 +387,8 @@ function loadProModule(moduleName) {
     return frameworkModule;
   }
 
-  // 2. npm packages — try canonical then fallback
-  const npmScopes = ['@aiox-fullstack/pro', '@aios-fullstack/pro'];
+  // 2. npm packages — try canonical then fallbacks
+  const npmScopes = ['@aiox-squads/pro', '@aiox-fullstack/pro', '@aios-fullstack/pro'];
   for (const scope of npmScopes) {
     const requestPath = `${scope}/license/${moduleName}`;
     const loadedModule = tryRequire(requestPath);
@@ -406,7 +406,7 @@ function loadProModule(moduleName) {
 
   // 4. npm package in user project via absolute path (npx context — require resolves from
   //    temp dir, so we need absolute path to where bootstrap installed the package)
-  const absScopeDirs = ['@aiox-fullstack', '@aios-fullstack'];
+  const absScopeDirs = ['@aiox-squads', '@aiox-fullstack', '@aios-fullstack'];
   for (const scopeDir of absScopeDirs) {
     const absPath = path.join(process.cwd(), 'node_modules', scopeDir, 'pro', 'license', moduleName);
     const loadedModule = tryRequire(absPath);
@@ -492,7 +492,7 @@ function generateMachineId() {
 /**
  * Get a license API client instance.
  *
- * Prefers the full LicenseApiClient from @aiox-fullstack/pro when available.
+ * Prefers the full LicenseApiClient from @aiox-squads/pro when available.
  * Falls back to InlineLicenseClient (native https) for pre-bootstrap scenarios.
  *
  * @returns {Object} Client instance with isOnline, checkEmail, login, signup, activateByAuth
@@ -508,7 +508,7 @@ function getLicenseClient() {
     return new LicenseApiClient();
   }
 
-  // Fallback: use inline client for pre-bootstrap (no @aiox-fullstack/pro yet)
+  // Fallback: use inline client for pre-bootstrap (no @aiox-squads/pro yet)
   return new InlineLicenseClient();
 }
 
@@ -623,7 +623,7 @@ async function ensureKeyValidationParity(client, activationResult, machineId, ai
  * Priority:
  * 1. Bundled pro/ content in the aiox-core checkout or package
  * 2. Auto-initialize the git submodule when running from a source checkout
- * 3. Installed @aiox-fullstack/pro package in the target project
+ * 3. Installed @aiox-squads/pro package in the target project
  *
  * @param {string} targetDir - Project root directory
  * @returns {{proSourceDir: string|null, bootstrapError?: string}} Resolution result
@@ -635,7 +635,11 @@ function resolveProSourceDir(targetDir) {
 
   const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
   const bundledProDir = path.join(repoRoot, 'pro');
-  const npmProDir = path.join(targetDir, 'node_modules', '@aiox-fullstack', 'pro');
+  const npmProDirs = [
+    path.join(targetDir, 'node_modules', '@aiox-squads', 'pro'),
+    path.join(targetDir, 'node_modules', '@aiox-fullstack', 'pro'),
+    path.join(targetDir, 'node_modules', '@aios-fullstack', 'pro'),
+  ];
   const bundledSquadsDir = path.join(bundledProDir, 'squads');
   const gitmodulesPath = path.join(repoRoot, '.gitmodules');
 
@@ -661,8 +665,10 @@ function resolveProSourceDir(targetDir) {
     }
   }
 
-  if (fs.existsSync(npmProDir)) {
-    return { proSourceDir: npmProDir };
+  for (const npmProDir of npmProDirs) {
+    if (fs.existsSync(npmProDir)) {
+      return { proSourceDir: npmProDir };
+    }
   }
 
   return { proSourceDir: null };
@@ -1674,7 +1680,7 @@ async function runProWizard(options = {}) {
     showProHeader();
   }
 
-  // Step 1: License Gate (uses InlineLicenseClient if @aiox-fullstack/pro not yet installed)
+  // Step 1: License Gate (uses InlineLicenseClient if @aiox-squads/pro not yet installed)
   const licenseResult = await stepLicenseGate({
     key: options.key || process.env.AIOX_PRO_KEY,
     email: options.email || process.env.AIOX_PRO_EMAIL,

--- a/packages/installer/tests/unit/doctor/doctor-checks.test.js
+++ b/packages/installer/tests/unit/doctor/doctor-checks.test.js
@@ -364,12 +364,15 @@ describe('code-intel check', () => {
 });
 
 describe('ide-sync check', () => {
+  const portablePath = (targetPath) => String(targetPath).replace(/\\/g, '/');
+
   it('should PASS when counts match', async () => {
     fs.existsSync.mockReturnValue(true);
     fs.readdirSync.mockImplementation((p) => {
-      if (p.includes('.claude/skills')) return [dirEntry('dev'), dirEntry('qa')];
-      if (p.includes('.claude/commands')) return ['dev.md', 'qa.md'];
-      if (p.includes('development/agents')) return ['dev.md', 'qa.md'];
+      const normalizedPath = portablePath(p);
+      if (normalizedPath.includes('.claude/skills')) return [dirEntry('dev'), dirEntry('qa')];
+      if (normalizedPath.includes('.claude/commands')) return ['dev.md', 'qa.md'];
+      if (normalizedPath.includes('development/agents')) return ['dev.md', 'qa.md'];
       return [];
     });
 
@@ -380,9 +383,10 @@ describe('ide-sync check', () => {
   it('should WARN when counts mismatch', async () => {
     fs.existsSync.mockReturnValue(true);
     fs.readdirSync.mockImplementation((p) => {
-      if (p.includes('.claude/skills')) return [dirEntry('dev'), dirEntry('qa')];
-      if (p.includes('commands')) return ['dev.md', 'qa.md', 'pm.md'];
-      if (p.includes('development/agents')) return ['dev.md', 'qa.md'];
+      const normalizedPath = portablePath(p);
+      if (normalizedPath.includes('.claude/skills')) return [dirEntry('dev'), dirEntry('qa')];
+      if (normalizedPath.includes('commands')) return ['dev.md', 'qa.md', 'pm.md'];
+      if (normalizedPath.includes('development/agents')) return ['dev.md', 'qa.md'];
       return [];
     });
 
@@ -393,9 +397,10 @@ describe('ide-sync check', () => {
   it('should WARN when counts match but agent identities mismatch', async () => {
     fs.existsSync.mockReturnValue(true);
     fs.readdirSync.mockImplementation((p) => {
-      if (p.includes('.claude/skills')) return [dirEntry('dev'), dirEntry('pm')];
-      if (p.includes('.claude/commands')) return ['dev.md', 'qa.md'];
-      if (p.includes('development/agents')) return ['dev.md', 'qa.md'];
+      const normalizedPath = portablePath(p);
+      if (normalizedPath.includes('.claude/skills')) return [dirEntry('dev'), dirEntry('pm')];
+      if (normalizedPath.includes('.claude/commands')) return ['dev.md', 'qa.md'];
+      if (normalizedPath.includes('development/agents')) return ['dev.md', 'qa.md'];
       return [];
     });
 
@@ -408,7 +413,8 @@ describe('ide-sync check', () => {
   it('should FAIL when Claude directories cannot be read', async () => {
     fs.existsSync.mockReturnValue(true);
     fs.readdirSync.mockImplementation((p) => {
-      if (p.includes('development/agents')) return ['dev.md', 'qa.md'];
+      const normalizedPath = portablePath(p);
+      if (normalizedPath.includes('development/agents')) return ['dev.md', 'qa.md'];
       throw new Error('permission denied');
     });
 

--- a/tests/installer/pro-scaffolder.test.js
+++ b/tests/installer/pro-scaffolder.test.js
@@ -49,7 +49,7 @@ beforeEach(async () => {
   );
   await fs.writeJson(
     path.join(proSourceDir, 'package.json'),
-    { name: '@aiox-fullstack/pro', version: '2.0.0' },
+    { name: '@aiox-squads/pro', version: '2.0.0' },
   );
 });
 

--- a/tests/pro/pro-detector.test.js
+++ b/tests/pro/pro-detector.test.js
@@ -22,6 +22,8 @@ const {
   resolveNpmProPackage,
   PRO_PACKAGE_CANONICAL,
   PRO_PACKAGE_FALLBACK,
+  PRO_PACKAGE_LEGACY,
+  PRO_PACKAGES,
   _PRO_DIR,
   _PRO_PACKAGE_PATH,
 } = require('../../bin/utils/pro-detector');
@@ -71,7 +73,7 @@ describe('pro-detector', () => {
 
     it('should return true when npm package exists (canonical or fallback)', () => {
       const tmpDir = realFs.mkdtempSync(path.join(os.tmpdir(), 'aiox-pro-detector-'));
-      const canonicalDir = path.join(tmpDir, 'node_modules', '@aiox-fullstack', 'pro');
+      const canonicalDir = path.join(tmpDir, 'node_modules', '@aiox-squads', 'pro');
       realFs.mkdirSync(canonicalDir, { recursive: true });
       realFs.writeFileSync(
         path.join(canonicalDir, 'package.json'),
@@ -104,14 +106,20 @@ describe('pro-detector', () => {
 
   describe('resolveNpmProPackage()', () => {
     it('should export canonical and fallback package names', () => {
-      expect(PRO_PACKAGE_CANONICAL).toBe('@aiox-fullstack/pro');
-      expect(PRO_PACKAGE_FALLBACK).toBe('@aios-fullstack/pro');
+      expect(PRO_PACKAGE_CANONICAL).toBe('@aiox-squads/pro');
+      expect(PRO_PACKAGE_FALLBACK).toBe('@aiox-fullstack/pro');
+      expect(PRO_PACKAGE_LEGACY).toBe('@aios-fullstack/pro');
+      expect(PRO_PACKAGES).toEqual([
+        '@aiox-squads/pro',
+        '@aiox-fullstack/pro',
+        '@aios-fullstack/pro',
+      ]);
     });
 
     it('should prefer the canonical package when both scopes resolve', () => {
       const tmpDir = realFs.mkdtempSync(path.join(os.tmpdir(), 'aiox-pro-detector-'));
-      const canonicalDir = path.join(tmpDir, 'node_modules', '@aiox-fullstack', 'pro');
-      const fallbackDir = path.join(tmpDir, 'node_modules', '@aios-fullstack', 'pro');
+      const canonicalDir = path.join(tmpDir, 'node_modules', '@aiox-squads', 'pro');
+      const fallbackDir = path.join(tmpDir, 'node_modules', '@aiox-fullstack', 'pro');
       realFs.mkdirSync(canonicalDir, { recursive: true });
       realFs.mkdirSync(fallbackDir, { recursive: true });
       realFs.writeFileSync(
@@ -137,7 +145,7 @@ describe('pro-detector', () => {
 
     it('should fall back when the canonical package cannot be resolved', () => {
       const tmpDir = realFs.mkdtempSync(path.join(os.tmpdir(), 'aiox-pro-detector-'));
-      const fallbackDir = path.join(tmpDir, 'node_modules', '@aios-fullstack', 'pro');
+      const fallbackDir = path.join(tmpDir, 'node_modules', '@aiox-fullstack', 'pro');
       realFs.mkdirSync(fallbackDir, { recursive: true });
       realFs.writeFileSync(
         path.join(fallbackDir, 'package.json'),
@@ -149,6 +157,27 @@ describe('pro-detector', () => {
         expect(resolveNpmProPackage()).toEqual({
           packagePath: realFs.realpathSync(fallbackDir),
           packageName: PRO_PACKAGE_FALLBACK,
+        });
+      } finally {
+        process.chdir(originalCwd);
+        realFs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('should fall back to the original AIOS package when newer scopes are unavailable', () => {
+      const tmpDir = realFs.mkdtempSync(path.join(os.tmpdir(), 'aiox-pro-detector-'));
+      const legacyDir = path.join(tmpDir, 'node_modules', '@aios-fullstack', 'pro');
+      realFs.mkdirSync(legacyDir, { recursive: true });
+      realFs.writeFileSync(
+        path.join(legacyDir, 'package.json'),
+        JSON.stringify({ name: PRO_PACKAGE_LEGACY, version: '0.3.0' }),
+      );
+      process.chdir(tmpDir);
+
+      try {
+        expect(resolveNpmProPackage()).toEqual({
+          packagePath: realFs.realpathSync(legacyDir),
+          packageName: PRO_PACKAGE_LEGACY,
         });
       } finally {
         process.chdir(originalCwd);

--- a/tests/pro/pro-updater.test.js
+++ b/tests/pro/pro-updater.test.js
@@ -42,6 +42,25 @@ function mockRegistryResponse(payload, statusCode = 200) {
   });
 }
 
+const PRO_PACKAGE_CANONICAL = '@aiox-squads/pro';
+
+function samePath(actual, expected) {
+  return path.normalize(String(actual)) === path.normalize(String(expected));
+}
+
+function portablePath(actual) {
+  return String(actual).replace(/\\/g, '/');
+}
+
+function isInstalledProPackageJson(actual) {
+  const [, packagePath] = PRO_PACKAGE_CANONICAL.split('@');
+  return portablePath(actual).endsWith(`/node_modules/@${packagePath}/package.json`);
+}
+
+function projectFile(projectRoot, ...segments) {
+  return path.join(path.resolve(projectRoot), ...segments);
+}
+
 describe('pro-updater', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -50,11 +69,11 @@ describe('pro-updater', () => {
   describe('getCoreVersion()', () => {
     it('should prefer .aiox-core/version.json when available', () => {
       const projectRoot = '/tmp/aiox-project';
-      const versionJsonPath = path.join(projectRoot, '.aiox-core', 'version.json');
+      const versionJsonPath = projectFile(projectRoot, '.aiox-core', 'version.json');
 
-      fs.existsSync.mockImplementation((targetPath) => targetPath === versionJsonPath);
+      fs.existsSync.mockImplementation((targetPath) => samePath(targetPath, versionJsonPath));
       fs.readFileSync.mockImplementation((targetPath) => {
-        if (targetPath === versionJsonPath) {
+        if (samePath(targetPath, versionJsonPath)) {
           return JSON.stringify({ version: '5.1.2' });
         }
         throw new Error(`Unexpected read: ${targetPath}`);
@@ -65,11 +84,11 @@ describe('pro-updater', () => {
 
     it('should read declared aiox-core dependency from the project manifest', () => {
       const projectRoot = '/tmp/aiox-project';
-      const packageJsonPath = path.join(projectRoot, 'package.json');
+      const packageJsonPath = projectFile(projectRoot, 'package.json');
 
-      fs.existsSync.mockImplementation((targetPath) => targetPath === packageJsonPath);
+      fs.existsSync.mockImplementation((targetPath) => samePath(targetPath, packageJsonPath));
       fs.readFileSync.mockImplementation((targetPath) => {
-        if (targetPath === packageJsonPath) {
+        if (samePath(targetPath, packageJsonPath)) {
           return JSON.stringify({
             name: 'my-app',
             dependencies: {
@@ -85,11 +104,11 @@ describe('pro-updater', () => {
 
     it('should read declared scoped aiox-core dependency from the project manifest', () => {
       const projectRoot = '/tmp/aiox-project';
-      const packageJsonPath = path.join(projectRoot, 'package.json');
+      const packageJsonPath = projectFile(projectRoot, 'package.json');
 
-      fs.existsSync.mockImplementation((targetPath) => targetPath === packageJsonPath);
+      fs.existsSync.mockImplementation((targetPath) => samePath(targetPath, packageJsonPath));
       fs.readFileSync.mockImplementation((targetPath) => {
-        if (targetPath === packageJsonPath) {
+        if (samePath(targetPath, packageJsonPath)) {
           return JSON.stringify({
             name: 'my-app',
             devDependencies: {
@@ -107,11 +126,11 @@ describe('pro-updater', () => {
   describe('detectCorePackageName()', () => {
     it('should detect the scoped core package from project dependencies', () => {
       const projectRoot = '/tmp/aiox-project';
-      const packageJsonPath = path.join(projectRoot, 'package.json');
+      const packageJsonPath = projectFile(projectRoot, 'package.json');
 
-      fs.existsSync.mockImplementation((targetPath) => targetPath === packageJsonPath);
+      fs.existsSync.mockImplementation((targetPath) => samePath(targetPath, packageJsonPath));
       fs.readFileSync.mockImplementation((targetPath) => {
-        if (targetPath === packageJsonPath) {
+        if (samePath(targetPath, packageJsonPath)) {
           return JSON.stringify({
             name: 'workspace-app',
             dependencies: {
@@ -139,7 +158,7 @@ describe('pro-updater', () => {
     it('should return null when the registry responds with a non-2xx status', async () => {
       mockRegistryResponse({ error: 'not found' }, 404);
 
-      await expect(fetchLatestFromNpm('@aiox-fullstack/pro')).resolves.toBeNull();
+      await expect(fetchLatestFromNpm(PRO_PACKAGE_CANONICAL)).resolves.toBeNull();
     });
   });
 
@@ -159,19 +178,18 @@ describe('pro-updater', () => {
 
     it('should use the detected scoped core package when includeCoreUpdate is requested in dry-run mode', async () => {
       const projectRoot = '/tmp/aiox-project';
-      const installedPackageJson = path.join(projectRoot, 'node_modules', '@aiox-fullstack', 'pro', 'package.json');
-      const packageJsonPath = path.join(projectRoot, 'package.json');
+      const packageJsonPath = projectFile(projectRoot, 'package.json');
 
       fs.statSync.mockReturnValue({ isDirectory: () => true });
       fs.existsSync.mockImplementation((targetPath) => (
-        targetPath === installedPackageJson
-        || targetPath === packageJsonPath
+        isInstalledProPackageJson(targetPath)
+        || samePath(targetPath, packageJsonPath)
       ));
       fs.readFileSync.mockImplementation((targetPath) => {
-        if (targetPath === installedPackageJson) {
+        if (isInstalledProPackageJson(targetPath)) {
           return JSON.stringify({ version: '0.3.0' });
         }
-        if (targetPath === packageJsonPath) {
+        if (samePath(targetPath, packageJsonPath)) {
           return JSON.stringify({
             name: 'workspace-app',
             dependencies: {
@@ -203,19 +221,18 @@ describe('pro-updater', () => {
 
     it('should honor scoped aiox-core peer dependencies when checking compatibility', async () => {
       const projectRoot = '/tmp/aiox-project';
-      const installedPackageJson = path.join(projectRoot, 'node_modules', '@aiox-fullstack', 'pro', 'package.json');
-      const versionJsonPath = path.join(projectRoot, '.aiox-core', 'version.json');
+      const versionJsonPath = projectFile(projectRoot, '.aiox-core', 'version.json');
 
       fs.statSync.mockReturnValue({ isDirectory: () => true });
       fs.existsSync.mockImplementation((targetPath) => (
-        targetPath === installedPackageJson
-        || targetPath === versionJsonPath
+        isInstalledProPackageJson(targetPath)
+        || samePath(targetPath, versionJsonPath)
       ));
       fs.readFileSync.mockImplementation((targetPath) => {
-        if (targetPath === installedPackageJson) {
+        if (isInstalledProPackageJson(targetPath)) {
           return JSON.stringify({ version: '0.3.0' });
         }
-        if (targetPath === versionJsonPath) {
+        if (samePath(targetPath, versionJsonPath)) {
           return JSON.stringify({ version: '5.0.4' });
         }
         throw new Error(`Unexpected read: ${targetPath}`);
@@ -244,20 +261,19 @@ describe('pro-updater', () => {
 
     it('should fail when the package update succeeds but re-scaffolding fails', async () => {
       const projectRoot = '/tmp/aiox-project';
-      const installedPackageJson = path.join(projectRoot, 'node_modules', '@aiox-fullstack', 'pro', 'package.json');
-      const versionJsonPath = path.join(projectRoot, '.aiox-core', 'version.json');
+      const versionJsonPath = projectFile(projectRoot, '.aiox-core', 'version.json');
       const scaffolderPath = 'aiox-core/installer/pro-scaffolder';
 
       fs.statSync.mockReturnValue({ isDirectory: () => true });
       fs.existsSync.mockImplementation((targetPath) => (
-        targetPath === installedPackageJson
-        || targetPath === versionJsonPath
+        isInstalledProPackageJson(targetPath)
+        || samePath(targetPath, versionJsonPath)
       ));
       fs.readFileSync.mockImplementation((targetPath) => {
-        if (targetPath === installedPackageJson) {
+        if (isInstalledProPackageJson(targetPath)) {
           return JSON.stringify({ version: '0.3.0' });
         }
-        if (targetPath === versionJsonPath) {
+        if (samePath(targetPath, versionJsonPath)) {
           return JSON.stringify({ version: '5.0.4' });
         }
         throw new Error(`Unexpected read: ${targetPath}`);

--- a/tests/unit/wizard/validation/dependency-validator.test.js
+++ b/tests/unit/wizard/validation/dependency-validator.test.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const fs = require('fs');
+const path = require('path');
 const childProcess = require('child_process');
 const { validateDependencies } = require('../../../../packages/installer/src/wizard/validation/validators/dependency-validator');
 
@@ -18,6 +19,14 @@ function mockExecSuccess(payload) {
   });
 }
 
+function samePath(actual, expected) {
+  return path.normalize(String(actual)) === path.normalize(String(expected));
+}
+
+function projectFile(projectPath, ...segments) {
+  return path.join(projectPath, ...segments);
+}
+
 describe('Dependency Validator', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -28,9 +37,9 @@ describe('Dependency Validator', () => {
     const projectPath = '/tmp/aiox-project';
 
     fs.existsSync.mockImplementation((targetPath) => (
-      targetPath === `${projectPath}/package.json`
-      || targetPath === `${projectPath}/node_modules`
-      || targetPath === `${projectPath}/node_modules/react`
+      samePath(targetPath, projectFile(projectPath, 'package.json'))
+      || samePath(targetPath, projectFile(projectPath, 'node_modules'))
+      || samePath(targetPath, projectFile(projectPath, 'node_modules', 'react'))
     ));
     fs.readFileSync.mockReturnValue(JSON.stringify({
       name: 'demo-app',
@@ -76,9 +85,9 @@ describe('Dependency Validator', () => {
     const projectPath = '/tmp/aiox-project';
 
     fs.existsSync.mockImplementation((targetPath) => (
-      targetPath === `${projectPath}/package.json`
-      || targetPath === `${projectPath}/node_modules`
-      || targetPath === `${projectPath}/node_modules/react`
+      samePath(targetPath, projectFile(projectPath, 'package.json'))
+      || samePath(targetPath, projectFile(projectPath, 'node_modules'))
+      || samePath(targetPath, projectFile(projectPath, 'node_modules', 'react'))
     ));
     fs.readFileSync.mockReturnValue(JSON.stringify({
       name: 'demo-app',
@@ -137,7 +146,7 @@ describe('Dependency Validator', () => {
   it('fails when package.json declares dependencies but node_modules is missing', async () => {
     const projectPath = '/tmp/aiox-broken';
 
-    fs.existsSync.mockImplementation((targetPath) => targetPath === `${projectPath}/package.json`);
+    fs.existsSync.mockImplementation((targetPath) => samePath(targetPath, projectFile(projectPath, 'package.json')));
     fs.readFileSync.mockReturnValue(JSON.stringify({
       name: 'demo-app',
       dependencies: {


### PR DESCRIPTION
## Summary
- Make `@aiox-squads/pro` the canonical Pro npm package across core runtime detection, Pro CLI setup, buyer flow, installer wizard, scaffolder, and updater paths.
- Keep `@aiox-fullstack/pro` and `@aios-fullstack/pro` as legacy fallbacks to avoid breaking existing installs.
- Update the `pro` submodule pointer to the already-merged Pro release work at `50271df` (`@aiox-squads/pro@0.4.0`) instead of duplicating that implementation in core.
- Refresh generated publish metadata (`install-manifest`, `entity-registry`).

## Validation
- `npm test -- packages/installer/tests/unit/doctor/doctor-checks.test.js tests/unit/wizard/validation/dependency-validator.test.js tests/pro/pro-updater.test.js tests/pro/pro-detector.test.js tests/installer/pro-scaffolder.test.js --runInBand --no-cache`
- `npm test -- --runInBand --no-cache` passed: 310 suites passed, 7,798 tests passed, 11 suites/149 tests skipped; Jest stayed open on the existing open-handle warning after printing the green summary.
- `npm run lint`
- `npm run typecheck`
- `npm run validate:publish`
- `npm run validate:codex-sync && npm run validate:codex-integration`
- `npm run sync:ide:check`
- `npm run validate:claude-sync && npm run validate:claude-integration`
- `npm run validate:gemini-sync && npm run validate:antigravity-sync`
- `npm pack --dry-run` in core: `aiox-core@5.0.8`, 4,153 files, 12.0 MB package.
- `npm pack --dry-run` in `pro/`: `@aiox-squads/pro@0.4.0`, 2,207 files, 6.7 MB package.
- `git diff --check HEAD~1..HEAD`

## Publish Status
- Registry currently has `aiox-core@5.0.7`.
- `@aiox-squads/pro` is not visible on npm yet (`E404`).
- Local npm auth is currently blocked: `npm whoami` returns `E401 Unauthorized`, so actual `npm publish` must wait for npm authentication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Pro module detection with expanded package scope support for improved installation and verification reliability.
  * Installer wizard now supports additional package resolution paths for Pro module loading.

* **Tests**
  * Added test coverage for enhanced package detection and multi-scope resolution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->