### PR TITLE
fix: harden npm publish visibility and installer runtime

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -209,6 +209,7 @@ jobs:
           npm publish --tag ${{ steps.publish-tag.outputs.tag }} --access public
 
           PKG_NAME=$(node -p "require('./package.json').name")
+          npm access set status=public "${PKG_NAME}" --registry="${NPM_REGISTRY}"
           echo "✅ Published ${PKG_NAME}@${{ needs.build.outputs.version }} with tag ${{ steps.publish-tag.outputs.tag }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_AIOX_SQUADS }}
@@ -240,13 +241,13 @@ jobs:
         include:
           - key: aiox-install
             path: packages/aiox-install
-            smoke: npx --yes @aiox-squads/aiox-install --version
+            smoke_args: --version
           - key: aiox-pro-cli
             path: packages/aiox-pro-cli
-            smoke: npx --yes @aiox-squads/aiox-pro-cli --help
+            smoke_args: --help
           - key: installer
             path: packages/installer
-            smoke: npx --yes @aiox-squads/installer --help
+            smoke_args: --help
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -323,6 +324,7 @@ jobs:
         run: |
           echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN_AIOX_SQUADS }}" > .npmrc
           npm publish --tag ${{ steps.publish-tag.outputs.tag }} --access public
+          npm access set status=public "${{ steps.pkg.outputs.name }}" --registry="${NPM_REGISTRY}"
           echo "✅ Published ${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_AIOX_SQUADS }}
@@ -330,14 +332,20 @@ jobs:
       - name: Smoke test - verify npx works
         if: steps.should-publish.outputs.should_publish == 'true'
         env:
-          SMOKE_COMMAND: ${{ matrix.smoke }}
+          PKG_SPEC: ${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }}
+          SMOKE_ARGS: ${{ matrix.smoke_args }}
         run: |
           # Wait for npm registry propagation
           for i in 1 2 3 4 5 6; do
             sleep 15
-            if $SMOKE_COMMAND >/dev/null 2>&1; then
-              echo "✅ Smoke test passed: ${SMOKE_COMMAND} works"
-              exit 0
+            if npm view "${PKG_SPEC}" version > /dev/null 2>&1; then
+              SMOKE_DIR=$(mktemp -d)
+              if (cd "${SMOKE_DIR}" && npx --yes "${PKG_SPEC}" ${SMOKE_ARGS} >/dev/null 2>&1); then
+                rm -rf "${SMOKE_DIR}"
+                echo "✅ Smoke test passed: npx --yes ${PKG_SPEC} ${SMOKE_ARGS} works"
+                exit 0
+              fi
+              rm -rf "${SMOKE_DIR}"
             fi
             echo "⏳ Waiting for npm propagation... (attempt $i/6)"
           done

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,6 +121,50 @@
       "resolved": "packages/aiox-pro-cli",
       "link": true
     },
