### PR TITLE
fix: stabilize npm publish test gate

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -59,7 +59,7 @@ jobs:
         run: npm ci
 
       - name: Run tests
-        run: npm test
+        run: npm run test:ci
 
       - name: Run security audit
         # Note: Using critical level because high vulns are in dev deps (semantic-release, mocha)

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "scripts": {
     "format": "prettier --write \"**/*.md\"",
     "test": "jest",
+    "test:ci": "jest --runInBand --forceExit",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:e2e:installed-skills": "node scripts/e2e/installed-skills-smoke.js",


### PR DESCRIPTION
## Summary
- add a deterministic `test:ci` script that runs Jest serially for CI/release gates
- update the NPM publish workflow to use `npm run test:ci` before publishing

## Validation
- `npm run test:ci` — 310 passed, 11 skipped, 0 failed
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run validate:publish`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/testing infrastructure to use a specialized test configuration for continuous integration environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->