### PR TITLE
fix: unref config cache cleanup timers

### DIFF
--- a/.aiox-core/core/config/config-cache.js
+++ b/.aiox-core/core/config/config-cache.js
@@ -229,12 +229,16 @@ class ConfigCache {
 const globalConfigCache = new ConfigCache();
 
 // Auto cleanup expired entries every minute
-setInterval(() => {
+const cacheCleanupTimer = setInterval(() => {
   const cleared = globalConfigCache.clearExpired();
   if (cleared > 0) {
     console.log(`🗑️ Config cache: Cleared ${cleared} expired entries`);
   }
 }, 60 * 1000);
+
+if (typeof cacheCleanupTimer.unref === 'function') {
+  cacheCleanupTimer.unref();
+}
 
 module.exports = {
   ConfigCache,

--- a/.aiox-core/infrastructure/scripts/config-cache.js
+++ b/.aiox-core/infrastructure/scripts/config-cache.js
@@ -228,12 +228,16 @@ class ConfigCache {
 const globalConfigCache = new ConfigCache();
 
 // Auto cleanup expired entries every minute
-setInterval(() => {
+const cacheCleanupTimer = setInterval(() => {
   const cleared = globalConfigCache.clearExpired();
   if (cleared > 0) {
     console.log(`🗑️ Config cache: Cleared ${cleared} expired entries`);
   }
 }, 60 * 1000);
+
+if (typeof cacheCleanupTimer.unref === 'function') {
+  cacheCleanupTimer.unref();
+}
 
 module.exports = {
   ConfigCache,

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -7,8 +7,8 @@
 # - SHA256 hashes for change detection
 # - File types for categorization
 #
-version: 5.1.13
-generated_at: "2026-05-07T16:42:59.200Z"
+version: 5.1.14
+generated_at: "2026-05-07T17:06:48.504Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1103
 files:
@@ -241,9 +241,9 @@ files:
     type: core
     size: 10891
   - path: core/config/config-cache.js
-    hash: sha256:b659dfae25865c732555d71abcb1939db908684586d0a06b699d3176077e486e
+    hash: sha256:9f3c3f90f574d5f49dd94592ab28109465d025b3a740d8639ab781c2560c12ab
     type: core
-    size: 4928
+    size: 5039
   - path: core/config/config-loader.js
     hash: sha256:bbc6a9e57e9db7a74ae63c901b199f8b8a79eb093f23a280b6420d1aa5f7f813
     type: core
@@ -3033,9 +3033,9 @@ files:
     type: script
     size: 7803
   - path: infrastructure/scripts/config-cache.js
-    hash: sha256:6264ae77eef1e98de62d9f6478becadf6a6692ca88027666dbf5a1e2399c844a
+    hash: sha256:363383dbf90df90d69b8ba769db4f9749b0ae91b4fe95ee15be633941906f8a2
     type: script
-    size: 7697
+    size: 7808
   - path: infrastructure/scripts/config-loader.js
     hash: sha256:8f9489f7c57e775bfbb750761d9714505d5df3938b664cbbdf6701f9e18e240b
     type: script

--- a/docs/stories/epic-123/STORY-123.19-config-cache-unref-runtime.md
+++ b/docs/stories/epic-123/STORY-123.19-config-cache-unref-runtime.md
@@ -1,0 +1,62 @@
+# STORY-123.19: Liberar timers globais do config cache
+
+## Status
+
+Done
+
+## Story
+
+Como mantenedor do AIOX Core, quero que os timers globais de limpeza do config cache usem `.unref()`, para que ativações e comandos curtos do CLI não mantenham o processo Node vivo depois que o trabalho real terminou.
+
+## Acceptance Criteria
+
+- [x] AC1. O config cache canônico em `.aiox-core/core/config/config-cache.js` mantém limpeza automática, mas não prende o event loop.
+- [x] AC2. A cópia de infraestrutura em `.aiox-core/infrastructure/scripts/config-cache.js` preserva o mesmo comportamento para superfícies que ainda importam esse módulo.
+- [x] AC3. Teste regressional prova que os timers de limpeza chamam `.unref()`.
+- [x] AC4. Versão, lockfile e manifest de instalação são atualizados para publicação patch.
+
+## Tasks
+
+- [x] Confrontar o PR antigo #378 contra `main` e identificar o caminho legado `.aios-core`.
+- [x] Localizar o resíduo funcional nos caminhos atuais `.aiox-core`.
+- [x] Implementar `.unref()` nos timers globais do config cache.
+- [x] Adicionar teste regressional focado.
+- [x] Atualizar versão e manifest.
+- [x] Rodar validações locais antes de PR.
+
+## Dev Notes
+
+- O PR #378 alterava `.aios-core/core/config/config-cache.js`, caminho legado que não resolve a superfície publicada atual.
+- O bug permanece relevante em `.aiox-core/core/config/config-cache.js` e na cópia de infraestrutura, ambas com `setInterval` de limpeza a cada 60 segundos.
+- A correção deve ser defensiva para ambientes de teste/mocks: chamar `.unref()` apenas quando a função existir.
+
+## Validation
+
+- `node -c .aiox-core/core/config/config-cache.js` -> PASS.
+- `node -c .aiox-core/infrastructure/scripts/config-cache.js` -> PASS.
+- `node -c tests/core/config-cache-unref.test.js` -> PASS.
+- `node -e "require('./.aiox-core/core/config/config-cache'); console.log('core_config_cache_exited')"` -> PASS.
+- `node -e "require('./.aiox-core/infrastructure/scripts/config-cache'); console.log('infra_config_cache_exited')"` -> PASS.
+- `npm test -- tests/core/config-cache-unref.test.js --runInBand --forceExit` -> PASS, 1 suite / 2 tests.
+- `npm test -- tests/core/config-cache-unref.test.js tests/config/config-cli.test.js tests/config/config-resolver.test.js tests/core/config/config-resolver.test.js tests/core/unified-activation-pipeline.test.js --runInBand --forceExit` -> PASS, 5 suites / 192 tests.
+- `git diff --check` -> PASS.
+- `npm run validate:manifest` -> PASS.
+- `npm run validate:semantic-lint` -> PASS.
+- `npm run validate:publish` -> PASS.
+- `npm run lint -- --quiet` -> PASS.
+- `npm run typecheck` -> PASS.
+- `npm run test:ci` -> PASS, 317 suites / 7.855 tests / 149 skipped.
+
+## Post-Merge Operations
+
+- Fechar o PR antigo #378 como superseded depois do merge e publicação da correção atual.
+
+## File List
+
+- `.aiox-core/core/config/config-cache.js`
+- `.aiox-core/infrastructure/scripts/config-cache.js`
+- `tests/core/config-cache-unref.test.js`
+- `.aiox-core/install-manifest.yaml`
+- `package.json`
+- `package-lock.json`
+- `docs/stories/epic-123/STORY-123.19-config-cache-unref-runtime.md`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.1.13",
+  "version": "5.1.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aiox-squads/core",
-      "version": "5.1.13",
+      "version": "5.1.14",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.1.13",
+  "version": "5.1.14",
   "description": "Synkra AIOX: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aiox": "bin/aiox.js",

--- a/tests/core/config-cache-unref.test.js
+++ b/tests/core/config-cache-unref.test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const path = require('path');
+
+const repoRoot = path.resolve(__dirname, '../..');
+const requireFromRoot = (modulePath) => require(path.join(repoRoot, modulePath));
+
+describe('config cache cleanup timers', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
+
+  it.each([
+    '.aiox-core/core/config/config-cache',
+    '.aiox-core/infrastructure/scripts/config-cache',
+  ])('unrefs the cleanup interval in %s', (modulePath) => {
+    const cleanupTimer = { unref: jest.fn() };
+    const setIntervalSpy = jest
+      .spyOn(global, 'setInterval')
+      .mockImplementation(() => cleanupTimer);
+
+    const moduleExports = requireFromRoot(modulePath);
+
+    expect(moduleExports.globalConfigCache).toBeDefined();
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 60 * 1000);
+    expect(cleanupTimer.unref).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Supersedes stale PR #378 with the fix applied to current `.aiox-core` paths instead of legacy `.aios-core`.
- Calls `.unref()` on the global config-cache cleanup intervals so short CLI/agent activation processes can exit naturally.
- Keeps cleanup behavior intact for both core runtime and infrastructure script surfaces.
- Adds regression coverage for both modules and bumps core to `5.1.14` with regenerated install manifest.

## Validation
- `node -c .aiox-core/core/config/config-cache.js`
- `node -c .aiox-core/infrastructure/scripts/config-cache.js`
- `node -c tests/core/config-cache-unref.test.js`
- `node -e "require('./.aiox-core/core/config/config-cache'); console.log('core_config_cache_exited')"`
- `node -e "require('./.aiox-core/infrastructure/scripts/config-cache'); console.log('infra_config_cache_exited')"`
- `npm test -- tests/core/config-cache-unref.test.js --runInBand --forceExit` -> 1 suite / 2 tests
- `npm test -- tests/core/config-cache-unref.test.js tests/config/config-cli.test.js tests/config/config-resolver.test.js tests/core/config/config-resolver.test.js tests/core/unified-activation-pipeline.test.js --runInBand --forceExit` -> 5 suites / 192 tests
- `git diff --check`
- `npm run validate:manifest`
- `npm run validate:semantic-lint`
- `npm run validate:publish`
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run test:ci` -> 317 suites / 7,855 tests / 149 skipped

## Follow-up After Merge
- Publish stable `@aiox-squads/core@5.1.14`.
- Close stale PR #378 as superseded after npm smoke passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced process termination behavior to prevent cleanup timers from keeping applications running after brief CLI operations complete.
* **Tests**
  * Added test coverage for timer cleanup functionality.
* **Chores**
  * Updated version to 5.1.14.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->