### PR TITLE
fix: align story lifecycle QA ownership

### DIFF
--- a/.claude/rules/story-lifecycle.md
+++ b/.claude/rules/story-lifecycle.md
@@ -16,11 +16,17 @@ Draft → Ready → InProgress → InReview → Done
 |--------|---------|-------|--------|
 | Draft | @sm creates story | @sm | Story file created |
 | Ready | @po validates (GO) | @po | **MUST update status field in story file from Draft → Ready** |
-| InProgress | @dev starts implementation | @dev | Update status field |
-| InReview | @dev completes, @qa reviews | @qa | Update status field |
-| Done | @qa PASS, @devops pushes | @devops | Update status field |
+| InProgress | @dev starts implementation; @qa FAIL returns story | @dev / @qa | **MUST update status field: Ready → InProgress on dev start, or InReview → InProgress on QA FAIL** |
+| InReview | @dev completes implementation | @dev | **MUST update status field from InProgress → InReview before QA handoff** |
+| Done | @qa PASS, CONCERNS, or WAIVED | @qa | **MUST update status field from InReview → Done before @devops push** |
 
 **CRITICAL:** The `Draft → Ready` transition is the responsibility of @po during `*validate-story-draft`. When verdict is GO (including conditional GO after fixes are applied), @po MUST update the story's Status field to `Ready` and log the transition in the Change Log. A story left in `Draft` after a GO verdict is a process violation.
+
+**CRITICAL:** The `Ready → InProgress` and `InProgress → InReview` transitions are the responsibility of @dev during `*dev-develop-story`. @dev MUST log both transitions in the Change Log using the mandatory status-transition block in `dev-develop-story.md`.
+
+**CRITICAL:** The `InReview → Done` and `InReview → InProgress` transitions are the responsibility of @qa during `*qa-gate`. PASS, CONCERNS, and WAIVED move the story to `Done`; FAIL returns it to `InProgress`. @qa MUST update the story status and Change Log before reporting the gate result.
+
+**CRITICAL:** @devops does not change story status. @devops push/PR/release authority starts only after the story already reflects the QA gate outcome.
 
 ## Phase 1: Create (@sm)
 

--- a/docs/stories/epic-123/STORY-123.14-story-lifecycle-qa-ownership.md
+++ b/docs/stories/epic-123/STORY-123.14-story-lifecycle-qa-ownership.md
@@ -1,0 +1,48 @@
+# STORY-123.14: Alinhar ownership de lifecycle com QA gate
+
+## Status
+
+Done
+
+## Story
+
+Como operador do ciclo de desenvolvimento AIOX, quero que a regra `story-lifecycle.md` atribua as transições finais de status ao agente correto, para que `@devops` não seja tratado como responsável por mutar story status depois do QA gate.
+
+## Acceptance Criteria
+
+- [x] AC1. `@dev` aparece como responsável por `Ready → InProgress` e `InProgress → InReview`.
+- [x] AC2. `@qa` aparece como responsável por `InReview → Done` em PASS/CONCERNS/WAIVED.
+- [x] AC3. `@qa` aparece como responsável por `InReview → InProgress` em FAIL.
+- [x] AC4. A regra deixa explícito que `@devops` só atua depois que o status já reflete o resultado do QA gate.
+- [x] AC5. A versão do pacote é atualizada para publicação patch.
+
+## Tasks
+
+- [x] Corrigir `.claude/rules/story-lifecycle.md`.
+- [x] Bump de patch para `@aiox-squads/core@5.1.10`.
+- [x] Validar markdown/rules e pacote antes do PR.
+
+## Dev Notes
+
+- Esta story completa a parte única do PR histórico #543 que não foi coberta pelo recorte #656.
+- #656 já incorporou os task files procedurais; este ajuste alinha a regra contextual com o comportamento imperativo atual.
+
+## Validation
+
+- `git diff --check` -> PASS.
+- `node -e "..."` version assertion -> PASS (`package.json`, `package-lock.json` root and package entry all `5.1.10`).
+- Lifecycle rule assertion script -> PASS.
+- `npm run validate:manifest` -> PASS.
+- `npm run validate:semantic-lint` -> PASS.
+- `npm run validate:publish` -> PASS.
+- `npm run lint -- --quiet` -> PASS.
+- `npm run typecheck` -> PASS.
+- `npm test -- tests/synapse/generate-constitution.test.js --runInBand --forceExit` -> PASS, 1 suite / 29 tests.
+- `npm run test:ci` -> PASS, 315 suites / 7.846 tests, 149 skipped.
+
+## File List
+
+- `.claude/rules/story-lifecycle.md`
+- `docs/stories/epic-123/STORY-123.14-story-lifecycle-qa-ownership.md`
+- `package.json`
+- `package-lock.json`

