### PR TITLE
fix(memory): load GotchasMemory named export (#517)

### DIFF
--- a/.aiox-core/core/execution/context-injector.js
+++ b/.aiox-core/core/execution/context-injector.js
@@ -21,7 +21,7 @@ try {
   MemoryQuery = null;
 }
 try {
-  GotchasMemory = require('../memory/gotchas-memory');
+  ({ GotchasMemory } = require('../memory/gotchas-memory'));
 } catch {
   GotchasMemory = null;
 }

--- a/.aiox-core/core/execution/context-injector.js
+++ b/.aiox-core/core/execution/context-injector.js
@@ -14,6 +14,7 @@ const fs = require('fs');
 const path = require('path');
 
 // Import dependencies with fallbacks
+const GOTCHAS_MEMORY_MODULE = '../memory/gotchas-memory';
 let MemoryQuery, GotchasMemory, SessionMemory;
 let gotchasMemoryLoadError = null;
 try {
@@ -22,12 +23,16 @@ try {
   MemoryQuery = null;
 }
 try {
-  ({ GotchasMemory } = require('../memory/gotchas-memory'));
+  const gotchasMemoryModule = require(GOTCHAS_MEMORY_MODULE);
+  if (!gotchasMemoryModule || typeof gotchasMemoryModule.GotchasMemory === 'undefined') {
+    throw new Error(`Missing named export GotchasMemory from ${GOTCHAS_MEMORY_MODULE}`);
+  }
+  GotchasMemory = gotchasMemoryModule.GotchasMemory;
 } catch (error) {
   gotchasMemoryLoadError = error;
   if (process.env.AIOX_DEBUG) {
     console.warn(
-      `[context-injector] Optional dependency '../memory/gotchas-memory' failed to load: ${error.stack || error.message}`,
+      `[context-injector] Optional dependency '${GOTCHAS_MEMORY_MODULE}' failed to load: ${error.stack || error.message}`,
     );
   }
   GotchasMemory = null;

--- a/.aiox-core/core/execution/context-injector.js
+++ b/.aiox-core/core/execution/context-injector.js
@@ -27,6 +27,11 @@ try {
   if (!gotchasMemoryModule || typeof gotchasMemoryModule.GotchasMemory === 'undefined') {
     throw new Error(`Missing named export GotchasMemory from ${GOTCHAS_MEMORY_MODULE}`);
   }
+  if (typeof gotchasMemoryModule.GotchasMemory !== 'function') {
+    throw new Error(
+      `Expected GotchasMemory from ${GOTCHAS_MEMORY_MODULE} to be constructible; got ${typeof gotchasMemoryModule.GotchasMemory}`,
+    );
+  }
   GotchasMemory = gotchasMemoryModule.GotchasMemory;
 } catch (error) {
   gotchasMemoryLoadError = error;

--- a/.aiox-core/core/execution/context-injector.js
+++ b/.aiox-core/core/execution/context-injector.js
@@ -15,6 +15,7 @@ const path = require('path');
 
 // Import dependencies with fallbacks
 let MemoryQuery, GotchasMemory, SessionMemory;
+let gotchasMemoryLoadError = null;
 try {
   MemoryQuery = require('../memory/memory-query');
 } catch {
@@ -22,7 +23,13 @@ try {
 }
 try {
   ({ GotchasMemory } = require('../memory/gotchas-memory'));
-} catch {
+} catch (error) {
+  gotchasMemoryLoadError = error;
+  if (process.env.AIOX_DEBUG) {
+    console.warn(
+      `[context-injector] Optional dependency '../memory/gotchas-memory' failed to load: ${error.stack || error.message}`,
+    );
+  }
   GotchasMemory = null;
 }
 try {
@@ -534,3 +541,4 @@ class ContextInjector {
 
 module.exports = ContextInjector;
 module.exports.ContextInjector = ContextInjector;
+module.exports.gotchasMemoryLoadError = gotchasMemoryLoadError;

--- a/.aiox-core/core/execution/subagent-dispatcher.js
+++ b/.aiox-core/core/execution/subagent-dispatcher.js
@@ -21,6 +21,7 @@ try {
 }
 
 // Import dependencies with fallbacks
+const GOTCHAS_MEMORY_MODULE = '../memory/gotchas-memory';
 let MemoryQuery, GotchasMemory;
 let gotchasMemoryLoadError = null;
 try {
@@ -29,12 +30,16 @@ try {
   MemoryQuery = null;
 }
 try {
-  ({ GotchasMemory } = require('../memory/gotchas-memory'));
+  const gotchasMemoryModule = require(GOTCHAS_MEMORY_MODULE);
+  if (!gotchasMemoryModule || typeof gotchasMemoryModule.GotchasMemory === 'undefined') {
+    throw new Error(`Missing named export GotchasMemory from ${GOTCHAS_MEMORY_MODULE}`);
+  }
+  GotchasMemory = gotchasMemoryModule.GotchasMemory;
 } catch (error) {
   gotchasMemoryLoadError = error;
   if (process.env.AIOX_DEBUG) {
     console.warn(
-      `[subagent-dispatcher] Optional dependency '../memory/gotchas-memory' failed to load: ${error.stack || error.message}`,
+      `[subagent-dispatcher] Optional dependency '${GOTCHAS_MEMORY_MODULE}' failed to load: ${error.stack || error.message}`,
     );
   }
   GotchasMemory = null;

--- a/.aiox-core/core/execution/subagent-dispatcher.js
+++ b/.aiox-core/core/execution/subagent-dispatcher.js
@@ -28,7 +28,7 @@ try {
   MemoryQuery = null;
 }
 try {
-  GotchasMemory = require('../memory/gotchas-memory');
+  ({ GotchasMemory } = require('../memory/gotchas-memory'));
 } catch {
   GotchasMemory = null;
 }

--- a/.aiox-core/core/execution/subagent-dispatcher.js
+++ b/.aiox-core/core/execution/subagent-dispatcher.js
@@ -34,6 +34,11 @@ try {
   if (!gotchasMemoryModule || typeof gotchasMemoryModule.GotchasMemory === 'undefined') {
     throw new Error(`Missing named export GotchasMemory from ${GOTCHAS_MEMORY_MODULE}`);
   }
+  if (typeof gotchasMemoryModule.GotchasMemory !== 'function') {
+    throw new Error(
+      `Expected GotchasMemory from ${GOTCHAS_MEMORY_MODULE} to be constructible; got ${typeof gotchasMemoryModule.GotchasMemory}`,
+    );
+  }
   GotchasMemory = gotchasMemoryModule.GotchasMemory;
 } catch (error) {
   gotchasMemoryLoadError = error;

--- a/.aiox-core/core/execution/subagent-dispatcher.js
+++ b/.aiox-core/core/execution/subagent-dispatcher.js
@@ -22,6 +22,7 @@ try {
 
 // Import dependencies with fallbacks
 let MemoryQuery, GotchasMemory;
+let gotchasMemoryLoadError = null;
 try {
   MemoryQuery = require('../memory/memory-query');
 } catch {
@@ -29,7 +30,13 @@ try {
 }
 try {
   ({ GotchasMemory } = require('../memory/gotchas-memory'));
-} catch {
+} catch (error) {
+  gotchasMemoryLoadError = error;
+  if (process.env.AIOX_DEBUG) {
+    console.warn(
+      `[subagent-dispatcher] Optional dependency '../memory/gotchas-memory' failed to load: ${error.stack || error.message}`,
+    );
+  }
   GotchasMemory = null;
 }
 
@@ -844,3 +851,4 @@ class SubagentDispatcher extends EventEmitter {
 
 module.exports = SubagentDispatcher;
 module.exports.SubagentDispatcher = SubagentDispatcher;
+module.exports.gotchasMemoryLoadError = gotchasMemoryLoadError;

--- a/.aiox-core/core/ideation/ideation-engine.js
+++ b/.aiox-core/core/ideation/ideation-engine.js
@@ -13,7 +13,7 @@ const { execSync } = require('child_process');
 // Import dependencies with fallbacks
 let GotchasMemory;
 try {
-  GotchasMemory = require('../memory/gotchas-memory');
+  ({ GotchasMemory } = require('../memory/gotchas-memory'));
 } catch {
   GotchasMemory = null;
 }

--- a/.aiox-core/core/ideation/ideation-engine.js
+++ b/.aiox-core/core/ideation/ideation-engine.js
@@ -12,9 +12,16 @@ const { execSync } = require('child_process');
 
 // Import dependencies with fallbacks
 let GotchasMemory;
+let gotchasMemoryLoadError = null;
 try {
   ({ GotchasMemory } = require('../memory/gotchas-memory'));
-} catch {
+} catch (error) {
+  gotchasMemoryLoadError = error;
+  if (process.env.AIOX_DEBUG) {
+    console.warn(
+      `[ideation-engine] Optional dependency '../memory/gotchas-memory' failed to load: ${error.stack || error.message}`,
+    );
+  }
   GotchasMemory = null;
 }
 
@@ -830,3 +837,4 @@ module.exports.SecurityAnalyzer = SecurityAnalyzer;
 module.exports.CodeQualityAnalyzer = CodeQualityAnalyzer;
 module.exports.UXAnalyzer = UXAnalyzer;
 module.exports.ArchitectureAnalyzer = ArchitectureAnalyzer;
+module.exports.gotchasMemoryLoadError = gotchasMemoryLoadError;

--- a/.aiox-core/core/ideation/ideation-engine.js
+++ b/.aiox-core/core/ideation/ideation-engine.js
@@ -11,17 +11,27 @@ const path = require('path');
 const { execSync } = require('child_process');
 
 // Import dependencies with fallbacks
+const GOTCHAS_MEMORY_MODULE = '../memory/gotchas-memory';
 let GotchasMemory;
 let gotchasMemoryLoadError = null;
-try {
-  ({ GotchasMemory } = require('../memory/gotchas-memory'));
-} catch (error) {
+
+function recordGotchasMemoryLoadError(error) {
   gotchasMemoryLoadError = error;
   if (process.env.AIOX_DEBUG) {
     console.warn(
-      `[ideation-engine] Optional dependency '../memory/gotchas-memory' failed to load: ${error.stack || error.message}`,
+      `[ideation-engine] Optional dependency '${GOTCHAS_MEMORY_MODULE}' failed to load: ${error.stack || error.message}`,
     );
   }
+}
+
+try {
+  const gotchasMemoryModule = require(GOTCHAS_MEMORY_MODULE);
+  if (!gotchasMemoryModule || typeof gotchasMemoryModule.GotchasMemory === 'undefined') {
+    throw new Error(`Missing named export GotchasMemory from ${GOTCHAS_MEMORY_MODULE}`);
+  }
+  GotchasMemory = gotchasMemoryModule.GotchasMemory;
+} catch (error) {
+  recordGotchasMemoryLoadError(error);
   GotchasMemory = null;
 }
 

--- a/.aiox-core/core/ideation/ideation-engine.js
+++ b/.aiox-core/core/ideation/ideation-engine.js
@@ -29,6 +29,11 @@ try {
   if (!gotchasMemoryModule || typeof gotchasMemoryModule.GotchasMemory === 'undefined') {
     throw new Error(`Missing named export GotchasMemory from ${GOTCHAS_MEMORY_MODULE}`);
   }
+  if (typeof gotchasMemoryModule.GotchasMemory !== 'function') {
+    throw new Error(
+      `Expected GotchasMemory from ${GOTCHAS_MEMORY_MODULE} to be constructible; got ${typeof gotchasMemoryModule.GotchasMemory}`,
+    );
+  }
   GotchasMemory = gotchasMemoryModule.GotchasMemory;
 } catch (error) {
   recordGotchasMemoryLoadError(error);

--- a/.aiox-core/data/entity-registry.yaml
+++ b/.aiox-core/data/entity-registry.yaml
@@ -1,6 +1,6 @@
 metadata:
   version: 1.0.0
-  lastUpdated: '2026-05-07T13:47:55.456Z'
+  lastUpdated: '2026-05-07T14:04:39.083Z'
   entityCount: 746
   checksumAlgorithm: sha256
   resolutionRate: 100
@@ -8744,8 +8744,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:bde5e934593deec8e0aab342b4f5af3c747ec48eda3293352a0496d2e3d461cb
-      lastVerified: '2026-05-07T13:47:55.452Z'
+      checksum: sha256:470e9e56992ce5bbb72e9ec97b52f224eabe8c7198c7a99230e1eb4543a9cd41
+      lastVerified: '2026-05-07T14:04:39.079Z'
     parallel-executor:
       path: .aiox-core/core/execution/parallel-executor.js
       layer: L1
@@ -8868,8 +8868,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:2454e1f1c5d55d933bdb22e0c3b44d9c7254bffd43e3097ae410385e44132ec5
-      lastVerified: '2026-05-07T13:47:55.453Z'
+      checksum: sha256:3877e7d8d2dcf6c411aea6505dfabcc5d1dc4b255aab16c0c5423967ff496be1
+      lastVerified: '2026-05-07T14:04:39.080Z'
     wave-executor:
       path: .aiox-core/core/execution/wave-executor.js
       layer: L1
@@ -9037,8 +9037,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:0022cd3c1e9f834be277718ef7edb3378950b568a1a85e24df5ed8a55873098b
-      lastVerified: '2026-05-07T13:47:55.453Z'
+      checksum: sha256:b44771e1b98104acfe05ee19066e6d9c6c394a6f1b6049b8da2bfee03bca551a
+      lastVerified: '2026-05-07T14:04:39.080Z'
     circuit-breaker:
       path: .aiox-core/core/ids/circuit-breaker.js
       layer: L1

--- a/.aiox-core/data/entity-registry.yaml
+++ b/.aiox-core/data/entity-registry.yaml
@@ -1,6 +1,6 @@
 metadata:
   version: 1.0.0
-  lastUpdated: '2026-05-07T14:04:39.083Z'
+  lastUpdated: '2026-05-07T14:19:31.369Z'
   entityCount: 746
   checksumAlgorithm: sha256
   resolutionRate: 100
@@ -8733,7 +8733,6 @@ entities:
       usedBy: []
       dependencies:
         - memory-query
-        - gotchas-memory
         - session-memory
       externalDeps: []
       plannedDeps:
@@ -8744,8 +8743,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:470e9e56992ce5bbb72e9ec97b52f224eabe8c7198c7a99230e1eb4543a9cd41
-      lastVerified: '2026-05-07T14:04:39.079Z'
+      checksum: sha256:9c7efd0e3a9a81bbe9e001a4d53334cabefa36398ebfcaed8bfcc2535cf4ff5d
+      lastVerified: '2026-05-07T14:19:31.364Z'
     parallel-executor:
       path: .aiox-core/core/execution/parallel-executor.js
       layer: L1
@@ -8858,7 +8857,6 @@ entities:
       dependencies:
         - ai-providers
         - memory-query
-        - gotchas-memory
       externalDeps: []
       plannedDeps:
         - ai-providers
@@ -8868,8 +8866,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:3877e7d8d2dcf6c411aea6505dfabcc5d1dc4b255aab16c0c5423967ff496be1
-      lastVerified: '2026-05-07T14:04:39.080Z'
+      checksum: sha256:9c3704e9e4a17023961818cc7079ec59975ed6d3720f9f9e35bb19294696afd5
+      lastVerified: '2026-05-07T14:19:31.366Z'
     wave-executor:
       path: .aiox-core/core/execution/wave-executor.js
       layer: L1
@@ -9028,8 +9026,7 @@ entities:
         - ideation
         - engine
       usedBy: []
-      dependencies:
-        - gotchas-memory
+      dependencies: []
       externalDeps: []
       plannedDeps: []
       lifecycle: experimental
@@ -9037,8 +9034,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:b44771e1b98104acfe05ee19066e6d9c6c394a6f1b6049b8da2bfee03bca551a
-      lastVerified: '2026-05-07T14:04:39.080Z'
+      checksum: sha256:f3068525b1a775a70cb7e9fff6fb7e5defe810821c20f55ba7e85e342e9f9b3f
+      lastVerified: '2026-05-07T14:19:31.366Z'
     circuit-breaker:
       path: .aiox-core/core/ids/circuit-breaker.js
       layer: L1
@@ -9341,9 +9338,6 @@ entities:
         - gotcha
         - gotchas
         - build-orchestrator
-        - context-injector
-        - subagent-dispatcher
-        - ideation-engine
         - active-modules.verify
         - dev
       dependencies: []

--- a/.aiox-core/data/entity-registry.yaml
+++ b/.aiox-core/data/entity-registry.yaml
@@ -1,6 +1,6 @@
 metadata:
   version: 1.0.0
-  lastUpdated: '2026-05-07T13:24:28.327Z'
+  lastUpdated: '2026-05-07T13:47:55.456Z'
   entityCount: 746
   checksumAlgorithm: sha256
   resolutionRate: 100
@@ -8732,7 +8732,9 @@ entities:
         - injector
       usedBy: []
       dependencies:
+        - memory-query
         - gotchas-memory
+        - session-memory
       externalDeps: []
       plannedDeps:
         - memory-query
@@ -8742,8 +8744,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:a183255eb4831f701086f23f371f94a9ce10c46ea18c8369ec0fd756777f042f
-      lastVerified: '2026-03-11T00:48:55.878Z'
+      checksum: sha256:bde5e934593deec8e0aab342b4f5af3c747ec48eda3293352a0496d2e3d461cb
+      lastVerified: '2026-05-07T13:47:55.452Z'
     parallel-executor:
       path: .aiox-core/core/execution/parallel-executor.js
       layer: L1
@@ -8854,6 +8856,8 @@ entities:
         - dispatcher
       usedBy: []
       dependencies:
+        - ai-providers
+        - memory-query
         - gotchas-memory
       externalDeps: []
       plannedDeps:
@@ -8864,8 +8868,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:7affbc04de9be2bc53427670009a885f0b35e1cc183f82c2e044abf9611344b6
-      lastVerified: '2026-03-11T00:48:55.878Z'
+      checksum: sha256:2454e1f1c5d55d933bdb22e0c3b44d9c7254bffd43e3097ae410385e44132ec5
+      lastVerified: '2026-05-07T13:47:55.453Z'
     wave-executor:
       path: .aiox-core/core/execution/wave-executor.js
       layer: L1
@@ -9033,8 +9037,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:d9108fa47ed7a9131703739befb214b97d5b8e546faf1b49d8ae9d083756c589
-      lastVerified: '2026-03-11T00:48:55.879Z'
+      checksum: sha256:0022cd3c1e9f834be277718ef7edb3378950b568a1a85e24df5ed8a55873098b
+      lastVerified: '2026-05-07T13:47:55.453Z'
     circuit-breaker:
       path: .aiox-core/core/ids/circuit-breaker.js
       layer: L1

--- a/.aiox-core/data/entity-registry.yaml
+++ b/.aiox-core/data/entity-registry.yaml
@@ -1,6 +1,6 @@
 metadata:
   version: 1.0.0
-  lastUpdated: '2026-05-07T14:19:31.369Z'
+  lastUpdated: '2026-05-07T14:31:05.482Z'
   entityCount: 746
   checksumAlgorithm: sha256
   resolutionRate: 100
@@ -8743,8 +8743,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:9c7efd0e3a9a81bbe9e001a4d53334cabefa36398ebfcaed8bfcc2535cf4ff5d
-      lastVerified: '2026-05-07T14:19:31.364Z'
+      checksum: sha256:7654f6e6c3d555f3963369e71edf84b15c0fdec53bd161800b71782f78275244
+      lastVerified: '2026-05-07T14:31:05.474Z'
     parallel-executor:
       path: .aiox-core/core/execution/parallel-executor.js
       layer: L1
@@ -8866,8 +8866,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:9c3704e9e4a17023961818cc7079ec59975ed6d3720f9f9e35bb19294696afd5
-      lastVerified: '2026-05-07T14:19:31.366Z'
+      checksum: sha256:a69a03b714a39c8daf59ce2bcfb03cc6168f25e1fab07a754bd0ac7c3a91109b
+      lastVerified: '2026-05-07T14:31:05.478Z'
     wave-executor:
       path: .aiox-core/core/execution/wave-executor.js
       layer: L1
@@ -9034,8 +9034,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:f3068525b1a775a70cb7e9fff6fb7e5defe810821c20f55ba7e85e342e9f9b3f
-      lastVerified: '2026-05-07T14:19:31.366Z'
+      checksum: sha256:a154a0ce92f6b39b358529a030025b9709e0e4e2b85f6af02bd474e15c1aeb83
+      lastVerified: '2026-05-07T14:31:05.479Z'
     circuit-breaker:
       path: .aiox-core/core/ids/circuit-breaker.js
       layer: L1

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -7,8 +7,8 @@
 # - SHA256 hashes for change detection
 # - File types for categorization
 #
-version: 5.1.7
-generated_at: "2026-05-07T13:26:26.223Z"
+version: 5.1.8
+generated_at: "2026-05-07T13:48:07.546Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1103
 files:
@@ -413,9 +413,9 @@ files:
     type: core
     size: 48976
   - path: core/execution/context-injector.js
-    hash: sha256:a183255eb4831f701086f23f371f94a9ce10c46ea18c8369ec0fd756777f042f
+    hash: sha256:bde5e934593deec8e0aab342b4f5af3c747ec48eda3293352a0496d2e3d461cb
     type: core
-    size: 14860
+    size: 14866
   - path: core/execution/parallel-executor.js
     hash: sha256:46870e5c8ff8db3ee0386e477d427cc98eeb008f630818b093a9524b410590ae
     type: core
@@ -437,9 +437,9 @@ files:
     type: core
     size: 51556
   - path: core/execution/subagent-dispatcher.js
-    hash: sha256:7affbc04de9be2bc53427670009a885f0b35e1cc183f82c2e044abf9611344b6
+    hash: sha256:2454e1f1c5d55d933bdb22e0c3b44d9c7254bffd43e3097ae410385e44132ec5
     type: core
-    size: 25738
+    size: 25744
   - path: core/execution/wave-executor.js
     hash: sha256:4e2324edb37ae0729062b5ac029f2891e050e7efd3a48d0f4a1dc4f227a6716b
     type: core
@@ -693,9 +693,9 @@ files:
     type: core
     size: 7755
   - path: core/ideation/ideation-engine.js
-    hash: sha256:d9108fa47ed7a9131703739befb214b97d5b8e546faf1b49d8ae9d083756c589
+    hash: sha256:0022cd3c1e9f834be277718ef7edb3378950b568a1a85e24df5ed8a55873098b
     type: core
-    size: 22865
+    size: 22871
   - path: core/ids/circuit-breaker.js
     hash: sha256:63be126f2e0d320daa60cb5b68b21df93cad4c19d1f959e06a6ac776213f8eba
     type: core
@@ -1229,9 +1229,9 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:39bacf2f05602f8cfa709b67062d5c9bfc1cac232ee68038e14f711ce060499a
+    hash: sha256:3ae6f9e68b8d109f063f656cbcceeec92219d3154f6d01318188a1ac683d88aa
     type: data
-    size: 522429
+    size: 522523
   - path: data/learned-patterns.yaml
     hash: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
     type: data

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.1.8
-generated_at: "2026-05-07T13:48:07.546Z"
+generated_at: "2026-05-07T14:05:20.227Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1103
 files:
@@ -413,9 +413,9 @@ files:
     type: core
     size: 48976
   - path: core/execution/context-injector.js
-    hash: sha256:bde5e934593deec8e0aab342b4f5af3c747ec48eda3293352a0496d2e3d461cb
+    hash: sha256:470e9e56992ce5bbb72e9ec97b52f224eabe8c7198c7a99230e1eb4543a9cd41
     type: core
-    size: 14866
+    size: 15191
   - path: core/execution/parallel-executor.js
     hash: sha256:46870e5c8ff8db3ee0386e477d427cc98eeb008f630818b093a9524b410590ae
     type: core
@@ -437,9 +437,9 @@ files:
     type: core
     size: 51556
   - path: core/execution/subagent-dispatcher.js
-    hash: sha256:2454e1f1c5d55d933bdb22e0c3b44d9c7254bffd43e3097ae410385e44132ec5
+    hash: sha256:3877e7d8d2dcf6c411aea6505dfabcc5d1dc4b255aab16c0c5423967ff496be1
     type: core
-    size: 25744
+    size: 26072
   - path: core/execution/wave-executor.js
     hash: sha256:4e2324edb37ae0729062b5ac029f2891e050e7efd3a48d0f4a1dc4f227a6716b
     type: core
@@ -693,9 +693,9 @@ files:
     type: core
     size: 7755
   - path: core/ideation/ideation-engine.js
-    hash: sha256:0022cd3c1e9f834be277718ef7edb3378950b568a1a85e24df5ed8a55873098b
+    hash: sha256:b44771e1b98104acfe05ee19066e6d9c6c394a6f1b6049b8da2bfee03bca551a
     type: core
-    size: 22871
+    size: 23195
   - path: core/ids/circuit-breaker.js
     hash: sha256:63be126f2e0d320daa60cb5b68b21df93cad4c19d1f959e06a6ac776213f8eba
     type: core
@@ -1229,7 +1229,7 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:3ae6f9e68b8d109f063f656cbcceeec92219d3154f6d01318188a1ac683d88aa
+    hash: sha256:fc7d91ffa8963eca43edf0a46ded21e39ba1417ffe2d826285f1cfd89e56d629
     type: data
     size: 522523
   - path: data/learned-patterns.yaml

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.1.8
-generated_at: "2026-05-07T14:19:50.403Z"
+generated_at: "2026-05-07T14:31:25.534Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1103
 files:
@@ -413,9 +413,9 @@ files:
     type: core
     size: 48976
   - path: core/execution/context-injector.js
-    hash: sha256:9c7efd0e3a9a81bbe9e001a4d53334cabefa36398ebfcaed8bfcc2535cf4ff5d
+    hash: sha256:7654f6e6c3d555f3963369e71edf84b15c0fdec53bd161800b71782f78275244
     type: core
-    size: 15486
+    size: 15714
   - path: core/execution/parallel-executor.js
     hash: sha256:46870e5c8ff8db3ee0386e477d427cc98eeb008f630818b093a9524b410590ae
     type: core
@@ -437,9 +437,9 @@ files:
     type: core
     size: 51556
   - path: core/execution/subagent-dispatcher.js
-    hash: sha256:9c3704e9e4a17023961818cc7079ec59975ed6d3720f9f9e35bb19294696afd5
+    hash: sha256:a69a03b714a39c8daf59ce2bcfb03cc6168f25e1fab07a754bd0ac7c3a91109b
     type: core
-    size: 26367
+    size: 26595
   - path: core/execution/wave-executor.js
     hash: sha256:4e2324edb37ae0729062b5ac029f2891e050e7efd3a48d0f4a1dc4f227a6716b
     type: core
@@ -693,9 +693,9 @@ files:
     type: core
     size: 7755
   - path: core/ideation/ideation-engine.js
-    hash: sha256:f3068525b1a775a70cb7e9fff6fb7e5defe810821c20f55ba7e85e342e9f9b3f
+    hash: sha256:a154a0ce92f6b39b358529a030025b9709e0e4e2b85f6af02bd474e15c1aeb83
     type: core
-    size: 23580
+    size: 23808
   - path: core/ids/circuit-breaker.js
     hash: sha256:63be126f2e0d320daa60cb5b68b21df93cad4c19d1f959e06a6ac776213f8eba
     type: core
@@ -1229,7 +1229,7 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:c694817064f922f7d2f03d4bac73300266b51fa20c09f7db940463c8be2c0cb5
+    hash: sha256:277cd2b2973a8b33b7b512794106c6e5e8a5536ed8aecc3c269f7c8ae84c9cf0
     type: data
     size: 522368
   - path: data/learned-patterns.yaml

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.1.8
-generated_at: "2026-05-07T14:05:20.227Z"
+generated_at: "2026-05-07T14:19:50.403Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1103
 files:
@@ -413,9 +413,9 @@ files:
     type: core
     size: 48976
   - path: core/execution/context-injector.js
-    hash: sha256:470e9e56992ce5bbb72e9ec97b52f224eabe8c7198c7a99230e1eb4543a9cd41
+    hash: sha256:9c7efd0e3a9a81bbe9e001a4d53334cabefa36398ebfcaed8bfcc2535cf4ff5d
     type: core
-    size: 15191
+    size: 15486
   - path: core/execution/parallel-executor.js
     hash: sha256:46870e5c8ff8db3ee0386e477d427cc98eeb008f630818b093a9524b410590ae
     type: core
@@ -437,9 +437,9 @@ files:
     type: core
     size: 51556
   - path: core/execution/subagent-dispatcher.js
-    hash: sha256:3877e7d8d2dcf6c411aea6505dfabcc5d1dc4b255aab16c0c5423967ff496be1
+    hash: sha256:9c3704e9e4a17023961818cc7079ec59975ed6d3720f9f9e35bb19294696afd5
     type: core
-    size: 26072
+    size: 26367
   - path: core/execution/wave-executor.js
     hash: sha256:4e2324edb37ae0729062b5ac029f2891e050e7efd3a48d0f4a1dc4f227a6716b
     type: core
@@ -693,9 +693,9 @@ files:
     type: core
     size: 7755
   - path: core/ideation/ideation-engine.js
-    hash: sha256:b44771e1b98104acfe05ee19066e6d9c6c394a6f1b6049b8da2bfee03bca551a
+    hash: sha256:f3068525b1a775a70cb7e9fff6fb7e5defe810821c20f55ba7e85e342e9f9b3f
     type: core
-    size: 23195
+    size: 23580
   - path: core/ids/circuit-breaker.js
     hash: sha256:63be126f2e0d320daa60cb5b68b21df93cad4c19d1f959e06a6ac776213f8eba
     type: core
@@ -1229,9 +1229,9 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:fc7d91ffa8963eca43edf0a46ded21e39ba1417ffe2d826285f1cfd89e56d629
+    hash: sha256:c694817064f922f7d2f03d4bac73300266b51fa20c09f7db940463c8be2c0cb5
     type: data
-    size: 522523
+    size: 522368
   - path: data/learned-patterns.yaml
     hash: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
     type: data

--- a/docs/stories/epic-123/STORY-123.12-gotchas-memory-named-export.md
+++ b/docs/stories/epic-123/STORY-123.12-gotchas-memory-named-export.md
@@ -1,0 +1,42 @@
+# STORY-123.12: Corrigir consumidores do named export GotchasMemory
+
+Status: Done
+
+Issue: #517
+PR relacionado: #521
+
+## Contexto
+
+O issue #517 identificou que `gotchas-memory.js` exporta `GotchasMemory` como named export, mas alguns consumidores importavam o módulo inteiro como se fosse a classe. Isso fazia `new GotchasMemory()` lançar `TypeError: GotchasMemory is not a constructor`, quebrando a instanciação padrão de componentes que deveriam carregar gotchas automaticamente.
+
+## Acceptance Criteria
+
+- [x] AC1. `IdeationEngine` instancia `GotchasMemory` automaticamente sem depender de injeção explícita.
+- [x] AC2. `ContextInjector` instancia `GotchasMemory` automaticamente sem depender de injeção explícita.
+- [x] AC3. `SubagentDispatcher` instancia `GotchasMemory` automaticamente sem depender de injeção explícita.
+- [x] AC4. Há teste automatizado cobrindo os consumidores reais do named export.
+- [x] AC5. A correção é publicada como patch `5.1.8`.
+
+## Tasks
+
+- [x] Corrigir imports de `GotchasMemory` para destructuring.
+- [x] Adicionar regressão para os três consumidores.
+- [x] Atualizar versão, registry e manifesto de instalação.
+- [x] Rodar gates locais antes do PR.
+
+## Dev Notes
+
+- O PR #521 continha a intenção correta, mas carregava mudanças antigas amplas e conflitantes; a correção foi reaplicada em branch limpa baseada na `main`.
+- A investigação encontrou o mesmo padrão quebrado também em `ContextInjector` e `SubagentDispatcher`, além de `IdeationEngine`.
+
+## File List
+
+- [docs/stories/epic-123/STORY-123.12-gotchas-memory-named-export.md](./STORY-123.12-gotchas-memory-named-export.md)
+- [.aiox-core/core/ideation/ideation-engine.js](../../../.aiox-core/core/ideation/ideation-engine.js)
+- [.aiox-core/core/execution/context-injector.js](../../../.aiox-core/core/execution/context-injector.js)
+- [.aiox-core/core/execution/subagent-dispatcher.js](../../../.aiox-core/core/execution/subagent-dispatcher.js)
+- [tests/core/gotchas-memory-imports.test.js](../../../tests/core/gotchas-memory-imports.test.js)
+- [.aiox-core/data/entity-registry.yaml](../../../.aiox-core/data/entity-registry.yaml)
+- [.aiox-core/install-manifest.yaml](../../../.aiox-core/install-manifest.yaml)
+- [package.json](../../../package.json)
+- [package-lock.json](../../../package-lock.json)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.1.7",
+  "version": "5.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aiox-squads/core",
-      "version": "5.1.7",
+      "version": "5.1.8",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.1.7",
+  "version": "5.1.8",
   "description": "Synkra AIOX: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aiox": "bin/aiox.js",

--- a/tests/core/gotchas-memory-imports.test.js
+++ b/tests/core/gotchas-memory-imports.test.js
@@ -9,6 +9,7 @@ const IdeationEngine = requireFromRoot('.aiox-core/core/ideation/ideation-engine
 const { ContextInjector } = requireFromRoot('.aiox-core/core/execution/context-injector');
 const { SubagentDispatcher } = requireFromRoot('.aiox-core/core/execution/subagent-dispatcher');
 const { GotchasMemory } = requireFromRoot('.aiox-core/core/memory/gotchas-memory');
+const gotchasMemoryModulePath = path.join(repoRoot, '.aiox-core/core/memory/gotchas-memory');
 
 describe('GotchasMemory named export consumers', () => {
   it('instantiates IdeationEngine with the default GotchasMemory dependency', () => {
@@ -27,5 +28,42 @@ describe('GotchasMemory named export consumers', () => {
     const dispatcher = new SubagentDispatcher();
 
     expect(dispatcher.gotchasMemory).toBeInstanceOf(GotchasMemory);
+  });
+
+  it('exposes a load error when GotchasMemory named export is missing', () => {
+    const previousDebug = process.env.AIOX_DEBUG;
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    process.env.AIOX_DEBUG = 'true';
+    jest.resetModules();
+    jest.doMock(gotchasMemoryModulePath, () => ({}));
+
+    try {
+      jest.isolateModules(() => {
+        const MissingIdeationEngine = requireFromRoot('.aiox-core/core/ideation/ideation-engine');
+        const { ContextInjector: MissingContextInjector } = requireFromRoot('.aiox-core/core/execution/context-injector');
+        const { SubagentDispatcher: MissingSubagentDispatcher } = requireFromRoot(
+          '.aiox-core/core/execution/subagent-dispatcher',
+        );
+
+        expect(new MissingIdeationEngine().gotchasMemory).toBeNull();
+        expect(new MissingContextInjector().gotchasMemory).toBeNull();
+        expect(new MissingSubagentDispatcher().gotchasMemory).toBeNull();
+        expect(MissingIdeationEngine.gotchasMemoryLoadError.message).toContain('Missing named export GotchasMemory');
+        expect(MissingContextInjector.gotchasMemoryLoadError.message).toContain('Missing named export GotchasMemory');
+        expect(MissingSubagentDispatcher.gotchasMemoryLoadError.message).toContain('Missing named export GotchasMemory');
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(3);
+    } finally {
+      jest.dontMock(gotchasMemoryModulePath);
+      jest.resetModules();
+      if (typeof previousDebug === 'undefined') {
+        delete process.env.AIOX_DEBUG;
+      } else {
+        process.env.AIOX_DEBUG = previousDebug;
+      }
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/tests/core/gotchas-memory-imports.test.js
+++ b/tests/core/gotchas-memory-imports.test.js
@@ -66,4 +66,41 @@ describe('GotchasMemory named export consumers', () => {
       warnSpy.mockRestore();
     }
   });
+
+  it('exposes a load error when GotchasMemory named export is not constructible', () => {
+    const previousDebug = process.env.AIOX_DEBUG;
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    process.env.AIOX_DEBUG = 'true';
+    jest.resetModules();
+    jest.doMock(gotchasMemoryModulePath, () => ({ GotchasMemory: {} }));
+
+    try {
+      jest.isolateModules(() => {
+        const InvalidIdeationEngine = requireFromRoot('.aiox-core/core/ideation/ideation-engine');
+        const { ContextInjector: InvalidContextInjector } = requireFromRoot('.aiox-core/core/execution/context-injector');
+        const { SubagentDispatcher: InvalidSubagentDispatcher } = requireFromRoot(
+          '.aiox-core/core/execution/subagent-dispatcher',
+        );
+
+        expect(new InvalidIdeationEngine().gotchasMemory).toBeNull();
+        expect(new InvalidContextInjector().gotchasMemory).toBeNull();
+        expect(new InvalidSubagentDispatcher().gotchasMemory).toBeNull();
+        expect(InvalidIdeationEngine.gotchasMemoryLoadError.message).toContain('to be constructible; got object');
+        expect(InvalidContextInjector.gotchasMemoryLoadError.message).toContain('to be constructible; got object');
+        expect(InvalidSubagentDispatcher.gotchasMemoryLoadError.message).toContain('to be constructible; got object');
+      });
+
+      expect(warnSpy).toHaveBeenCalledTimes(3);
+    } finally {
+      jest.dontMock(gotchasMemoryModulePath);
+      jest.resetModules();
+      if (typeof previousDebug === 'undefined') {
+        delete process.env.AIOX_DEBUG;
+      } else {
+        process.env.AIOX_DEBUG = previousDebug;
+      }
+      warnSpy.mockRestore();
+    }
+  });
 });

--- a/tests/core/gotchas-memory-imports.test.js
+++ b/tests/core/gotchas-memory-imports.test.js
@@ -1,9 +1,14 @@
 'use strict';
 
-const IdeationEngine = require('../../.aiox-core/core/ideation/ideation-engine');
-const { ContextInjector } = require('../../.aiox-core/core/execution/context-injector');
-const { SubagentDispatcher } = require('../../.aiox-core/core/execution/subagent-dispatcher');
-const { GotchasMemory } = require('../../.aiox-core/core/memory/gotchas-memory');
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '../..');
+const requireFromRoot = (modulePath) => require(path.join(repoRoot, modulePath));
+
+const IdeationEngine = requireFromRoot('.aiox-core/core/ideation/ideation-engine');
+const { ContextInjector } = requireFromRoot('.aiox-core/core/execution/context-injector');
+const { SubagentDispatcher } = requireFromRoot('.aiox-core/core/execution/subagent-dispatcher');
+const { GotchasMemory } = requireFromRoot('.aiox-core/core/memory/gotchas-memory');
 
 describe('GotchasMemory named export consumers', () => {
   it('instantiates IdeationEngine with the default GotchasMemory dependency', () => {

--- a/tests/core/gotchas-memory-imports.test.js
+++ b/tests/core/gotchas-memory-imports.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const IdeationEngine = require('../../.aiox-core/core/ideation/ideation-engine');
+const { ContextInjector } = require('../../.aiox-core/core/execution/context-injector');
+const { SubagentDispatcher } = require('../../.aiox-core/core/execution/subagent-dispatcher');
+const { GotchasMemory } = require('../../.aiox-core/core/memory/gotchas-memory');
+
+describe('GotchasMemory named export consumers', () => {
+  it('instantiates IdeationEngine with the default GotchasMemory dependency', () => {
+    const engine = new IdeationEngine();
+
+    expect(engine.gotchasMemory).toBeInstanceOf(GotchasMemory);
+  });
+
+  it('instantiates ContextInjector with the default GotchasMemory dependency', () => {
+    const injector = new ContextInjector();
+
+    expect(injector.gotchasMemory).toBeInstanceOf(GotchasMemory);
+  });
+
+  it('instantiates SubagentDispatcher with the default GotchasMemory dependency', () => {
+    const dispatcher = new SubagentDispatcher();
+
+    expect(dispatcher.gotchasMemory).toBeInstanceOf(GotchasMemory);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes GotchasMemory imports in ideation/execution consumers to use the named export from `gotchas-memory.js`.
- Adds a regression test that instantiates `IdeationEngine`, `ContextInjector`, and `SubagentDispatcher` and verifies each receives a real `GotchasMemory` instance.
- Bumps `@aiox-squads/core` to `5.1.8` and records Story 123.12.

## Validation
- `node -c .aiox-core/core/ideation/ideation-engine.js && node -c .aiox-core/core/execution/context-injector.js && node -c .aiox-core/core/execution/subagent-dispatcher.js`
- constructor smoke for `IdeationEngine`, `ContextInjector`, `SubagentDispatcher`
- `npm test -- tests/core/gotchas-memory-imports.test.js --runInBand`
- `npm test -- tests/core/gotchas-memory-imports.test.js tests/core/context-injector.test.js tests/core/subagent-dispatcher.test.js --runInBand` (69 tests passed)
- `npm run validate:manifest`
- `npm run validate:publish`
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run test:ci` (315 suites passed, 7838 tests passed, 149 skipped)
- `git diff --check`

Refs #517.
Supersedes #521.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of an optional memory dependency: load/validation failures are now captured, exposed for inspection, and conditionally logged when debug is enabled; components continue operating without the optional memory.

* **Tests**
  * Added regression tests for normal and failure import scenarios and for load-error reporting.

* **Documentation**
  * Added story documenting the named-export behavior and acceptance criteria.

* **Chores**
  * Version bumped to 5.1.8 and refreshed generated manifests/metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->