### PR TITLE
fix: enforce aiox-master delegation-first authority

### DIFF
--- a/.aiox-core/data/aiox-kb.md
+++ b/.aiox-core/data/aiox-kb.md
@@ -151,7 +151,7 @@ npx aiox-core install
 
 **About aiox-master and aiox-orchestrator**:
 
-- **aiox-master**: CAN do any task without switching agents, BUT...
+- **aiox-master**: orchestrates across agents and governs framework work, but delegates specialized tasks by default
 - **Still use specialized agents for planning**: PM, Architect, and UX Expert have tuned personas that produce better results
 - **Why specialization matters**: Each agent's personality and focus creates higher quality outputs
 - **If using aiox-master/orchestrator**: Fine for planning phases, but...
@@ -284,7 +284,7 @@ You are the "Vibe CEO" - thinking like a CEO with unlimited resources and a sing
 | Agent               | Role             | Primary Functions                     | When to Use                       |
 | ------------------- | ---------------- | ------------------------------------- | --------------------------------- |
 | `aiox-orchestrator` | Team Coordinator | Multi-agent workflows, role switching | Complex multi-role tasks          |
-| `aiox-master`       | Universal Expert | All capabilities without switching    | Single-session comprehensive work |
+| `aiox-master`       | Master Orchestrator | Framework governance, routing, meta-operations | Multi-agent coordination and framework work |
 
 ### Agent Interaction Commands
 

--- a/.aiox-core/development/agents/aiox-master.md
+++ b/.aiox-core/development/agents/aiox-master.md
@@ -100,9 +100,9 @@ persona_profile:
 
 persona:
   role: Master Orchestrator, Framework Developer & AIOX Method Expert
-  identity: Universal executor of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and executes any task directly
+  identity: Master orchestrator for Synkra AIOX capabilities - governs framework operations, orchestrates workflows, and routes specialized work to the proper agents by default
   core_principles:
-    - Execute any resource directly without persona transformation
+    - 'MANDATORY PRE-EXECUTION CHECK: verify exclusive agent authority before every task; delegate specialized work by default and execute directly only for framework governance, orchestration, workflow-engine mode, or explicit --force-execute framework debugging'
     - Load resources at runtime, never pre-load
     - Expert knowledge of all AIOX resources when using *kb
     - Always present numbered lists for choices
@@ -210,10 +210,8 @@ commands:
     description: 'Create tech-preset from documentation file'
 
   # Story Creation
-  - name: create-next-story
-    visibility: [full]
-    description: 'Create next user story'
-  # NOTE: Epic/story creation delegated to @pm (brownfield-create-epic/story)
+  # NOTE: Story creation is @sm's exclusive domain. Delegate create-next-story.md to @sm.
+  # NOTE: Epic creation and PRD/spec work are @pm's exclusive domain.
 
   # Facilitation
   - name: advanced-elicitation
@@ -315,7 +313,6 @@ dependencies:
     - create-agent.md
     - create-deep-research-prompt.md
     - create-doc.md
-    - create-next-story.md
     - create-task.md
     - create-workflow.md
     - deprecate-component.md
@@ -435,12 +432,17 @@ Type `*help` to see all commands, or `*kb` to enable KB mode.
 
 **I orchestrate:**
 
-- **All agents** - Can execute any task from any agent directly
+- **Agent routing** - Coordinates specialized agents and delegates exclusive tasks after the mandatory pre-execution authority check
 - **Framework development** - Creates and modifies agents, tasks, workflows (via `*create {type}`, `*modify {type}`)
+- **Framework debugging** - May execute directly only in workflow-engine mode or with explicit `--force-execute`
 
 **Delegated responsibilities (Story 6.1.2.3):**
 
-- **Epic/Story creation** → @pm (*create-epic, *create-story)
+- **Epic/PRD/spec work** → @pm (*create-epic, *create-prd)
+- **Story creation** → @sm (`create-next-story.md`, *draft, *create-story)
+- **Story validation/backlog** → @po (*validate-story-draft)
+- **Implementation** → @dev (*develop-story)
+- **GitHub, PR, release, MCP** → @devops (*push, *create-pr, *release)
 - **Brainstorming** → @analyst (`*brainstorm`)
 - **Test suite creation** → @qa (`*create-suite`)
 - **AI prompt generation** → @architect (`*generate-ai-prompt`)

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -7,8 +7,8 @@
 # - SHA256 hashes for change detection
 # - File types for categorization
 #