+    "node_modules/@aiox-squads/core": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@aiox-squads/core/-/core-5.1.0.tgz",
+      "integrity": "sha512-2Ha5NUnsHjIgEPGO9tgftk0xYqArQwgENlSFyPWSVDahiOgVpo472QJ58f8gxstvOqzpiRUxBX3kGgkRFCAkaQ==",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
+      "dependencies": {
+        "@clack/prompts": "^0.11.0",
+        "@kayvan/markdown-tree-parser": "^1.5.0",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "ansi-to-html": "^0.7.2",
+        "asciichart": "^1.5.25",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.5.3",
+        "cli-progress": "^3.12.0",
+        "commander": "^12.1.0",
+        "execa": "^5.1.1",
+        "fast-glob": "^3.3.3",
+        "fs-extra": "^11.3.2",
+        "glob": "^10.4.4",
+        "handlebars": "^4.7.8",
+        "inquirer": "^8.2.6",
+        "js-yaml": "^4.1.0",
+        "node-machine-id": "^1.1.12",
+        "ora": "^5.4.1",
+        "picocolors": "^1.1.1",
+        "proper-lockfile": "^4.1.2",
+        "semver": "^7.7.2",
+        "validator": "^13.15.15"
+      },
+      "bin": {
+        "aiox": "bin/aiox.js",
+        "aiox-core": "bin/aiox.js",
+        "aiox-graph": "bin/aiox-graph.js",
+        "aiox-minimal": "bin/aiox-minimal.js"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
+      }
+    },
     "node_modules/@aiox-squads/installer": {
       "resolved": "packages/installer",
       "link": true
@@ -14507,12 +14551,18 @@
     },
     "packages/installer": {
       "name": "@aiox-squads/installer",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "MIT",
       "dependencies": {
+        "@aiox-squads/core": "^5.1.0",
         "@clack/prompts": "^0.11.0",
         "chalk": "^4.1.2",
-        "fs-extra": "^11.3.2"
+        "cli-progress": "^3.12.0",
+        "fs-extra": "^11.3.2",
+        "inquirer": "^8.2.6",
+        "js-yaml": "^4.1.0",
+        "ora": "^5.4.1",
+        "semver": "^7.7.2"
       },
       "bin": {
         "aiox-installer": "src/index.js"

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/installer",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "AIOX Installer - Automated setup wizard for AIOX projects (greenfield & brownfield)",
   "main": "src/index.js",
   "bin": {
@@ -34,9 +34,15 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
+    "@aiox-squads/core": "^5.1.0",
     "@clack/prompts": "^0.11.0",
     "chalk": "^4.1.2",
-    "fs-extra": "^11.3.2"
+    "cli-progress": "^3.12.0",
+    "fs-extra": "^11.3.2",
+    "inquirer": "^8.2.6",
+    "js-yaml": "^4.1.0",
+    "ora": "^5.4.1",
+    "semver": "^7.7.2"
   },
   "devDependencies": {
     "jest": "^30.2.0"

--- a/packages/installer/src/config/templates/env-template.js
+++ b/packages/installer/src/config/templates/env-template.js
@@ -7,8 +7,7 @@
  * @module env-template
  */
 
-const path = require('path');
-const fs = require('fs');
+const { getAioxCoreVersion } = require('../../utils/package-paths');
 
 /**
  * Get the current AIOX version from package.json
@@ -16,12 +15,7 @@ const fs = require('fs');
  */
 function getAioxVersion() {
   try {
-    // Try to find the root package.json
-    const rootPkgPath = path.resolve(__dirname, '../../../../package.json');
-    if (fs.existsSync(rootPkgPath)) {
-      const pkg = JSON.parse(fs.readFileSync(rootPkgPath, 'utf8'));
-      return pkg.version || '2.2.0';
-    }
+    return getAioxCoreVersion() || '2.2.0';
   } catch {
     // Ignore errors
   }

--- a/packages/installer/src/index.js
+++ b/packages/installer/src/index.js
@@ -1,16 +1,30 @@
 #!/usr/bin/env node
 'use strict';
 
-const { runWizard } = require('./wizard');
+const pkg = require('../package.json');
+
+function printHelp() {
+  console.log('Usage: aiox-installer [--help] [--version]');
+  console.log('');
+  console.log('Runs the AIOX interactive installer wizard.');
+}
+
+function loadWizard() {
+  return require('./wizard');
+}
 
 async function main() {
   if (process.argv.includes('--help') || process.argv.includes('-h')) {
-    console.log('Usage: aiox-installer [--help]');
-    console.log('');
-    console.log('Runs the AIOX interactive installer wizard.');
+    printHelp();
     return;
   }
 
+  if (process.argv.includes('--version') || process.argv.includes('-v')) {
+    console.log(pkg.version);
+    return;
+  }
+
+  const { runWizard } = loadWizard();
   await runWizard();
 }
 
@@ -22,7 +36,13 @@ if (require.main === module) {
 }
 
 module.exports = {
-  runWizard,
-  proSetup: require('./wizard/pro-setup'),
-  proScaffolder: require('./pro/pro-scaffolder'),
+  get runWizard() {
+    return loadWizard().runWizard;
+  },
+  get proSetup() {
+    return require('./wizard/pro-setup');
+  },
+  get proScaffolder() {
+    return require('./pro/pro-scaffolder');
+  },
 };

--- a/packages/installer/src/installer/aiox-core-installer.js
+++ b/packages/installer/src/installer/aiox-core-installer.js
@@ -13,14 +13,14 @@ const path = require('path');
 const ora = require('ora');
 const { hashFile } = require('./file-hasher');
 const { loadSourceManifest, updateInstalledManifest } = require('./brownfield-upgrader');
+const { getAioxCoreVersion, resolveAioxCorePath } = require('../utils/package-paths');
 
 /**
  * Get the path to the source .aiox-core directory in the package
  * @returns {string} Absolute path to .aiox-core source
  */
 function getAioxCoreSourcePath() {
-  // Navigate from packages/installer/src/installer/ to project root/.aiox-core
-  return path.join(__dirname, '..', '..', '..', '..', '.aiox-core');
+  return resolveAioxCorePath('.aiox-core');
 }
 
 /**
@@ -384,7 +384,7 @@ async function installAioxCore(options = {}) {
 
     const sourceManifest = loadSourceManifest(sourceDir);
     const manifestFileHashes = extractManifestFileHashes(sourceManifest);
-    const packageVersion = providedPackageVersion || require('../../../../package.json').version;
+    const packageVersion = providedPackageVersion || getAioxCoreVersion();
 
     spinner.text = 'Copying installation manifest...';
     await copyManifestArtifacts(sourceDir, targetAioxCore);

--- a/packages/installer/src/utils/package-paths.js
+++ b/packages/installer/src/utils/package-paths.js
@@ -1,0 +1,71 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function isCorePackageRoot(candidate) {
+  if (!candidate) return false;
+
+  try {
+    const packageJsonPath = path.join(candidate, 'package.json');
+    const aioxCorePath = path.join(candidate, '.aiox-core');
+
+    if (!fs.existsSync(packageJsonPath) || !fs.existsSync(aioxCorePath)) {
+      return false;
+    }
+
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    return packageJson.name === '@aiox-squads/core';
+  } catch {
+    return false;
+  }
+}
+
+function resolvePackageJsonRoot(packageName) {
+  try {
+    return path.dirname(require.resolve(`${packageName}/package.json`));
+  } catch {
+    return null;
+  }
+}
+
+function getLocalRepoRoot() {
+  return path.resolve(__dirname, '..', '..', '..', '..');
+}
+
+function getAioxCorePackageRoot() {
+  const candidates = [
+    process.env.AIOX_CORE_PACKAGE_ROOT,
+    getLocalRepoRoot(),
+    resolvePackageJsonRoot('@aiox-squads/core'),
+  ];
+
+  const packageRoot = candidates.find(isCorePackageRoot);
+  if (!packageRoot) {
+    throw new Error(
+      'AIOX core package root not found. Install @aiox-squads/core or set AIOX_CORE_PACKAGE_ROOT.',
+    );
+  }
+
+  return packageRoot;
+}
+
+function resolveAioxCorePath(...segments) {
+  return path.join(getAioxCorePackageRoot(), ...segments);
+}
+
+function requireAioxCoreModule(...segments) {
+  return require(resolveAioxCorePath(...segments));
+}
+
+function getAioxCoreVersion() {
+  const packageJson = require(resolveAioxCorePath('package.json'));
+  return packageJson.version;
+}
+
+module.exports = {
+  getAioxCorePackageRoot,
+  resolveAioxCorePath,
+  requireAioxCoreModule,
+  getAioxCoreVersion,
+};

--- a/packages/installer/src/wizard/feedback.js
+++ b/packages/installer/src/wizard/feedback.js
@@ -9,6 +9,7 @@
 const ora = require('ora');
 const cliProgress = require('cli-progress');
 const { colors, status, headings } = require('../utils/aiox-colors');
+const { getAioxCoreVersion } = require('../utils/package-paths');
 const { t } = require('./i18n');
 
 /**
@@ -134,14 +135,9 @@ const BANNER = `
  * Show welcome banner
  */
 function showWelcome() {
-  // Get version from package.json
-  const path = require('path');
-  const fs = require('fs');
   let version = '2.1.0';
   try {
-    const pkgPath = path.join(__dirname, '..', '..', '..', '..', 'package.json');
-    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-    version = pkg.version || version;
+    version = getAioxCoreVersion() || version;
   } catch (_e) {
     // Use default version
   }

--- a/packages/installer/src/wizard/ide-config-generator.js
+++ b/packages/installer/src/wizard/ide-config-generator.js
@@ -16,7 +16,11 @@ const { spawnSync } = require('child_process');
 const { getIDEConfig } = require('../config/ide-configs');
 const { validateProjectName } = require('./validators');
 const { getMergeStrategy, hasMergeStrategy } = require('../merger/index.js');
-const { syncSkills } = require('../../../../.aiox-core/infrastructure/scripts/codex-skills-sync/index');
+const { requireAioxCoreModule, resolveAioxCorePath } = require('../utils/package-paths');
+
+function loadCodexSkillsSync() {
+  return requireAioxCoreModule('.aiox-core', 'infrastructure', 'scripts', 'codex-skills-sync', 'index');
+}
 
 /**
  * Render template with variables
@@ -220,7 +224,7 @@ function generateTemplateVariables(wizardState) {
  */
 async function copyAgentFiles(projectRoot, agentFolder, ideConfig = null) {
   // v4: Agents are in development/agents/ (not root agents/)
-  const sourceDir = path.join(__dirname, '..', '..', '..', '..', '.aiox-core', 'development', 'agents');
+  const sourceDir = resolveAioxCorePath('.aiox-core', 'development', 'agents');
   const targetDir = path.join(projectRoot, agentFolder);
   const copiedFiles = [];
 
@@ -261,8 +265,21 @@ async function copyAgentFiles(projectRoot, agentFolder, ideConfig = null) {
       } else if (ideConfig && ideConfig.agentFolder && ideConfig.agentFolder.includes('.github')) {
         // GitHub Copilot: apply transformer for .agent.md format with YAML frontmatter
         try {
-          const agentParser = require('../../../../.aiox-core/infrastructure/scripts/ide-sync/agent-parser');
-          const copilotTransformer = require('../../../../.aiox-core/infrastructure/scripts/ide-sync/transformers/github-copilot');
+          const agentParser = requireAioxCoreModule(
+            '.aiox-core',
+            'infrastructure',
+            'scripts',
+            'ide-sync',
+            'agent-parser',
+          );
+          const copilotTransformer = requireAioxCoreModule(
+            '.aiox-core',
+            'infrastructure',
+            'scripts',
+            'ide-sync',
+            'transformers',
+            'github-copilot',
+          );
           const agentData = agentParser.parseAgentFile(sourcePath);
           const content = copilotTransformer.transform(agentData);
           const filename = copilotTransformer.getFilename(agentData);
@@ -293,7 +310,7 @@ async function copyAgentFiles(projectRoot, agentFolder, ideConfig = null) {
  * @returns {Promise<string[]>} List of copied files
  */
 async function copyClaudeRulesFolder(projectRoot) {
-  const sourceDir = path.join(__dirname, '..', '..', '..', '..', '.claude', 'rules');
+  const sourceDir = resolveAioxCorePath('.claude', 'rules');
   const targetDir = path.join(projectRoot, '.claude', 'rules');
   const copiedFiles = [];
 
@@ -471,7 +488,7 @@ async function generateIDEConfigs(selectedIDEs, wizardState, options = {}) {
         }
 
         // Load template from .aiox-core/product/templates/
-        const templatePath = path.join(__dirname, '..', '..', '..', '..', '.aiox-core', 'product', 'templates', ide.template);
+        const templatePath = resolveAioxCorePath('.aiox-core', 'product', 'templates', ide.template);
 
         if (!await fs.pathExists(templatePath)) {
           throw new Error(`Template file not found: ${ide.template}`);
@@ -665,7 +682,7 @@ function showSuccessSummary(result) {
  * @returns {Promise<string[]>} List of copied files
  */
 async function copyClaudeHooksFolder(projectRoot, wizardState = {}) {
-  const sourceDir = path.join(__dirname, '..', '..', '..', '..', '.claude', 'hooks');
+  const sourceDir = resolveAioxCorePath('.claude', 'hooks');
   const targetDir = path.join(projectRoot, '.claude', 'hooks');
   const copiedFiles = [];
 
@@ -730,7 +747,7 @@ function shouldCopyProHooks(wizardState = {}) {
   }
 
   try {
-    const { isProAvailable } = require('../../../../bin/utils/pro-detector');
+    const { isProAvailable } = requireAioxCoreModule('bin', 'utils', 'pro-detector');
     return isProAvailable();
   } catch {
     return false;
@@ -876,7 +893,7 @@ async function createClaudeSettingsLocal(projectRoot) {
  * @returns {Promise<string[]>} List of copied files
  */
 async function copyGeminiHooksFolder(projectRoot) {
-  const sourceDir = path.join(__dirname, '..', '..', '..', '..', '.aiox-core', 'hooks', 'gemini');
+  const sourceDir = resolveAioxCorePath('.aiox-core', 'hooks', 'gemini');
   const targetDir = path.join(projectRoot, '.gemini', 'hooks');
   const copiedFiles = [];
 
@@ -1097,7 +1114,7 @@ async function linkGeminiExtension(projectRoot) {
 async function copySkillFiles(projectRoot, _sourceRoot) {
   const sourceDir = _sourceRoot
     ? path.join(_sourceRoot, '.claude', 'skills')
-    : path.join(__dirname, '..', '..', '..', '..', '.claude', 'skills');
+    : resolveAioxCorePath('.claude', 'skills');
   const targetDir = path.join(projectRoot, '.claude', 'skills');
 
   if (!await fs.pathExists(sourceDir)) {
@@ -1140,6 +1157,7 @@ function generateCodexSkills(projectRoot) {
     return { count: 0, skipped: true };
   }
 
+  const { syncSkills } = loadCodexSkillsSync();
   const result = syncSkills({
     projectRoot,
     sourceDir,
@@ -1165,7 +1183,7 @@ function generateCodexSkills(projectRoot) {
 async function copyExtraCommandFiles(projectRoot, _sourceRoot) {
   const sourceDir = _sourceRoot
     ? path.join(_sourceRoot, '.claude', 'commands')
-    : path.join(__dirname, '..', '..', '..', '..', '.claude', 'commands');
+    : resolveAioxCorePath('.claude', 'commands');
   const targetDir = path.join(projectRoot, '.claude', 'commands');
 
   if (!await fs.pathExists(sourceDir)) {

--- a/packages/installer/src/wizard/index.js
+++ b/packages/installer/src/wizard/index.js
@@ -22,6 +22,7 @@ const {
 const { setLanguage, t } = require('./i18n');
 const yaml = require('js-yaml');
 const { showWelcome, showCompletion, showCancellation } = require('./feedback');
+const { requireAioxCoreModule } = require('../utils/package-paths');
 const {
   generateIDEConfigs,
   showSuccessSummary,
@@ -35,8 +36,6 @@ const {
 const {
   installDependencies,
 } = require('../installer/dependency-installer');
-const { commandSync, commandValidate } = require('../../../../.aiox-core/infrastructure/scripts/ide-sync/index');
-const { syncSkills: syncCodexSkills } = require('../../../../.aiox-core/infrastructure/scripts/codex-skills-sync/index');
 const {
   installAioxCore,
   hasPackageJson,
@@ -46,10 +45,24 @@ const {
   displayValidationReport,
   provideTroubleshooting,
 } = require('./validation');
-const {
-  installLLMRouting,
-  isLLMRoutingInstalled,
-} = require('../../../../.aiox-core/infrastructure/scripts/llm-routing/install-llm-routing');
+
+function loadIdeSync() {
+  return requireAioxCoreModule('.aiox-core', 'infrastructure', 'scripts', 'ide-sync', 'index');
+}
+
+function loadCodexSkillsSync() {
+  return requireAioxCoreModule('.aiox-core', 'infrastructure', 'scripts', 'codex-skills-sync', 'index');
+}
+
+function loadLLMRoutingInstaller() {
+  return requireAioxCoreModule(
+    '.aiox-core',
+    'infrastructure',
+    'scripts',
+    'llm-routing',
+    'install-llm-routing',
+  );
+}
 
 // DISABLED: Legacy installation block superseded by squads flow (OSR-8)
 // /**
@@ -531,7 +544,12 @@ async function runWizard(options = {}) {
     // Story INS-4.3: Wire settings.json boundary generator after .aiox-core/ copy
     console.log('\n🔒 Generating boundary rules...');
     try {
-      const settingsGenerator = require('../../../../.aiox-core/infrastructure/scripts/generate-settings-json');
+      const settingsGenerator = requireAioxCoreModule(
+        '.aiox-core',
+        'infrastructure',
+        'scripts',
+        'generate-settings-json',
+      );
       settingsGenerator.generate(process.cwd());
       const settingsContent = await fse.readFile(path.join(process.cwd(), '.claude', 'settings.json'), 'utf8').catch(() => '{}');
       const settingsParsed = JSON.parse(settingsContent);
@@ -599,6 +617,7 @@ async function runWizard(options = {}) {
     const targetProjectRoot = process.cwd();
     const savedCwd = process.cwd();
     try {
+      const { commandSync, commandValidate } = loadIdeSync();
       process.chdir(targetProjectRoot);
       await commandSync({ quiet: true });
       answers.ideSyncStatus = 'synced';
@@ -629,6 +648,7 @@ async function runWizard(options = {}) {
     // ACORE-SKILLS.7: Generate Codex local skills in installed projects.
     console.log('\n🧩 Running Codex skills sync...');
     try {
+      const { syncSkills: syncCodexSkills } = loadCodexSkillsSync();
       const codexSkillsResult = syncCodexSkills({
         sourceDir: path.join(targetProjectRoot, '.aiox-core', 'development', 'agents'),
         localSkillsDir: path.join(targetProjectRoot, '.codex', 'skills'),
@@ -884,6 +904,11 @@ async function runWizard(options = {}) {
     // Story 6.7: LLM Routing Installation
     console.log('\nInstalling LLM Routing commands...');
     try {
+      const {
+        installLLMRouting,
+        isLLMRoutingInstalled,
+      } = loadLLMRoutingInstaller();
+
       // Check if already installed
       if (isLLMRoutingInstalled()) {
         console.log('   ℹ️  LLM Routing already installed');

--- a/packages/installer/src/wizard/pro-setup.js
+++ b/packages/installer/src/wizard/pro-setup.js
@@ -15,8 +15,10 @@
 
 'use strict';
 
+const path = require('path');
 const { createSpinner, showSuccess, showError, showWarning, showInfo } = require('./feedback');
 const { colors, status } = require('../utils/aiox-colors');
+const { getAioxCoreVersion, resolveAioxCorePath } = require('../utils/package-paths');
 const { t, tf } = require('./i18n');
 
 /**
@@ -396,7 +398,6 @@ function showStep(current, total, label) {
  * @returns {Object|null} Loaded module or null
  */
 function loadProModule(moduleName) {
-  const path = require('path');
   const tryRequire = (requestPath) => {
     try {
       return require(requestPath);
@@ -412,11 +413,14 @@ function loadProModule(moduleName) {
     }
   };
 
-  // 1. Framework-dev mode (cloned repo with pro/ submodule)
-  const frameworkPath = `../../../../pro/license/${moduleName}`;
-  const frameworkModule = tryRequire(frameworkPath);
-  if (frameworkModule) {
-    return frameworkModule;
+  // 1. Core package root (framework-dev repo or @aiox-squads/core dependency)
+  try {
+    const frameworkModule = tryRequire(resolveAioxCorePath('pro', 'license', moduleName));
+    if (frameworkModule) {
+      return frameworkModule;
+    }
+  } catch {
+    // Fall through to standalone Pro package resolution.
   }
 
   // 2. npm package
@@ -1386,11 +1390,7 @@ async function activateProByAuth(client, sessionToken) {
     // Read aiox-core version
     let aioxCoreVersion = 'unknown';
     try {
-      const path = require('path');
-      const fs = require('fs');
-      const pkgPath = path.join(__dirname, '..', '..', '..', '..', 'package.json');
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-      aioxCoreVersion = pkg.version || 'unknown';
+      aioxCoreVersion = getAioxCoreVersion() || 'unknown';
     } catch {
       // Keep 'unknown'
     }
@@ -1532,11 +1532,7 @@ async function validateKeyWithApi(key) {
     // Read aiox-core version
     let aioxCoreVersion = 'unknown';
     try {
-      const path = require('path');
-      const fs = require('fs');
-      const pkgPath = path.join(__dirname, '..', '..', '..', '..', 'package.json');
-      const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
-      aioxCoreVersion = pkg.version || 'unknown';
+      aioxCoreVersion = getAioxCoreVersion() || 'unknown';
     } catch {
       // Keep 'unknown'
     }

--- a/packages/installer/src/wizard/wizard.js
+++ b/packages/installer/src/wizard/wizard.js
@@ -1,10 +1,58 @@
 const { detectProjectType } = require('../detection/detect-project-type');
+const { requireAioxCoreModule } = require('../utils/package-paths');
+
+const FALLBACK_INSTALLATION_MODE = {
+  GREENFIELD: 'GREENFIELD',
+  BROWNFIELD: 'BROWNFIELD',
+  EXISTING_AIOX: 'EXISTING_AIOX',
+  FRAMEWORK_DEV: 'FRAMEWORK_DEV',
+  UNKNOWN: 'UNKNOWN',
+};
+
+function loadModeDetector() {
+  try {
+    return requireAioxCoreModule(
+      '.aiox-core',
+      'infrastructure',
+      'scripts',
+      'documentation-integrity',
+      'mode-detector',
+    );
+  } catch {
+    return {
+      InstallationMode: FALLBACK_INSTALLATION_MODE,
+      detectInstallationMode(targetDir) {
+        const legacyType = detectProjectType(targetDir);
+        return {
+          mode: legacyType,
+          legacyType,
+          reason: legacyType === 'EXISTING_AIOX'
+            ? 'brownfield project (existing AIOX)'
+            : `${legacyType.toLowerCase()} project`,
+        };
+      },
+      getModeOptions(detected) {
+        return [
+          {
+            value: detected.mode,
+            label: detected.mode,
+            hint: detected.reason || '',
+          },
+        ];
+      },
+      validateModeSelection() {
+        return { warnings: [] };
+      },
+    };
+  }
+}
+
 const {
   detectInstallationMode,
   getModeOptions,
   validateModeSelection,
   InstallationMode,
-} = require('../../../../.aiox-core/infrastructure/scripts/documentation-integrity/mode-detector');
+} = loadModeDetector();
 
 /**
  * Interactive Wizard for AIOX Installation
@@ -241,4 +289,3 @@ module.exports = {
   getProjectType,
   InstallationMode,
 };
-

--- a/packages/installer/tests/unit/ide-sync-integration/ide-sync-integration.test.js
+++ b/packages/installer/tests/unit/ide-sync-integration/ide-sync-integration.test.js
@@ -32,9 +32,13 @@ describe('IDE Sync Integration (Story INS-4.5)', () => {
   });
 
   describe('AC1: IDE sync called via adapter pattern', () => {
-    test('wizard imports commandSync and commandValidate from ide-sync', () => {
+    test('wizard loads commandSync and commandValidate from the core package resolver', () => {
+      expect(wizardSource).toContain('function loadIdeSync()');
       expect(wizardSource).toContain(
-        "const { commandSync, commandValidate } = require('../../../../.aiox-core/infrastructure/scripts/ide-sync/index')",
+        "return requireAioxCoreModule('.aiox-core', 'infrastructure', 'scripts', 'ide-sync', 'index')",
+      );
+      expect(wizardSource).toContain(
+        'const { commandSync, commandValidate } = loadIdeSync()',
       );
     });
 

--- a/packages/installer/tests/unit/package-paths.test.js
+++ b/packages/installer/tests/unit/package-paths.test.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const {
+  getAioxCorePackageRoot,
+  getAioxCoreVersion,
+  resolveAioxCorePath,
+} = require('../../src/utils/package-paths');
+
+describe('installer package path resolution', () => {
+  test('resolves an AIOX core package root with .aiox-core assets', () => {
+    const packageRoot = getAioxCorePackageRoot();
+    const packageJson = require(path.join(packageRoot, 'package.json'));
+
+    expect(packageJson.name).toBe('@aiox-squads/core');
+    expect(fs.existsSync(path.join(packageRoot, '.aiox-core'))).toBe(true);
+  });
+
+  test('resolves .aiox-core paths from the core package root', () => {
+    const coreConfigPath = resolveAioxCorePath('.aiox-core', 'core-config.yaml');
+
+    expect(fs.existsSync(coreConfigPath)).toBe(true);
+  });
+
+  test('reads the AIOX core package version', () => {
+    const packageRoot = getAioxCorePackageRoot();
+    const packageJson = require(path.join(packageRoot, 'package.json'));
+
+    expect(getAioxCoreVersion()).toBe(packageJson.version);
+  });
+});


### PR DESCRIPTION
## Summary
- Force public npm visibility after publishing core and workspace packages.
- Make workspace package smoke tests verify the exact published version from a clean temp directory.
- Fix @aiox-squads/installer@3.3.1 runtime by declaring missing dependencies and resolving assets from @aiox-squads/core.
- Add regression coverage for installer package path resolution and update IDE sync integration expectations.

## Validation
- npm run lint -- --quiet
- npm run typecheck
- npm run validate:publish
- npm run test:ci
- npm pack --workspace packages/installer --pack-destination /tmp
- tarball smoke: npx aiox-installer --help / --version
- tarball smoke: installer.runWizard({ quiet: true, dryRun: true })
- tarball smoke: installAioxCore() installed .aiox-core into a temp project

## Notes
- CodeRabbit CLI is installed locally but blocked by interactive auth: coderabbit auth login required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped installer version to 3.3.1 with updated dependencies including `cli-progress`, `inquirer`, `js-yaml`, `ora`, and `semver`.
  * Enhanced npm publishing workflow to automatically ensure newly published packages are set to public and improved workspace package smoke testing with registry propagation.
  * Added unit tests for package path resolution utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->