### PR TITLE
fix: resolve Pro squad script dependencies

### DIFF
--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -7,8 +7,8 @@
 # - SHA256 hashes for change detection
 # - File types for categorization
 #
-version: 5.1.5
-generated_at: "2026-05-07T11:58:48.672Z"
+version: 5.1.6
+generated_at: "2026-05-07T12:43:37.364Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1103
 files:

--- a/bin/aiox-init.js
+++ b/bin/aiox-init.js
@@ -110,6 +110,14 @@ try {
   brownfieldUpgrader = null;
 }
 
+let ensureProjectNodeModulesLink;
+try {
+  ({ ensureProjectNodeModulesLink } = require('@aiox-squads/core/installer/aiox-core-installer'));
+} catch (_err) {
+  // Module may not be available in older installations
+  ensureProjectNodeModulesLink = null;
+}
+
 async function main() {
   console.clear();
 
@@ -519,21 +527,19 @@ async function main() {
     );
 
     // Ensure root squad scripts can resolve framework dependencies.
-    const projectNodeModules = path.join(context.projectRoot, 'node_modules');
-    const frameworkNodeModules = path.join(targetCoreDir, 'node_modules');
-    if (!fs.existsSync(projectNodeModules) && fs.existsSync(frameworkNodeModules)) {
-      try {
-        const linkTarget = process.platform === 'win32'
-          ? frameworkNodeModules
-          : path.relative(context.projectRoot, frameworkNodeModules);
-        const linkType = process.platform === 'win32' ? 'junction' : 'dir';
-        await fse.symlink(linkTarget || frameworkNodeModules, projectNodeModules, linkType);
+    if (ensureProjectNodeModulesLink) {
+      const linkResult = await ensureProjectNodeModulesLink({
+        targetDir: context.projectRoot,
+        targetAioxCore: targetCoreDir,
+      });
+      if (linkResult.linked) {
         console.log(chalk.green('✓') + ' node_modules linked to .aiox-core/node_modules');
-      } catch (symlinkError) {
+      } else if (!linkResult.success) {
         console.log(
           chalk.yellow('⚠') +
             ' Could not create node_modules symlink: ' +
-            symlinkError.message
+            linkResult.reason +
+            (linkResult.error ? ` (${linkResult.error})` : '')
         );
       }
     }

--- a/bin/aiox-init.js
+++ b/bin/aiox-init.js
@@ -518,6 +518,26 @@ async function main() {
         chalk.gray('(11 agents, 68 tasks, 23 templates)')
     );
 
+    // Ensure root squad scripts can resolve framework dependencies.
+    const projectNodeModules = path.join(context.projectRoot, 'node_modules');
+    const frameworkNodeModules = path.join(targetCoreDir, 'node_modules');
+    if (!fs.existsSync(projectNodeModules) && fs.existsSync(frameworkNodeModules)) {
+      try {
+        const linkTarget = process.platform === 'win32'
+          ? frameworkNodeModules
+          : path.relative(context.projectRoot, frameworkNodeModules);
+        const linkType = process.platform === 'win32' ? 'junction' : 'dir';
+        await fse.symlink(linkTarget || frameworkNodeModules, projectNodeModules, linkType);
+        console.log(chalk.green('✓') + ' node_modules linked to .aiox-core/node_modules');
+      } catch (symlinkError) {
+        console.log(
+          chalk.yellow('⚠') +
+            ' Could not create node_modules symlink: ' +
+            symlinkError.message
+        );
+      }
+    }
+
     // Create installed manifest for brownfield upgrades (Story 6.18)
     if (brownfieldUpgrader) {
       try {

--- a/docs/stories/epic-123/STORY-123.10-squad-dependency-resolution.md
+++ b/docs/stories/epic-123/STORY-123.10-squad-dependency-resolution.md
@@ -1,0 +1,39 @@
+# STORY-123.10: Corrigir resolução de dependências dos scripts de squads Pro
+
+Status: Done
+
+PR relacionado: #624
+
+## Contexto
+
+O PR #624 propôs corrigir scripts em `squads/` que falhavam com `Cannot find module 'js-yaml'` quando executados a partir da raiz do projeto instalado. A proposta original alterava apenas o installer legado (`bin/aiox-init.js`), mas o fluxo atual usa o wizard v4 e copia os squads Pro por `packages/installer/src/pro/pro-scaffolder.js`.
+
+## Acceptance Criteria
+
+- [x] AC1. Scripts copiados para `squads/` conseguem resolver dependências instaladas em `.aiox-core/node_modules`.
+- [x] AC2. O link `node_modules -> .aiox-core/node_modules` só é criado quando o projeto ainda não possui `node_modules`.
+- [x] AC3. Projetos com `node_modules` próprio não são sobrescritos.
+- [x] AC4. A correção cobre o scaffolder Pro atual e mantém o fallback legado alinhado com o PR #624.
+- [x] AC5. Há testes automatizados para criação do link, idempotência e resolução de `js-yaml` a partir de um script de squad.
+
+## Tasks
+
+- [x] Adicionar helper idempotente de link de dependências no installer core.
+- [x] Integrar o helper ao scaffolder Pro.
+- [x] Alinhar o fallback legado `bin/aiox-init.js`.
+- [x] Adicionar regressões em `tests/installer`.
+- [x] Rodar gates locais e preparar patch `5.1.6`.
+
+## Dev Notes
+
+- O wizard v4 removeu o antigo fluxo comunitário de instalação direta de squads; a superfície ativa com scripts em `squads/` é o conteúdo Pro scaffoldado.
+- O link é não destrutivo: se `node_modules` já existir no projeto, a instalação não altera a árvore de dependências do usuário.
+
+## File List
+
+- [docs/stories/epic-123/STORY-123.10-squad-dependency-resolution.md](./STORY-123.10-squad-dependency-resolution.md)
+- [bin/aiox-init.js](../../../bin/aiox-init.js)
+- [packages/installer/src/installer/aiox-core-installer.js](../../../packages/installer/src/installer/aiox-core-installer.js)
+- [packages/installer/src/pro/pro-scaffolder.js](../../../packages/installer/src/pro/pro-scaffolder.js)
+- [tests/installer/aiox-core-installer.test.js](../../../tests/installer/aiox-core-installer.test.js)
+- [tests/installer/pro-scaffolder.test.js](../../../tests/installer/pro-scaffolder.test.js)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.1.5",
+  "version": "5.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aiox-squads/core",
-      "version": "5.1.5",
+      "version": "5.1.6",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "LICENSE"
   ],
   "exports": {
+    "./installer/aiox-core-installer": "./packages/installer/src/installer/aiox-core-installer.js",
     "./installer/pro-scaffolder": "./packages/installer/src/pro/pro-scaffolder.js",
     "./package.json": "./package.json"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.1.5",
+  "version": "5.1.6",
   "description": "Synkra AIOX: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aiox": "bin/aiox.js",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -8,6 +8,7 @@
   },
   "exports": {
     ".": "./src/index.js",
+    "./aiox-core-installer": "./src/installer/aiox-core-installer.js",
     "./pro-setup": "./src/wizard/pro-setup.js",
     "./pro-scaffolder": "./src/pro/pro-scaffolder.js",
     "./package.json": "./package.json"

--- a/packages/installer/src/installer/aiox-core-installer.js
+++ b/packages/installer/src/installer/aiox-core-installer.js
@@ -467,6 +467,69 @@ async function hasPackageJson(targetDir = process.cwd()) {
 }
 
 /**
+ * Link project-level node_modules to the framework dependency install when the
+ * project has no node_modules of its own. This lets root-level squad scripts
+ * resolve framework dependencies such as js-yaml after Pro scaffolding.
+ *
+ * @param {Object} options - Options
+ * @param {string} [options.targetDir=process.cwd()] - Project root directory
+ * @param {string} [options.targetAioxCore] - Installed .aiox-core directory
+ * @returns {Promise<Object>} Link result
+ */
+async function ensureProjectNodeModulesLink(options = {}) {
+  const {
+    targetDir = process.cwd(),
+    targetAioxCore = path.join(targetDir, '.aiox-core'),
+  } = options;
+
+  const projectNodeModules = path.join(targetDir, 'node_modules');
+  const frameworkNodeModules = path.join(targetAioxCore, 'node_modules');
+
+  if (await fs.pathExists(projectNodeModules)) {
+    return {
+      success: true,
+      linked: false,
+      reason: 'project-node-modules-exists',
+      path: projectNodeModules,
+    };
+  }
+
+  if (!(await fs.pathExists(frameworkNodeModules))) {
+    return {
+      success: false,
+      linked: false,
+      reason: 'framework-node-modules-missing',
+      path: projectNodeModules,
+      target: frameworkNodeModules,
+    };
+  }
+
+  const linkTarget = process.platform === 'win32'
+    ? frameworkNodeModules
+    : path.relative(targetDir, frameworkNodeModules) || frameworkNodeModules;
+  const linkType = process.platform === 'win32' ? 'junction' : 'dir';
+
+  try {
+    await fs.symlink(linkTarget, projectNodeModules, linkType);
+    return {
+      success: true,
+      linked: true,
+      path: projectNodeModules,
+      target: frameworkNodeModules,
+    };
+  } catch (error) {
+    return {
+      success: false,
+      linked: false,
+      reason: 'link-failed',
+      path: projectNodeModules,
+      target: frameworkNodeModules,
+      error: error.message,
+    };
+  }
+}
+
+/**
  * Create a basic package.json for AIOX projects
  * @param {Object} options - Options
  * @param {string} [options.targetDir=process.cwd()] - Target directory
@@ -515,6 +578,7 @@ function sanitizePackageName(name) {
 module.exports = {
   installAioxCore,
   hasPackageJson,
+  ensureProjectNodeModulesLink,
   createBasicPackageJson,
   getAioxCoreSourcePath,
   copyFileWithRootReplacement,

--- a/packages/installer/src/pro/pro-scaffolder.js
+++ b/packages/installer/src/pro/pro-scaffolder.js
@@ -15,7 +15,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const yaml = require('js-yaml');
 const { hashFileAsync, hashFilesMatchAsync } = require('../installer/file-hasher');
-const { ensureProjectNodeModulesLink } = require('../installer/aiox-core-installer');
+const { ensureProjectNodeModulesLink } = require('@aiox-squads/installer/aiox-core-installer');
 
 /**
  * Directories excluded from scaffolding (private/internal squads).

--- a/packages/installer/src/pro/pro-scaffolder.js
+++ b/packages/installer/src/pro/pro-scaffolder.js
@@ -15,6 +15,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const yaml = require('js-yaml');
 const { hashFileAsync, hashFilesMatchAsync } = require('../installer/file-hasher');
+const { ensureProjectNodeModulesLink } = require('../installer/aiox-core-installer');
 
 /**
  * Directories excluded from scaffolding (private/internal squads).
@@ -70,6 +71,7 @@ async function scaffoldProContent(targetDir, proSourceDir, options = {}) {
     errors: [],
     manifest: null,
     versionInfo: null,
+    dependencyResolution: null,
   };
 
   // Track files for rollback on partial failure
@@ -152,6 +154,24 @@ async function scaffoldProContent(targetDir, proSourceDir, options = {}) {
           message: `${commandsResult.installed} squad agent commands installed`,
         });
       }
+    }
+
+    const dependencyResolution = await ensureProjectNodeModulesLink({ targetDir });
+    result.dependencyResolution = dependencyResolution;
+    if (dependencyResolution.linked) {
+      rollbackFiles.push(dependencyResolution.path);
+    }
+    if (dependencyResolution.linked && onProgress) {
+      onProgress({
+        item: 'squad-dependencies',
+        status: 'done',
+        message: 'Squad dependency resolution linked',
+      });
+    } else if (!dependencyResolution.success) {
+      result.warnings.push(
+        `Squad dependency resolution not linked: ${dependencyResolution.reason}` +
+          (dependencyResolution.error ? ` (${dependencyResolution.error})` : '')
+      );
     }
 
     // Generate pro-version.json (AC4)

--- a/tests/installer/aiox-core-installer.test.js
+++ b/tests/installer/aiox-core-installer.test.js
@@ -10,6 +10,7 @@ const os = require('os');
 
 const {
   installAioxCore,
+  ensureProjectNodeModulesLink,
   copyDirectoryWithRootReplacement,
   generateFileHashes,
   generateVersionJson,
@@ -220,6 +221,51 @@ describe('AIOX Core Installer - Version Tracking', () => {
 
       expect(result.success).toBe(true);
       expect(await fs.readFile(existingMemoryPath, 'utf8')).toBe('custom project memory');
+    });
+  });
+
+  describe('ensureProjectNodeModulesLink', () => {
+    it('should link project node_modules to .aiox-core dependencies when absent', async () => {
+      const frameworkNodeModules = path.join(tempDir, '.aiox-core', 'node_modules');
+      await fs.ensureDir(path.join(frameworkNodeModules, 'js-yaml'));
+      await fs.writeFile(
+        path.join(frameworkNodeModules, 'js-yaml', 'index.js'),
+        'module.exports = { ok: true };\n',
+      );
+
+      const result = await ensureProjectNodeModulesLink({ targetDir: tempDir });
+
+      expect(result.success).toBe(true);
+      expect(result.linked).toBe(true);
+      expect(await fs.pathExists(path.join(tempDir, 'node_modules'))).toBe(true);
+      expect(await fs.realpath(path.join(tempDir, 'node_modules'))).toBe(
+        await fs.realpath(frameworkNodeModules),
+      );
+
+      const resolved = require.resolve('js-yaml', {
+        paths: [path.join(tempDir, 'squads', 'example', 'scripts')],
+      });
+      expect(resolved).toContain(path.join('js-yaml', 'index.js'));
+    });
+
+    it('should not overwrite an existing project node_modules directory', async () => {
+      await fs.ensureDir(path.join(tempDir, 'node_modules', 'existing-package'));
+      await fs.ensureDir(path.join(tempDir, '.aiox-core', 'node_modules', 'js-yaml'));
+
+      const result = await ensureProjectNodeModulesLink({ targetDir: tempDir });
+
+      expect(result.success).toBe(true);
+      expect(result.linked).toBe(false);
+      expect(result.reason).toBe('project-node-modules-exists');
+      expect(await fs.pathExists(path.join(tempDir, 'node_modules', 'existing-package'))).toBe(true);
+    });
+
+    it('should report missing .aiox-core dependencies without throwing', async () => {
+      const result = await ensureProjectNodeModulesLink({ targetDir: tempDir });
+
+      expect(result.success).toBe(false);
+      expect(result.linked).toBe(false);
+      expect(result.reason).toBe('framework-node-modules-missing');
     });
   });
 });

--- a/tests/installer/pro-scaffolder.test.js
+++ b/tests/installer/pro-scaffolder.test.js
@@ -207,6 +207,32 @@ describe('scaffoldProContent', () => {
     expect(progress.length).toBeGreaterThan(0);
     expect(progress.some(p => p.status === 'done')).toBe(true);
   });
+
+  it('should link framework dependencies so copied squad scripts resolve js-yaml', async () => {
+    await fs.ensureDir(path.join(targetDir, '.aiox-core', 'node_modules', 'js-yaml'));
+    await fs.writeFile(
+      path.join(targetDir, '.aiox-core', 'node_modules', 'js-yaml', 'index.js'),
+      'module.exports = { ok: true };\n',
+    );
+    await fs.ensureDir(path.join(proSourceDir, 'squads', 'devops-squad', 'scripts'));
+    await fs.writeFile(
+      path.join(proSourceDir, 'squads', 'devops-squad', 'scripts', 'uses-yaml.js'),
+      "require('js-yaml');\n",
+    );
+
+    const result = await scaffoldProContent(targetDir, proSourceDir);
+
+    expect(result.success).toBe(true);
+    expect(result.dependencyResolution.linked).toBe(true);
+    expect(await fs.realpath(path.join(targetDir, 'node_modules'))).toBe(
+      await fs.realpath(path.join(targetDir, '.aiox-core', 'node_modules')),
+    );
+
+    const resolved = require.resolve('js-yaml', {
+      paths: [path.join(targetDir, 'squads', 'devops-squad', 'scripts')],
+    });
+    expect(resolved).toContain(path.join('js-yaml', 'index.js'));
+  });
 });
 
 describe('rollbackScaffold', () => {


### PR DESCRIPTION
## Summary
- Ports the approved #624 dependency-resolution fix into the active v4/Pro install path instead of only the legacy `bin/aiox-init.js` fallback.
- Adds an idempotent installer helper that links project `node_modules` to `.aiox-core/node_modules` only when the project has no `node_modules` of its own.
- Integrates that helper into Pro content scaffolding so copied `squads/**/scripts` can resolve framework dependencies like `js-yaml`.
- Keeps the legacy `aiox-init.js` fallback aligned with the original #624 patch.
- Bumps core package/manifest to `5.1.6`.

## Validation
- `node -c packages/installer/src/installer/aiox-core-installer.js && node -c packages/installer/src/pro/pro-scaffolder.js && node -c bin/aiox-init.js`
- `npm test -- tests/installer/aiox-core-installer.test.js tests/installer/pro-scaffolder.test.js --runInBand`
- Pro scaffolder smoke with real `pro/` content: `require.resolve('js-yaml')` from `squads/squad-creator-pro/scripts` resolves through `.aiox-core/node_modules`
- `npm run validate:manifest`
- `npm run validate:publish`
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run test:ci` — 314 suites passed, 7,834 tests passed, 149 skipped
- `git diff --check`

Refs #624


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional installer helper to create a project-level node_modules link to the framework when appropriate; installer now attempts this and reports status.

* **Bug Fixes**
  * Resolved dependency resolution issues for Pro squad scripts that previously failed with module not found errors when run from the installed project root.

* **Tests**
  * Added tests covering the new linking behavior and related regression scenarios.

* **Chores**
  * Version bumped to 5.1.6.

* **Documentation**
  * Updated story/docs describing the dependency-resolution fix and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->