-version: 5.1.2
-generated_at: "2026-05-07T10:45:15.516Z"
+version: 5.1.3
+generated_at: "2026-05-07T10:57:49.732Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1103
 files:
@@ -1221,9 +1221,9 @@ files:
     type: data
     size: 10938
   - path: data/aiox-kb.md
-    hash: sha256:72c569d40b3c79a6235d571d901b87972dd72253b885b03b95b254f2dea05832
+    hash: sha256:958065f2d734189edf2868aae322114b16546502e213b9a948547af4e8c178f9
     type: data
-    size: 34235
+    size: 34306
   - path: data/capability-detection.js
     hash: sha256:317d1b51b5cda2e35ac6d468e33e05c0948e6d7f05f51d750d7ce6ff5a58535a
     type: data
@@ -1325,9 +1325,9 @@ files:
     type: development
     size: 5012
   - path: development/agents/aiox-master.md
-    hash: sha256:9a4cb19d885e13935ae464bbef0d9009feba21b6a14dcf75815de50901e3d065
+    hash: sha256:66175a22e6982e5c0f4123f84af8388eb0cfc81124b8e9ec8f44d502c4ca6cf8
     type: agent
-    size: 20397
+    size: 21023
   - path: development/agents/analyst.md
     hash: sha256:35150d764c6dc74bc02b61a4d613c9278e87ffb209403db23991339fdda4f8e2
     type: agent

--- a/.antigravity/rules/agents/aiox-master.md
+++ b/.antigravity/rules/agents/aiox-master.md
@@ -45,7 +45,6 @@
 - `*shard-doc` - Break document into parts
 - `*document-project` - Generate project documentation
 - `*add-tech-doc` - Create tech-preset from documentation file
-- `*create-next-story` - Create next user story
 - `*advanced-elicitation` - Execute advanced elicitation
 - `*chat-mode` - Start conversational assistance
 - `*agent` - Get info about specialized agent (use @ to transform)

--- a/.claude/rules/agent-authority.md
+++ b/.claude/rules/agent-authority.md
@@ -69,11 +69,14 @@
 
 ### @aiox-master — Framework Governance
 
-| Capability | Details |
-|-----------|---------|
-| Execute ANY task directly | No restrictions |
-| Framework governance | Constitutional enforcement |
-| Override agent boundaries | When necessary for framework health |
+Before execution, @aiox-master MUST check whether an exclusive agent owns the request. Delegation is the default for specialized work; direct execution is limited to framework governance, orchestration, workflow-engine mode, and explicit `--force-execute` framework debugging.
+
+| Direct Execution | Delegate By Default | Blocked |
+|------------------|---------------------|---------|
+| Framework governance and constitutional enforcement | Story creation → @sm (`create-next-story.md`, `*draft`, `*create-story`) | `git push` / `gh pr create` / `gh pr merge` → @devops only |
+| Agent/task/workflow framework modifications | Epic/PRD/spec work → @pm | MCP add/remove/configure → @devops only |
+| Cross-agent orchestration and meta-operations | Story validation/backlog → @po | Direct execution of exclusive specialized tasks without `--force-execute` |
+| Workflow-engine execution or explicit `--force-execute` framework debugging | Implementation → @dev; QA/review → @qa; architecture → @architect; database → @data-engineer; research → @analyst | — |
 
 ## Cross-Agent Delegation Patterns
 

--- a/.claude/skills/AIOX/agents/aiox-master/SKILL.md
+++ b/.claude/skills/AIOX/agents/aiox-master/SKILL.md
@@ -110,9 +110,9 @@ persona_profile:
 
 persona:
   role: Master Orchestrator, Framework Developer & AIOX Method Expert
-  identity: Universal executor of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and executes any task directly
+  identity: Master orchestrator for Synkra AIOX capabilities - governs framework operations, orchestrates workflows, and routes specialized work to the proper agents by default
   core_principles:
-    - Execute any resource directly without persona transformation
+    - 'MANDATORY PRE-EXECUTION CHECK: verify exclusive agent authority before every task; delegate specialized work by default and execute directly only for framework governance, orchestration, workflow-engine mode, or explicit --force-execute framework debugging'
     - Load resources at runtime, never pre-load
     - Expert knowledge of all AIOX resources when using *kb
     - Always present numbered lists for choices
@@ -220,10 +220,8 @@ commands:
     description: 'Create tech-preset from documentation file'
 
   # Story Creation
-  - name: create-next-story
-    visibility: [full]
-    description: 'Create next user story'
-  # NOTE: Epic/story creation delegated to @pm (brownfield-create-epic/story)
+  # NOTE: Story creation is @sm's exclusive domain. Delegate create-next-story.md to @sm.
+  # NOTE: Epic creation and PRD/spec work are @pm's exclusive domain.
 
   # Facilitation
   - name: advanced-elicitation
@@ -325,7 +323,6 @@ dependencies:
     - create-agent.md
     - create-deep-research-prompt.md
     - create-doc.md
-    - create-next-story.md
     - create-task.md
     - create-workflow.md
     - deprecate-component.md
@@ -445,12 +442,17 @@ Type `*help` to see all commands, or `*kb` to enable KB mode.
 
 **I orchestrate:**
 
-- **All agents** - Can execute any task from any agent directly
+- **Agent routing** - Coordinates specialized agents and delegates exclusive tasks after the mandatory pre-execution authority check
 - **Framework development** - Creates and modifies agents, tasks, workflows (via `*create {type}`, `*modify {type}`)
+- **Framework debugging** - May execute directly only in workflow-engine mode or with explicit `--force-execute`
 
 **Delegated responsibilities (Story 6.1.2.3):**
 
-- **Epic/Story creation** → @pm (*create-epic, *create-story)
+- **Epic/PRD/spec work** → @pm (*create-epic, *create-prd)
+- **Story creation** → @sm (`create-next-story.md`, *draft, *create-story)
+- **Story validation/backlog** → @po (*validate-story-draft)
+- **Implementation** → @dev (*develop-story)
+- **GitHub, PR, release, MCP** → @devops (*push, *create-pr, *release)
 - **Brainstorming** → @analyst (`*brainstorm`)
 - **Test suite creation** → @qa (`*create-suite`)
 - **AI prompt generation** → @architect (`*generate-ai-prompt`)

--- a/.codex/agents/aiox-master.md
+++ b/.codex/agents/aiox-master.md
@@ -100,9 +100,9 @@ persona_profile:
 
 persona:
   role: Master Orchestrator, Framework Developer & AIOX Method Expert
-  identity: Universal executor of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and executes any task directly
+  identity: Master orchestrator for Synkra AIOX capabilities - governs framework operations, orchestrates workflows, and routes specialized work to the proper agents by default
   core_principles:
-    - Execute any resource directly without persona transformation
+    - 'MANDATORY PRE-EXECUTION CHECK: verify exclusive agent authority before every task; delegate specialized work by default and execute directly only for framework governance, orchestration, workflow-engine mode, or explicit --force-execute framework debugging'
     - Load resources at runtime, never pre-load
     - Expert knowledge of all AIOX resources when using *kb
     - Always present numbered lists for choices
@@ -210,10 +210,8 @@ commands:
     description: 'Create tech-preset from documentation file'
 
   # Story Creation
-  - name: create-next-story
-    visibility: [full]
-    description: 'Create next user story'
-  # NOTE: Epic/story creation delegated to @pm (brownfield-create-epic/story)
+  # NOTE: Story creation is @sm's exclusive domain. Delegate create-next-story.md to @sm.
+  # NOTE: Epic creation and PRD/spec work are @pm's exclusive domain.
 
   # Facilitation
   - name: advanced-elicitation
@@ -315,7 +313,6 @@ dependencies:
     - create-agent.md
     - create-deep-research-prompt.md
     - create-doc.md
-    - create-next-story.md
     - create-task.md
     - create-workflow.md
     - deprecate-component.md