--- a/docs/stories/epic-123/STORY-123.15-package-completeness-pro-contract.md
+++ b/docs/stories/epic-123/STORY-123.15-package-completeness-pro-contract.md
@@ -1,0 +1,42 @@
+# STORY-123.15: Alinhar package completeness ao contrato Pro atual
+
+## Status
+
+Done
+
+## Story
+
+Como release manager do AIOX Core, quero que o validador de completude do pacote reflita o contrato atual de publicação, para que ele não bloqueie falsamente releases que incluem o runtime de entitlement Pro exigido pelo próprio publish safety gate.
+
+## Acceptance Criteria
+
+- [x] AC1. `scripts/validate-package-completeness.js` não trata `pro/` como leak genérico.
+- [x] AC2. O validador exige `pro/license/license-api.js`, alinhado ao `validate:publish`.
+- [x] AC3. O validador continua bloqueando conteúdo local/private como `.env`, `.git/`, `node_modules/`, `.aiox/` e `tests/`.
+- [x] AC4. O script passa localmente junto com `validate:publish`.
+
+## Tasks
+
+- [x] Atualizar `scripts/validate-package-completeness.js`.
+- [x] Rodar `node scripts/validate-package-completeness.js`.
+- [x] Rodar `npm run validate:publish`.
+
+## Dev Notes
+
+- `validate:publish` já exige `pro/` populado e `pro/license/license-api.js` presente. O validador de completude estava herdando um contrato antigo e acusava falso leak.
+- Este ajuste não amplia o conteúdo publicado; apenas alinha o script ao `files[]` atual de `package.json`.
+
+## Validation
+
+- `node -c scripts/validate-package-completeness.js` -> PASS.
+- `node scripts/validate-package-completeness.js` -> PASS, 30/30 checks.
+- `npm run validate:publish` -> PASS.
+- `npm run validate:semantic-lint` -> PASS.
+- `npm run lint -- --quiet` -> PASS.
+- `npm run typecheck` -> PASS.
+- `npm run test:ci` -> PASS, 315 suites / 7.846 tests, 149 skipped.
+
+## File List
+
+- `scripts/validate-package-completeness.js`
+- `docs/stories/epic-123/STORY-123.15-package-completeness-pro-contract.md`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.1.9",
+  "version": "5.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aiox-squads/core",
-      "version": "5.1.9",
+      "version": "5.1.10",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.1.9",
+  "version": "5.1.10",
   "description": "Synkra AIOX: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aiox": "bin/aiox.js",

--- a/scripts/validate-package-completeness.js
+++ b/scripts/validate-package-completeness.js
@@ -3,7 +3,7 @@
  * Validate Package Completeness for npm Publishing
  *
  * Ensures the npm tarball contains all critical files and excludes
- * private content before publishing. Runs as prepublishOnly hook.
+ * local/private development content before publishing.
  *
  * @script scripts/validate-package-completeness.js
  * @story INS-2 - Release Pipeline: Preview to Latest
@@ -44,13 +44,14 @@ const REQUIRED_PATHS = [
   '.aiox-core/constitution.md',
   '.aiox-core/development/agents/',
   '.aiox-core/development/tasks/',
+  // Pro entitlement runtime is intentionally shipped with core.
+  'pro/license/license-api.js',
 ];
 
 /**
  * Paths that MUST NOT appear in the tarball (leak prevention).
  */
 const EXCLUDED_PATHS = [
-  'pro/',
   '.env',
   '.git/',
   'node_modules/',


### PR DESCRIPTION
## Summary

- Aligns `.claude/rules/story-lifecycle.md` with the procedural task files merged in #656: `@dev` owns `Ready -> InProgress` and `InProgress -> InReview`; `@qa` owns `InReview -> Done` and `InReview -> InProgress`; `@devops` only acts after QA status is already reflected.
- Updates `scripts/validate-package-completeness.js` to match the current publish contract: `pro/license/license-api.js` is required instead of treating all `pro/` files as a leak.
- Bumps `@aiox-squads/core` to `5.1.10` and adds two story records under Epic 123.

## Validation

- `git diff --check` PASS
- lifecycle rule assertion script PASS
- `node -c scripts/validate-package-completeness.js` PASS
- `node scripts/validate-package-completeness.js` PASS, 30/30 checks
- `npm run validate:manifest` PASS
- `npm run validate:semantic-lint` PASS
- `npm run validate:publish` PASS
- `npm run lint -- --quiet` PASS
- `npm run typecheck` PASS
- `npm test -- tests/synapse/generate-constitution.test.js --runInBand --forceExit` PASS, 1 suite / 29 tests
- `npm run test:ci` PASS, 315 suites / 7,846 tests, 149 skipped

## Notes

- Completes the unique lifecycle-rule portion of stale PR #543 after #656 already merged the procedural task-file enforcement for #636.
- Supersedes stale PRs #543 and #550 for merge purposes once this lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released package version 5.1.10.
  * Enhanced package validation requirements and documented QA gate ownership to clarify internal process workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->