### PR TITLE
fix: guard master orchestrator progress

### DIFF
--- a/.aiox-core/core/orchestration/master-orchestrator.js
+++ b/.aiox-core/core/orchestration/master-orchestrator.js
@@ -1355,9 +1355,11 @@ class MasterOrchestrator extends EventEmitter {
     if (!state.epics) return 0;
 
     const totalEpics = Object.keys(EPIC_CONFIG).filter((num) => !EPIC_CONFIG[num].onDemand).length;
+    if (totalEpics === 0) return 0;
 
-    const completedEpics = Object.values(state.epics).filter(
-      (epic) => epic.status === EpicStatus.COMPLETED,
+    const completedEpics = Object.entries(state.epics).filter(
+      ([num, epic]) =>
+        epic.status === EpicStatus.COMPLETED && EPIC_CONFIG[num] && !EPIC_CONFIG[num].onDemand,
     ).length;
 
     return Math.round((completedEpics / totalEpics) * 100);
@@ -1411,9 +1413,11 @@ class MasterOrchestrator extends EventEmitter {
    */
   getProgressPercentage() {
     const totalEpics = Object.keys(EPIC_CONFIG).filter((num) => !EPIC_CONFIG[num].onDemand).length;
+    if (totalEpics === 0) return 0;
 
-    const completedEpics = Object.values(this.executionState.epics).filter(
-      (epic) => epic.status === EpicStatus.COMPLETED,
+    const completedEpics = Object.entries(this.executionState.epics).filter(
+      ([num, epic]) =>
+        epic.status === EpicStatus.COMPLETED && EPIC_CONFIG[num] && !EPIC_CONFIG[num].onDemand,
     ).length;
 
     return Math.round((completedEpics / totalEpics) * 100);

--- a/.aiox-core/data/entity-registry.yaml
+++ b/.aiox-core/data/entity-registry.yaml
@@ -1,6 +1,6 @@
 metadata:
   version: 1.0.0
-  lastUpdated: '2026-05-07T07:53:00.000Z'
+  lastUpdated: '2026-05-07T10:44:44.077Z'
   entityCount: 746
   checksumAlgorithm: sha256
   resolutionRate: 100
@@ -9734,6 +9734,7 @@ entities:
         - cli-commands
       dependencies:
         - tech-stack-detector
+        - executors
         - recovery-handler
         - gate-evaluator
         - agent-invoker
@@ -9746,8 +9747,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:61b874d74fae62e9307861b02b7505538f1c94362fe638fc3941b0665dcbbdf6
-      lastVerified: '2026-03-11T00:48:55.885Z'
+      checksum: sha256:61c988509c2edc03c1cd4dec333b284f7d15273f3e799c56950706a2e88f341b
+      lastVerified: '2026-05-07T10:44:44.074Z'
     message-formatter:
       path: .aiox-core/core/orchestration/message-formatter.js
       layer: L1

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -7,8 +7,8 @@
 # - SHA256 hashes for change detection
 # - File types for categorization
 #
-version: 5.1.1
-generated_at: "2026-05-07T10:20:29.036Z"
+version: 5.1.2
+generated_at: "2026-05-07T10:45:15.516Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1103
 files:
@@ -905,9 +905,9 @@ files:
     type: core
     size: 8663
   - path: core/orchestration/master-orchestrator.js
-    hash: sha256:61b874d74fae62e9307861b02b7505538f1c94362fe638fc3941b0665dcbbdf6
+    hash: sha256:61c988509c2edc03c1cd4dec333b284f7d15273f3e799c56950706a2e88f341b
     type: core
-    size: 54417
+    size: 54621
   - path: core/orchestration/message-formatter.js
     hash: sha256:b7413c04fa22db1c5fc2f5c2aa47bb8ca0374e079894a44df21b733da6c258ae
     type: core
@@ -1229,9 +1229,9 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:2968dcdf527e4f428298a6590ef91e4ed4fce6df6b46d2404f954537f6113a68
+    hash: sha256:b79e4aa7eece851a30ad7b3598efc3033fd921f5b0b19dac5843a454ee8eec98
     type: data
-    size: 522409
+    size: 522429
   - path: data/learned-patterns.yaml
     hash: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
     type: data

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aiox-squads/core",
-      "version": "5.1.1",
+      "version": "5.1.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Synkra AIOX: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aiox": "bin/aiox.js",

--- a/tests/core/master-orchestrator.test.js
+++ b/tests/core/master-orchestrator.test.js
@@ -21,6 +21,25 @@ describe('MasterOrchestrator', () => {
   let tempDir;
   let orchestrator;
 
+  function snapshotOnDemandConfig() {
+    return Object.fromEntries(
+      Object.entries(EPIC_CONFIG).map(([num, cfg]) => [
+        num,
+        { had: Object.prototype.hasOwnProperty.call(cfg, 'onDemand'), value: cfg.onDemand },
+      ]),
+    );
+  }
+
+  function restoreOnDemandConfig(snapshot) {
+    for (const [num, original] of Object.entries(snapshot)) {
+      if (original.had) {
+        EPIC_CONFIG[num].onDemand = original.value;
+      } else {
+        delete EPIC_CONFIG[num].onDemand;
+      }
+    }
+  }
+
   beforeEach(async () => {
     // Create temp directory for tests
     tempDir = path.join(os.tmpdir(), `master-orchestrator-test-${Date.now()}`);
@@ -425,6 +444,68 @@ describe('MasterOrchestrator', () => {
 
       await orchestrator.executeEpic(4);
       expect(orchestrator.getProgressPercentage()).toBe(67); // 2 of 3
+    });
+
+    it('should return 0 when all epics are on-demand', async () => {
+      await orchestrator.initialize();
+
+      const originalConfig = snapshotOnDemandConfig();
+
+      try {
+        for (const cfg of Object.values(EPIC_CONFIG)) {
+          cfg.onDemand = true;
+        }
+
+        const progress = orchestrator.getProgressPercentage();
+
+        expect(progress).toBe(0);
+        expect(Number.isNaN(progress)).toBe(false);
+      } finally {
+        restoreOnDemandConfig(originalConfig);
+      }
+    });
+
+    it('should return 0 from saved state progress when all epics are on-demand', async () => {
+      await orchestrator.initialize();
+
+      const originalConfig = snapshotOnDemandConfig();
+
+      try {
+        for (const cfg of Object.values(EPIC_CONFIG)) {
+          cfg.onDemand = true;
+        }
+
+        const progress = orchestrator._calculateProgressFromState({
+          epics: {
+            3: { status: EpicStatus.COMPLETED },
+            5: { status: EpicStatus.COMPLETED },
+          },
+        });
+
+        expect(progress).toBe(0);
+        expect(Number.isNaN(progress)).toBe(false);
+      } finally {
+        restoreOnDemandConfig(originalConfig);
+      }
+    });
+
+    it('should ignore on-demand and unknown epics in progress calculation', async () => {
+      await orchestrator.initialize();
+      await orchestrator.executeEpic(3);
+      await orchestrator.executeEpic(5);
+
+      orchestrator.executionState.epics[999] = { status: EpicStatus.COMPLETED };
+
+      expect(orchestrator.getProgressPercentage()).toBe(33);
+      expect(
+        orchestrator._calculateProgressFromState({
+          epics: {
+            3: { status: EpicStatus.COMPLETED },
+            5: { status: EpicStatus.COMPLETED },
+            999: { status: EpicStatus.COMPLETED },
+          },
+        }),
+      ).toBe(33);
     });
 
     it('should return status summary', async () => {


### PR DESCRIPTION
## Summary
- add zero-denominator guards to master orchestrator progress calculations
- exclude on-demand and unknown/legacy epics from completed progress counts
- add regression coverage for all-on-demand and unknown epic states
- bump `@aiox-squads/core` to 5.1.2 and regenerate manifest/IDS metadata

## Existing PR validation
- PR #536 has the correct fix direction but is `DIRTY` against current `main` and carries stale manifest churn
- this PR reapplies the validated correction cleanly from current `main`

## Validation
- `npm test -- tests/core/master-orchestrator.test.js --runInBand`
- `node -c .aiox-core/core/orchestration/master-orchestrator.js`
- `npm run validate:manifest`
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run validate:publish`
- `npm run test:ci`

Supersedes #536.
Closes #532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Progress tracking now excludes on-demand epics from both total count and completion calculations.

* **Tests**
  * Added test coverage validating on-demand epic exclusion from progress calculations and handling of unknown epic entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->