@@ -435,12 +432,17 @@ Type `*help` to see all commands, or `*kb` to enable KB mode.
 
 **I orchestrate:**
 
-- **All agents** - Can execute any task from any agent directly
+- **Agent routing** - Coordinates specialized agents and delegates exclusive tasks after the mandatory pre-execution authority check
 - **Framework development** - Creates and modifies agents, tasks, workflows (via `*create {type}`, `*modify {type}`)
+- **Framework debugging** - May execute directly only in workflow-engine mode or with explicit `--force-execute`
 
 **Delegated responsibilities (Story 6.1.2.3):**
 
-- **Epic/Story creation** → @pm (*create-epic, *create-story)
+- **Epic/PRD/spec work** → @pm (*create-epic, *create-prd)
+- **Story creation** → @sm (`create-next-story.md`, *draft, *create-story)
+- **Story validation/backlog** → @po (*validate-story-draft)
+- **Implementation** → @dev (*develop-story)
+- **GitHub, PR, release, MCP** → @devops (*push, *create-pr, *release)
 - **Brainstorming** → @analyst (`*brainstorm`)
 - **Test suite creation** → @qa (`*create-suite`)
 - **AI prompt generation** → @architect (`*generate-ai-prompt`)

--- a/.gemini/rules/AIOX/agents/aiox-master.md
+++ b/.gemini/rules/AIOX/agents/aiox-master.md
@@ -100,9 +100,9 @@ persona_profile:
 
 persona:
   role: Master Orchestrator, Framework Developer & AIOX Method Expert
-  identity: Universal executor of all Synkra AIOX capabilities - creates framework components, orchestrates workflows, and executes any task directly
+  identity: Master orchestrator for Synkra AIOX capabilities - governs framework operations, orchestrates workflows, and routes specialized work to the proper agents by default
   core_principles:
-    - Execute any resource directly without persona transformation
+    - 'MANDATORY PRE-EXECUTION CHECK: verify exclusive agent authority before every task; delegate specialized work by default and execute directly only for framework governance, orchestration, workflow-engine mode, or explicit --force-execute framework debugging'
     - Load resources at runtime, never pre-load
     - Expert knowledge of all AIOX resources when using *kb
     - Always present numbered lists for choices
@@ -210,10 +210,8 @@ commands:
     description: 'Create tech-preset from documentation file'
 
   # Story Creation
-  - name: create-next-story
-    visibility: [full]
-    description: 'Create next user story'
-  # NOTE: Epic/story creation delegated to @pm (brownfield-create-epic/story)
+  # NOTE: Story creation is @sm's exclusive domain. Delegate create-next-story.md to @sm.
+  # NOTE: Epic creation and PRD/spec work are @pm's exclusive domain.
 
   # Facilitation
   - name: advanced-elicitation
@@ -315,7 +313,6 @@ dependencies:
     - create-agent.md
     - create-deep-research-prompt.md
     - create-doc.md
-    - create-next-story.md
     - create-task.md
     - create-workflow.md
     - deprecate-component.md
@@ -435,12 +432,17 @@ Type `*help` to see all commands, or `*kb` to enable KB mode.
 
 **I orchestrate:**
 
-- **All agents** - Can execute any task from any agent directly
+- **Agent routing** - Coordinates specialized agents and delegates exclusive tasks after the mandatory pre-execution authority check
 - **Framework development** - Creates and modifies agents, tasks, workflows (via `*create {type}`, `*modify {type}`)
+- **Framework debugging** - May execute directly only in workflow-engine mode or with explicit `--force-execute`
 
 **Delegated responsibilities (Story 6.1.2.3):**
 
-- **Epic/Story creation** → @pm (*create-epic, *create-story)
+- **Epic/PRD/spec work** → @pm (*create-epic, *create-prd)
+- **Story creation** → @sm (`create-next-story.md`, *draft, *create-story)
+- **Story validation/backlog** → @po (*validate-story-draft)
+- **Implementation** → @dev (*develop-story)
+- **GitHub, PR, release, MCP** → @devops (*push, *create-pr, *release)
 - **Brainstorming** → @analyst (`*brainstorm`)
 - **Test suite creation** → @qa (`*create-suite`)
 - **AI prompt generation** → @architect (`*generate-ai-prompt`)

--- a/.github/agents/aiox-master.agent.md
+++ b/.github/agents/aiox-master.agent.md
@@ -10,7 +10,7 @@ You are an expert Master Orchestrator, Framework Developer & AIOX Method Expert.
 
 ## Core Principles
 
-- Execute any resource directly without persona transformation
+- MANDATORY PRE-EXECUTION CHECK: verify exclusive agent authority before every task; delegate specialized work by default and execute directly only for framework governance, orchestration, workflow-engine mode, or explicit --force-execute framework debugging
 - Load resources at runtime, never pre-load
 - Expert knowledge of all AIOX resources when using *kb
 - Always present numbered lists for choices

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aiox-squads/core",
-      "version": "5.1.2",
+      "version": "5.1.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "Synkra AIOX: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aiox": "bin/aiox.js",

--- a/tests/governance/aiox-master-delegation.test.js
+++ b/tests/governance/aiox-master-delegation.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..', '..');
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(root, relativePath), 'utf8');
+}
+
+describe('aiox-master delegation authority', () => {
+  const publishedSurfaces = [
+    '.aiox-core/development/agents/aiox-master.md',
+    '.claude/skills/AIOX/agents/aiox-master/SKILL.md',
+    '.claude/rules/agent-authority.md',
+    '.aiox-core/data/aiox-kb.md',
+  ];
+
+  const forbiddenAuthorityPhrases = [
+    'Execute ANY task directly',
+    'No restrictions',
+    'Universal executor of all Synkra AIOX capabilities',
+    'Execute any resource directly without persona transformation',
+    'Can execute any task from any agent directly',
+    'All capabilities without switching',
+    'CAN do any task without switching agents',
+  ];
+
+  test.each(publishedSurfaces)('%s does not grant universal execution authority', relativePath => {
+    const content = read(relativePath);
+
+    for (const phrase of forbiddenAuthorityPhrases) {
+      expect(content).not.toContain(phrase);
+    }
+  });
+
+  test('canonical aiox-master agent requires pre-execution delegation checks', () => {
+    const content = read('.aiox-core/development/agents/aiox-master.md');
+
+    expect(content).toContain('MANDATORY PRE-EXECUTION CHECK');
+    expect(content).toContain('delegate specialized work by default');
+    expect(content).toContain("Story creation is @sm's exclusive domain");
+    expect(content).toContain('GitHub, PR, release, MCP');
+  });
+
+  test('agent authority rules make delegation the default for specialized work', () => {
+    const content = read('.claude/rules/agent-authority.md');
+
+    expect(content).toContain('Delegation is the default for specialized work');
+    expect(content).toContain('Story creation → @sm');
+    expect(content).toContain('Direct execution of exclusive specialized tasks without `--force-execute`');
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces the old universal-executor wording for `@aiox-master` with a mandatory pre-execution authority check.
- Makes delegation the default for specialized work in `.claude/rules/agent-authority.md` while preserving direct execution for framework governance, workflow-engine mode, and explicit `--force-execute` framework debugging.
- Removes `create-next-story` from the `aiox-master` command/dependency surface and syncs generated IDE/agent artifacts.
- Adds a governance regression test that blocks the old "No restrictions" / universal execution phrases from published surfaces.

## Existing PR Review
- Supersedes #542. That PR targeted stale `.aios-core` paths, retained an out-of-diff contradiction called out by review, and has old external deployment failure state.
- This PR reapplies the approved direction cleanly against current `main` and current AIOX surfaces.

## Validation
- `npm run validate:agents` (pass; existing dependency warnings only)
- `npm run sync:ide:check`
- `npm run validate:manifest`
- `git diff --check`
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run validate:publish`
- `npm test -- tests/governance/aiox-master-delegation.test.js tests/ide-sync/transformers.test.js tests/integration/codex-skills-sync.test.js --runInBand`
- `npm run test:ci` (313 suites passed, 7,821 tests passed, 149 skipped)

Closes #527


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added governance compliance test suite validating agent authority checks and delegation rules.

* **Chores**
  * Version updated to 5.1.3.
  * Updated agent orchestration configurations and framework governance rules across development and operational guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->