### PR TITLE
fix: generate Cursor MDC rules on install

### DIFF
--- a/.aiox-core/infrastructure/scripts/ide-sync/README.md
+++ b/.aiox-core/infrastructure/scripts/ide-sync/README.md
@@ -138,7 +138,7 @@ Each IDE has a specific format for agent files:
 | Codex CLI   | Full markdown with YAML | `.md`     |
 | Gemini CLI  | Full markdown with YAML | `.md`     |
 | GitHub Copilot | Full markdown with YAML | `.md`   |
-| Cursor      | Condensed rules         | `.md`     |
+| Cursor      | Condensed MDC rules     | `.mdc`    |
 | Antigravity | Cursor-style            | `.md`     |
 
 Platform-specific checks:
@@ -158,10 +158,15 @@ Deprecated or renamed agents are handled via redirects. When an old agent name i
 
 Example redirect file:
 
-```markdown
+```mdc
+---
+description: 'AIOX redirect from @aiox-developer to @aiox-master'
+alwaysApply: false
+---
+
 # Agent Redirect: aiox-developer -> aiox-master
 
-This agent has been renamed. Use `aiox-master` instead.
+> This agent has been renamed. Use `@aiox-master` instead.
 ```
 
 ## File Structure

--- a/.aiox-core/infrastructure/scripts/ide-sync/index.js
+++ b/.aiox-core/infrastructure/scripts/ide-sync/index.js
@@ -432,6 +432,7 @@ async function commandValidate(options) {
     ideConfigs[ideName] = {
       expectedFiles,
       targetDir: path.join(projectRoot, ideConfig.path),
+      format: ideConfig.format,
     };
 
     // Gemini CLI command launcher files are synced under .gemini/commands/*.toml

--- a/.aiox-core/infrastructure/scripts/ide-sync/redirect-generator.js
+++ b/.aiox-core/infrastructure/scripts/ide-sync/redirect-generator.js
@@ -5,6 +5,7 @@
 
 const fs = require('fs-extra');
 const path = require('path');
+const { escapeFrontmatterString } = require('./transformers/cursor');
 
 /**
  * Default redirects configuration
@@ -16,6 +17,38 @@ const DEFAULT_REDIRECTS = {
   'db-sage': 'data-engineer',
   'github-devops': 'devops',
 };
+
+function getRedirectExtension(format) {
+  return format === 'condensed-rules' ? '.mdc' : '.md';
+}
+
+function sanitizeRedirectId(id) {
+  const safeId = String(id ?? '')
+    .replace(/\0/g, '')
+    .replace(/[\\/]+/g, '-')
+    .replace(/\.\.+/g, '-')
+    .replace(/[:*?"<>|]/g, '-')
+    .trim()
+    .replace(/^-+|-+$/g, '');
+
+  if (!safeId) {
+    throw new Error(`Invalid redirect id for filename: ${id}`);
+  }
+
+  return safeId;
+}
+
+function resolveRedirectPath(targetDir, filename) {
+  const resolvedTargetDir = path.resolve(targetDir);
+  const resolvedPath = path.resolve(resolvedTargetDir, filename);
+  const relativePath = path.relative(resolvedTargetDir, resolvedPath);
+
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error(`Redirect path escapes target directory: ${filename}`);
+  }
+
+  return resolvedPath;
+}
 
 /**
  * Generate redirect content for a specific IDE format
@@ -73,7 +106,24 @@ ${baseContent.instruction}
 *AIOX Redirect - Synced automatically*
 `;
 
-    case 'condensed-rules':
+    case 'condensed-rules': {
+      const safeOldId = escapeFrontmatterString(oldId);
+      const safeNewId = escapeFrontmatterString(newId);
+
+      return `---
+description: 'AIOX redirect from @${safeOldId} to @${safeNewId}'
+alwaysApply: false
+---
+
+${baseContent.header}
+
+> ${baseContent.notice} ${baseContent.instruction}
+
+---
+*AIOX Redirect - Synced automatically*
+`;
+    }
+
     case 'cursor-style':
     default:
       // Cursor/Antigravity format
@@ -96,8 +146,8 @@ ${baseContent.instruction}
  * @returns {object} - Result with path and content
  */
 function generateRedirect(oldId, newId, targetDir, format) {
-  const filename = `${oldId}.md`;
-  const filePath = path.join(targetDir, filename);
+  const filename = `${sanitizeRedirectId(oldId)}${getRedirectExtension(format)}`;
+  const filePath = resolveRedirectPath(targetDir, filename);
   const content = generateRedirectContent(oldId, newId, format);
 
   return {
@@ -163,16 +213,19 @@ function writeRedirects(redirects, dryRun = false) {
  * @param {object} redirectsConfig - Redirects configuration
  * @returns {string[]} - Array of filenames
  */
-function getRedirectFilenames(redirectsConfig) {
+function getRedirectFilenames(redirectsConfig, format) {
   const redirects = redirectsConfig || DEFAULT_REDIRECTS;
-  return Object.keys(redirects).map(id => `${id}.md`);
+  const extension = getRedirectExtension(format);
+  return Object.keys(redirects).map(id => `${sanitizeRedirectId(id)}${extension}`);
 }
 
 module.exports = {
   DEFAULT_REDIRECTS,
+  sanitizeRedirectId,
   generateRedirectContent,
   generateRedirect,
   generateAllRedirects,
   writeRedirects,
   getRedirectFilenames,
+  getRedirectExtension,
 };

--- a/.aiox-core/infrastructure/scripts/ide-sync/transformers/cursor.js
+++ b/.aiox-core/infrastructure/scripts/ide-sync/transformers/cursor.js
@@ -2,11 +2,23 @@
  * Cursor Transformer - Condensed rules format
  * @story 6.19 - IDE Command Auto-Sync System
  *
- * Format: Condensed markdown with icon, title, quick commands
- * Target: .cursor/rules/agents/*.md
+ * Format: Cursor MDC rule with frontmatter, icon, title, quick commands
+ * Target: .cursor/rules/agents/*.mdc
  */
 
 const { getVisibleCommands, normalizeCommands } = require('../agent-parser');
+
+function escapeFrontmatterString(value) {
+  return String(value || '')
+    .replace(/\r?\n/g, ' ')
+    .replace(/'/g, "''")
+    .trim();
+}
+
+function toMdcFilename(filename, fallbackId = 'agent') {
+  const baseName = String(filename || `${fallbackId}.md`).replace(/\.md$/i, '');
+  return `${baseName}.mdc`;
+}
 
 /**
  * Transform agent data to Cursor format
@@ -22,6 +34,7 @@ function transform(agentData) {
   const title = agent.title || 'AIOX Agent';
   const whenToUse = agent.whenToUse || 'Use this agent for specific tasks';
   const archetype = persona.archetype || '';
+  const description = escapeFrontmatterString(`AIOX agent @${agentData.id} - ${title}`);
 
   // Get quick visibility commands (normalized to consistent format)
   const allCommands = normalizeCommands(agentData.commands || []);
@@ -29,7 +42,12 @@ function transform(agentData) {
   const keyCommands = getVisibleCommands(allCommands, 'key');
 
   // Build content
-  let content = `# ${name} (@${agentData.id})
+  let content = `---
+description: '${description}'
+alwaysApply: false
+---
+
+# ${name} (@${agentData.id})
 
 ${icon} **${title}**${archetype ? ` | ${archetype}` : ''}
 
@@ -84,11 +102,13 @@ ${agentData.sections.collaboration}
  * @returns {string} - Target filename
  */
 function getFilename(agentData) {
-  return agentData.filename;
+  return toMdcFilename(agentData.filename, agentData.id);
 }
 
 module.exports = {
   transform,
   getFilename,
+  toMdcFilename,
+  escapeFrontmatterString,
   format: 'condensed-rules',
 };

--- a/.aiox-core/infrastructure/scripts/ide-sync/validator.js
+++ b/.aiox-core/infrastructure/scripts/ide-sync/validator.js
@@ -49,9 +49,10 @@ function readFileIfExists(filePath) {
  * @param {object[]} expectedFiles - Array of {filename, content} expected
  * @param {string} targetDir - Target directory to check
  * @param {object} redirectsConfig - Redirects configuration
+ * @param {string} format - IDE format
  * @returns {object} - Validation result
  */
-function validateIdeSync(expectedFiles, targetDir, redirectsConfig) {
+function validateIdeSync(expectedFiles, targetDir, redirectsConfig, format) {
   const result = {
     targetDir,
     missing: [],
@@ -71,7 +72,7 @@ function validateIdeSync(expectedFiles, targetDir, redirectsConfig) {
   const expectedFilenames = new Set(expectedFiles.map(f => f.filename));
 
   // Add redirect filenames to expected
-  const redirectFilenames = getRedirectFilenames(redirectsConfig);
+  const redirectFilenames = getRedirectFilenames(redirectsConfig, format);
   for (const rf of redirectFilenames) {
     expectedFilenames.add(rf);
   }
@@ -116,7 +117,9 @@ function validateIdeSync(expectedFiles, targetDir, redirectsConfig) {
   // Check for orphaned files (files in target not in expected)
   if (fs.existsSync(targetDir)) {
     try {
-      const actualFiles = fs.readdirSync(targetDir).filter(f => f.endsWith('.md'));
+      const actualFiles = fs.readdirSync(targetDir).filter(f =>
+        f.endsWith('.md') || f.endsWith('.mdc')
+      );
 
       for (const file of actualFiles) {
         if (!expectedFilenames.has(file)) {
@@ -158,7 +161,8 @@ function validateAllIdes(ideConfigs, redirectsConfig) {
     const ideResult = validateIdeSync(
       config.expectedFiles,
       config.targetDir,
-      redirectsConfig
+      redirectsConfig,
+      config.format
     );
 
     results.ides[ideName] = ideResult;

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -7,8 +7,8 @@
 # - SHA256 hashes for change detection
 # - File types for categorization
 #
-version: 5.1.14
-generated_at: "2026-05-07T17:06:48.504Z"
+version: 5.1.15
+generated_at: "2026-05-07T18:54:14.793Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1103
 files:
@@ -3133,17 +3133,17 @@ files:
     type: script
     size: 5534
   - path: infrastructure/scripts/ide-sync/index.js
-    hash: sha256:a5269ff6d99103d389a6b3b923a7678ccfde3d7cd30debbc1fe0f5bd0bf9d7c1
+    hash: sha256:a7aadbec210e0b5d9c96d187104c8378d097ae6ffb88356614d0ed723298d2ac
     type: script
-    size: 17246
+    size: 17278
   - path: infrastructure/scripts/ide-sync/README.md
-    hash: sha256:c18c2563b2ca64580a4814edd3c20a79c96f33fa8b953ee02206ef0faad53d35
+    hash: sha256:5e88ac0d9d73dee28538c09af86093cb8ddeba1e9d62e993a16d03218b4bc62d
     type: script
-    size: 5313
+    size: 5405
   - path: infrastructure/scripts/ide-sync/redirect-generator.js
-    hash: sha256:89ead2308414418e83fb66f591abddabd7137d87b57adca129fa57d119780b2a
+    hash: sha256:5bebf478e331716b4fb42d624076eb2570c90c4aa829427c700995d6b9ec361e
     type: script
-    size: 4213
+    size: 5675
   - path: infrastructure/scripts/ide-sync/transformers/antigravity.js
     hash: sha256:e00910c008c8547a1943f79c676d0a4c0d014b638fc15c8a68e2574d6949744b
     type: script
@@ -3153,17 +3153,17 @@ files:
     type: script
     size: 6272
   - path: infrastructure/scripts/ide-sync/transformers/cursor.js
-    hash: sha256:c24d24e4bec477c3b75340aeac08c5a4a2780001eec9c25e6b00d4f0af53d4f0
+    hash: sha256:9a38f664747ea71472585d4f8c3e52b844dc75a39a526f5873e6bf97370a4723
     type: script
-    size: 2427
+    size: 2967
   - path: infrastructure/scripts/ide-sync/transformers/github-copilot.js
     hash: sha256:6d365be4a55e2f5ced316a0efbfa50fb925562f3e145d47a86c57a2c685343ac
     type: script
     size: 5693
   - path: infrastructure/scripts/ide-sync/validator.js
-    hash: sha256:356c78125db7f88d14f4e521808e96593d729291c3d7a1c36cb02f78b4aef8fc
+    hash: sha256:29d87e56562627e841c10369644dbb275d8b2a9fd2e366756d25a6d05a1f786d
     type: script
-    size: 7316
+    size: 7429
   - path: infrastructure/scripts/improvement-engine.js
     hash: sha256:4fed61115f4148eb6b8c42ebd9d5b05732695ab1b4343e2466383baf4883d58d
     type: script
@@ -3917,9 +3917,9 @@ files:
     type: template
     size: 3101
   - path: product/templates/ide-rules/cursor-rules.md
-    hash: sha256:40c5a75ec40a9d2da713336ced608eb4606bf7e76fe9b34827e888ed27903464
+    hash: sha256:ea607f2b6a089afccbcaaec3b1197b5396c4446e76a689a51867a78bceda09b2
     type: template
-    size: 3071
+    size: 3172
   - path: product/templates/ide-rules/gemini-rules.md
     hash: sha256:20f687384c4deb909e9171f8e83f40b962a9cc717755b62d88db285316b2188a
     type: template

--- a/.aiox-core/product/templates/ide-rules/cursor-rules.md
+++ b/.aiox-core/product/templates/ide-rules/cursor-rules.md
@@ -1,3 +1,8 @@
+---
+description: Synkra AIOX global rules loaded on every Cursor conversation
+alwaysApply: true
+---
+
 # Synkra AIOX Development Rules for Cursor
 
 You are working with Synkra AIOX, an AI-Orchestrated System for Full Stack Development.
@@ -112,4 +117,4 @@ async function operation() {
 ```
 
 ---
-*Synkra AIOX Cursor Configuration v1.0* 
+*Synkra AIOX Cursor Configuration v2.0*

--- a/.cursor/rules/agents/aiox-master.mdc
+++ b/.cursor/rules/agents/aiox-master.mdc
@@ -1,3 +1,8 @@
+---
+description: 'AIOX agent @aiox-master - AIOX Master Orchestrator & Framework Developer'
+alwaysApply: false
+---
+
 # Orion (@aiox-master)
 
 👑 **AIOX Master Orchestrator & Framework Developer** | Orchestrator

--- a/.cursor/rules/agents/analyst.mdc
+++ b/.cursor/rules/agents/analyst.mdc
@@ -1,3 +1,8 @@
+---
+description: 'AIOX agent @analyst - Business Analyst'
+alwaysApply: false
+---
+
 # Atlas (@analyst)
 
 🔍 **Business Analyst** | Decoder

--- a/.cursor/rules/agents/architect.mdc
+++ b/.cursor/rules/agents/architect.mdc
@@ -1,3 +1,8 @@
+---
+description: 'AIOX agent @architect - Architect'
+alwaysApply: false
+---
+
 # Aria (@architect)
 
 🏛️ **Architect** | Visionary

--- a/.cursor/rules/agents/data-engineer.mdc
+++ b/.cursor/rules/agents/data-engineer.mdc
@@ -1,3 +1,8 @@
+---
+description: 'AIOX agent @data-engineer - Database Architect & Operations Engineer'
+alwaysApply: false
+---
+
 # Dara (@data-engineer)
 
 📊 **Database Architect & Operations Engineer** | Sage

--- a/.cursor/rules/agents/dev.mdc
+++ b/.cursor/rules/agents/dev.mdc
@@ -1,3 +1,8 @@
+---
+description: 'AIOX agent @dev - Full Stack Developer'
+alwaysApply: false
+---
+
 # Dex (@dev)
 
 💻 **Full Stack Developer** | Builder

--- a/.cursor/rules/agents/devops.mdc
+++ b/.cursor/rules/agents/devops.mdc
@@ -1,3 +1,8 @@
+---
+description: 'AIOX agent @devops - GitHub Repository Manager & DevOps Specialist'
+alwaysApply: false
+---
+
 # Gage (@devops)
 
 ⚡ **GitHub Repository Manager & DevOps Specialist** | Operator

--- a/.cursor/rules/agents/pm.mdc
+++ b/.cursor/rules/agents/pm.mdc
@@ -1,3 +1,8 @@
+---
+description: 'AIOX agent @pm - Product Manager'
+alwaysApply: false
+---
+
 # Morgan (@pm)
 
 📋 **Product Manager** | Strategist

--- a/.cursor/rules/agents/po.mdc
+++ b/.cursor/rules/agents/po.mdc
@@ -1,3 +1,8 @@
+---
+description: 'AIOX agent @po - Product Owner'
+alwaysApply: false
+---
+
 # Pax (@po)
 
 🎯 **Product Owner** | Balancer

--- a/.cursor/rules/agents/qa.mdc
+++ b/.cursor/rules/agents/qa.mdc
@@ -1,3 +1,8 @@
+---
+description: 'AIOX agent @qa - Test Architect & Quality Advisor'
+alwaysApply: false
+---
+
 # Quinn (@qa)
 
 ✅ **Test Architect & Quality Advisor** | Guardian

--- a/.cursor/rules/agents/sm.mdc
+++ b/.cursor/rules/agents/sm.mdc
@@ -1,3 +1,8 @@
+---
+description: 'AIOX agent @sm - Scrum Master'
+alwaysApply: false
+---
+
 # River (@sm)
 
 🌊 **Scrum Master** | Facilitator

--- a/.cursor/rules/agents/squad-creator.mdc
+++ b/.cursor/rules/agents/squad-creator.mdc
@@ -1,3 +1,8 @@
+---
+description: 'AIOX agent @squad-creator - Squad Creator'
+alwaysApply: false
+---
+
 # Craft (@squad-creator)
 
 🏗️ **Squad Creator** | Builder

--- a/.cursor/rules/agents/ux-design-expert.mdc
+++ b/.cursor/rules/agents/ux-design-expert.mdc
@@ -1,3 +1,8 @@
+---
+description: 'AIOX agent @ux-design-expert - UX/UI Designer & Design System Architect'
+alwaysApply: false
+---
+
 # Uma (@ux-design-expert)
 
 🎨 **UX/UI Designer & Design System Architect** | Empathizer

--- a/bin/aiox-init.js
+++ b/bin/aiox-init.js
@@ -118,6 +118,43 @@ try {
   ensureProjectNodeModulesLink = null;
 }
 
+function escapeCursorMdcFrontmatterString(value) {
+  return String(value || '')
+    .replace(/\r?\n/g, ' ')
+    .replace(/'/g, "''")
+    .trim();
+}
+
+function createCursorMdcFallbackContent(agentName, rawContent) {
+  const safeAgentName = escapeCursorMdcFrontmatterString(agentName || 'agent');
+
+  return `---
+description: 'AIOX agent @${safeAgentName}'
+alwaysApply: false
+---
+
+${rawContent}`;
+}
+
+async function writeCursorMdcAgent(sourcePath, targetPath) {
+  try {
+    const agentParser = resolveAioxCoreModule('infrastructure/scripts/ide-sync/agent-parser');
+    const cursorTransformer = resolveAioxCoreModule('infrastructure/scripts/ide-sync/transformers/cursor');
+    const agentData = agentParser.parseAgentFile(sourcePath);
+    const content = cursorTransformer.transform(agentData);
+    await fse.writeFile(targetPath, content, 'utf8');
+  } catch (err) {
+    const agentName = path.basename(sourcePath, path.extname(sourcePath));
+    const rawContent = await fse.readFile(sourcePath, 'utf8');
+    const content = createCursorMdcFallbackContent(agentName, rawContent);
+    await fse.writeFile(targetPath, content, 'utf8');
+    console.warn(
+      chalk.yellow('⚠') +
+        ` Cursor MDC transform fallback used for ${path.basename(sourcePath)}: ${err.message}`
+    );
+  }
+}
+
 async function main() {
   console.clear();
 
@@ -582,7 +619,7 @@ async function main() {
 
     const ideRulesMap = {
       claude: { source: 'claude-rules.md', target: '.claude/CLAUDE.md' },
-      cursor: { source: 'cursor-rules.md', target: '.cursor/rules.md' },
+      cursor: { source: 'cursor-rules.md', target: '.cursor/rules/aiox-global.mdc' },
       gemini: { source: 'gemini-rules.md', target: '.gemini/rules.md' },
       'github-copilot': { source: 'copilot-rules.md', target: '.github/chatmodes/aiox-agent.md' },
       antigravity: { source: 'antigravity-rules.md', target: '.antigravity/rules.md' },
@@ -686,7 +723,6 @@ See .aiox-core/user-guide.md for complete documentation.
         context.projectRoot,
         '.cursor',
         'rules',
-        'AIOX',
         'agents'
       );
 
@@ -698,7 +734,7 @@ See .aiox-core/user-guide.md for complete documentation.
           const sourcePath = path.join(coreAgentsSource, agentFile);
           const targetFileName = agentFile.replace('.md', '.mdc');
           const targetPath = path.join(cursorRulesTarget, targetFileName);
-          await fse.copy(sourcePath, targetPath);
+          await writeCursorMdcAgent(sourcePath, targetPath);
         }
 
         console.log(
@@ -707,7 +743,7 @@ See .aiox-core/user-guide.md for complete documentation.
       }
 
       // Create AIOX README for Cursor
-      const cursorReadme = path.join(context.projectRoot, '.cursor', 'rules', 'AIOX', 'README.md');
+      const cursorReadme = path.join(context.projectRoot, '.cursor', 'rules', 'README.md');
       await fse.ensureDir(path.dirname(cursorReadme));
       await fse.writeFile(
         cursorReadme,
@@ -912,8 +948,8 @@ See .aiox-core/user-guide.md for complete documentation.
             context.projectRoot,
             '.cursor',
             'rules',
-            squad,
-            'agents'
+            'agents',
+            squad
           );
           await fse.ensureDir(cursorSquadTarget);
 
@@ -922,7 +958,7 @@ See .aiox-core/user-guide.md for complete documentation.
             const sourcePath = path.join(squadAgentsSource, agentFile);
             const targetFileName = agentFile.replace('.md', '.mdc');
             const targetPath = path.join(cursorSquadTarget, targetFileName);
-            await fse.copy(sourcePath, targetPath);
+            await writeCursorMdcAgent(sourcePath, targetPath);
           }
 
           console.log(chalk.green('  ✓') + ` Cursor ${squad} rules (${squadAgentFiles.length} agents)`);
@@ -931,7 +967,7 @@ See .aiox-core/user-guide.md for complete documentation.
           if (hasSquadReadme) {
             await fse.copy(
               squadReadmeSource,
-              path.join(context.projectRoot, '.cursor', 'rules', squad, 'README.md')
+              path.join(context.projectRoot, '.cursor', 'rules', 'agents', squad, 'README.md')
             );
           }
         }
@@ -1028,7 +1064,7 @@ See .aiox-core/user-guide.md for complete documentation.
 
   if (ides.includes('cursor')) {
     console.log('  ' + chalk.dim('.cursor/'));
-    console.log('    ' + chalk.dim('├─ rules.md') + '         - Main configuration');
+    console.log('    ' + chalk.dim('├─ rules/aiox-global.mdc') + ' - Main configuration');
     console.log('    ' + chalk.dim('└─ rules/'));
     console.log('      ' + chalk.dim('  ├─ AIOX/') + '         - Core agent rules');
     if (selectedSquads && selectedSquads.length > 0) {

--- a/bin/modules/env-config.js
+++ b/bin/modules/env-config.js
@@ -352,7 +352,7 @@ async function generateCoreConfigYAML(projectPath, wizardState) {
  */
 function getIDEConfigFile(ideKey) {
   const ideConfigMap = {
-    cursor: '.cursorrules',
+    cursor: '.cursor/rules/aiox-global.mdc',
     zed: '.zed/settings.json',
     antigravity: '.antigravity.yaml',
     continue: '.continue/config.json',

--- a/docs/stories/epic-123/STORY-123.20-cursor-mdc-install-rules.md
+++ b/docs/stories/epic-123/STORY-123.20-cursor-mdc-install-rules.md
@@ -1,0 +1,98 @@
+# STORY-123.20: Gerar regras Cursor em formato MDC no install
+
+## Status
+
+Done
+
+## Story
+
+Como mantenedor do AIOX Core, quero que a instalação e o sync do Cursor gerem regras em `.cursor/rules/*.mdc` com front matter válido, para que projetos recém-instalados recebam regras globais e agentes carregáveis pelo Cursor atual.
+
+## Acceptance Criteria
+
+- [x] AC1. O instalador modular grava a regra global do Cursor em `.cursor/rules/aiox-global.mdc`.
+- [x] AC2. Os agentes do Cursor são gerados como `.mdc` em `.cursor/rules/agents/`, com `description` e `alwaysApply: false`.
+- [x] AC3. O sync de IDE gera agentes e redirects Cursor em `.mdc`, e a validação reconhece `.mdc` sem marcar redirects como órfãos.
+- [x] AC4. O instalador legado e o helper de env config não apontam mais para `.cursorrules` ou `.cursor/rules.md`.
+- [x] AC5. Versão, lockfile e manifest de instalação são atualizados para publicação patch.
+- [x] AC6. Validações locais antes de PR são concluídas.
+
+## Tasks
+
+- [x] Confrontar o PR antigo #465 contra `main` e descartar caminhos legados `.aios`/`.cursorrules`.
+- [x] Atualizar metadados do instalador Cursor para `.cursor/rules/aiox-global.mdc` e `.cursor/rules/agents`.
+- [x] Adicionar front matter Cursor MDC ao template global.
+- [x] Transformar agentes Cursor em `.mdc` no instalador modular e legado.
+- [x] Fazer o sync e redirects Cursor emitirem `.mdc`.
+- [x] Migrar a projeção versionada `.cursor/rules/agents/*.md` para `.mdc`.
+- [x] Ajustar o validador para escanear `.md` e `.mdc`.
+- [x] Registrar `.mdc` na estratégia de merge markdown para instalações brownfield.
+- [x] Corrigir feedback CodeRabbit para escaping, fallback MDC, merge brownfield, paths legados e sanitização de redirects.
+- [x] Atualizar testes unitários e de integração.
+- [x] Atualizar versão, lockfile e manifest.
+- [x] Rodar bateria completa de validação antes de PR.
+
+## Dev Notes
+
+- O PR #465 propunha alterações em caminhos antigos (`.aios-core`, `aios`, `.cursorrules`), então não podia ser mergeado diretamente.
+- A documentação atual do Cursor usa Project Rules em `.cursor/rules/*.mdc`; a correção preserva AIOX naming e remove o resíduo funcional legado.
+- O sync canônico já apontava para `.cursor/rules/agents`, mas o transformer ainda devolvia `.md` e sem front matter MDC.
+
+## Validation
+
+- `node -c packages/installer/src/config/ide-configs.js` -> PASS.
+- `node -c packages/installer/src/wizard/ide-config-generator.js` -> PASS.
+- `node -c .aiox-core/infrastructure/scripts/ide-sync/transformers/cursor.js` -> PASS.
+- `node -c .aiox-core/infrastructure/scripts/ide-sync/redirect-generator.js` -> PASS.
+- `node -c .aiox-core/infrastructure/scripts/ide-sync/validator.js` -> PASS.
+- `node -c bin/aiox-init.js` -> PASS.
+- `node -c packages/installer/src/merger/index.js` -> PASS.
+- `node -c packages/installer/src/merger/strategies/index.js` -> PASS.
+- `npm test -- tests/ide-sync/transformers.test.js tests/ide-sync/validator.test.js tests/unit/config/ide-configs.test.js tests/unit/wizard/ide-config-generator.test.js tests/integration/wizard-ide-flow.test.js --runInBand --forceExit` -> PASS, 5 suites / 110 tests.
+- `npm test -- packages/installer/tests/unit/merger/strategies.test.js tests/unit/wizard/ide-config-generator.test.js tests/integration/wizard-ide-flow.test.js --runInBand --forceExit` -> PASS, 3 suites / 66 tests.
+- `npm test -- tests/ide-sync/transformers.test.js packages/installer/tests/unit/merger/strategies.test.js tests/unit/wizard/ide-config-generator.test.js tests/integration/wizard-ide-flow.test.js --runInBand --forceExit` -> PASS, 4 suites / 94 tests.
+- `npm test -- tests/ide-sync/transformers.test.js --runInBand --forceExit` -> PASS, 1 suite / 27 tests.
+- `npm version 5.1.15 --no-git-tag-version` -> PASS.
+- `npm run generate:manifest` -> PASS, 1.103 files, manifest v5.1.15.
+- `npm run sync:ide:cursor -- --dry-run --verbose` -> PASS, 12 Cursor agent files would be written to `.cursor/rules/agents`.
+- `npm run sync:ide` -> PASS, 97 files + 0 redirects.
+- `npm run sync:ide:check` -> PASS, 97 synced / 0 missing / 0 drift / 0 orphaned.
+- `npm run validate:parity` -> PASS, cursor-sync restored.
+- `git diff --check` -> PASS.
+- `npm run validate:manifest` -> PASS.
+- `npm run validate:semantic-lint` -> PASS.
+- `npm run validate:publish` -> PASS.
+- `npm run lint -- --quiet` -> PASS.
+- `npm run typecheck` -> PASS.
+- `npm run test:ci` -> PASS, 317 suites / 7.867 tests / 149 skipped.
+
+## Post-Merge Operations
+
+- Fechar o PR antigo #465 como superseded depois do merge e publicação da correção atual.
+
+## File List
+
+- `.aiox-core/infrastructure/scripts/ide-sync/README.md`
+- `.aiox-core/infrastructure/scripts/ide-sync/index.js`
+- `.aiox-core/infrastructure/scripts/ide-sync/redirect-generator.js`
+- `.aiox-core/infrastructure/scripts/ide-sync/transformers/cursor.js`
+- `.aiox-core/infrastructure/scripts/ide-sync/validator.js`
+- `.aiox-core/product/templates/ide-rules/cursor-rules.md`
+- `bin/aiox-init.js`
+- `bin/modules/env-config.js`
+- `.cursor/rules/agents/*.mdc`
+- `.aiox-core/install-manifest.yaml`
+- `package.json`
+- `package-lock.json`
+- `packages/installer/src/merger/index.js`
+- `packages/installer/src/merger/strategies/index.js`
+- `packages/installer/src/merger/strategies/markdown-merger.js`
+- `packages/installer/src/config/ide-configs.js`
+- `packages/installer/src/wizard/ide-config-generator.js`
+- `packages/installer/tests/unit/merger/strategies.test.js`
+- `tests/ide-sync/transformers.test.js`
+- `tests/ide-sync/validator.test.js`
+- `tests/integration/wizard-ide-flow.test.js`
+- `tests/unit/config/ide-configs.test.js`
+- `tests/unit/wizard/ide-config-generator.test.js`
+- `docs/stories/epic-123/STORY-123.20-cursor-mdc-install-rules.md`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.1.14",
+  "version": "5.1.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aiox-squads/core",
-      "version": "5.1.14",
+      "version": "5.1.15",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.1.14",
+  "version": "5.1.15",
   "description": "Synkra AIOX: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aiox": "bin/aiox.js",

--- a/packages/installer/src/config/ide-configs.js
+++ b/packages/installer/src/config/ide-configs.js
@@ -67,11 +67,11 @@ const IDE_CONFIGS = {
   cursor: {
     name: 'Cursor',
     description: '',
-    configFile: path.join('.cursor', 'rules.md'),
+    configFile: path.join('.cursor', 'rules', 'aiox-global.mdc'),
     template: 'ide-rules/cursor-rules.md',
     requiresDirectory: true,
     format: 'text',
-    agentFolder: path.join('.cursor', 'rules'),
+    agentFolder: path.join('.cursor', 'rules', 'agents'),
   },
   'github-copilot': {
     name: 'GitHub Copilot',

--- a/packages/installer/src/merger/index.js
+++ b/packages/installer/src/merger/index.js
@@ -7,7 +7,7 @@
  *
  * Supported file types:
  * - .env files: Key-based merge (adds new variables, preserves existing)
- * - .md files: Section-based merge using AIOX-MANAGED markers
+ * - .md/.mdc files: Section-based merge using AIOX-MANAGED markers
  * - .yaml/.yml files: Deep merge with target-wins (Phase 1 — Story INS-4.7)
  *
  * @module merger

--- a/packages/installer/src/merger/strategies/index.js
+++ b/packages/installer/src/merger/strategies/index.js
@@ -21,8 +21,9 @@ fileNameStrategies.set('.env', EnvMerger);
 fileNameStrategies.set('.env.local', EnvMerger);
 fileNameStrategies.set('.env.example', EnvMerger);
 
-// Markdown files
+// Markdown and Cursor MDC rule files
 strategies.set('.md', MarkdownMerger);
+strategies.set('.mdc', MarkdownMerger);
 
 // YAML files (Story INS-4.7)
 strategies.set('.yaml', YamlMerger);

--- a/packages/installer/src/merger/strategies/markdown-merger.js
+++ b/packages/installer/src/merger/strategies/markdown-merger.js
@@ -7,6 +7,16 @@ const { BaseMerger } = require('./base-merger.js');
 const { createMergeResult, createEmptyStats } = require('../types.js');
 const { parseMarkdownSections, hasAioxMarkers } = require('../parsers/markdown-section-parser.js');
 
+function startsWithYamlFrontmatter(content) {
+  const trimmed = String(content || '').trimStart();
+  if (!trimmed.startsWith('---\n') && !trimmed.startsWith('---\r\n')) {
+    return false;
+  }
+
+  const lines = trimmed.split(/\r?\n/);
+  return lines.slice(1).some(line => line.trim() === '---');
+}
+
 /**
  * Merge strategy for Markdown files (CLAUDE.md, rules.md).
  * Uses AIOX-MANAGED markers to identify sections that can be updated.
@@ -171,7 +181,7 @@ class MarkdownMerger extends BaseMerger {
 
     // Add separator and AIOX sections
     if (aioxSections.length > 0) {
-      merged += '\n---\n\n';
+      merged += startsWithYamlFrontmatter(merged) ? '\n\n' : '\n---\n\n';
       merged += '<!-- AIOX-MANAGED SECTIONS -->\n';
       merged += '<!-- These sections are managed by AIOX. Edit content between markers carefully. -->\n';
       merged += '<!-- Your custom content above will be preserved during updates. -->\n\n';

--- a/packages/installer/src/wizard/ide-config-generator.js
+++ b/packages/installer/src/wizard/ide-config-generator.js
@@ -22,6 +22,24 @@ function loadCodexSkillsSync() {
   return requireAioxCoreModule('.aiox-core', 'infrastructure', 'scripts', 'codex-skills-sync', 'index');
 }
 
+function escapeMdcFrontmatterString(value) {
+  return String(value || '')
+    .replace(/\r?\n/g, ' ')
+    .replace(/'/g, "''")
+    .trim();
+}
+
+function createCursorMdcFallbackContent(agentName, rawContent) {
+  const safeAgentName = escapeMdcFrontmatterString(agentName || 'agent');
+
+  return `---
+description: 'AIOX agent @${safeAgentName}'
+alwaysApply: false
+---
+
+${rawContent}`;
+}
+
 /**
  * Render template with variables
  * @param {string} template - Template string
@@ -241,6 +259,7 @@ async function copyAgentFiles(projectRoot, agentFolder, ideConfig = null) {
 
   // Check if this is AntiGravity - needs workflow files instead of direct copy
   const isAntiGravity = ideConfig && ideConfig.specialConfig && ideConfig.specialConfig.type === 'antigravity';
+  const isCursor = ideConfig && ideConfig.agentFolder && ideConfig.agentFolder.includes('.cursor');
 
   for (const file of agentFiles) {
     const sourcePath = path.join(sourceDir, file);
@@ -262,6 +281,38 @@ async function copyAgentFiles(projectRoot, agentFolder, ideConfig = null) {
         const agentTargetPath = path.join(agentsDir, file);
         await fs.copy(sourcePath, agentTargetPath);
         copiedFiles.push(agentTargetPath);
+      } else if (isCursor) {
+        // Cursor: generate .mdc project rules with frontmatter instead of raw agent markdown.
+        try {
+          const agentParser = requireAioxCoreModule(
+            '.aiox-core',
+            'infrastructure',
+            'scripts',
+            'ide-sync',
+            'agent-parser',
+          );
+          const cursorTransformer = requireAioxCoreModule(
+            '.aiox-core',
+            'infrastructure',
+            'scripts',
+            'ide-sync',
+            'transformers',
+            'cursor',
+          );
+          const agentData = agentParser.parseAgentFile(sourcePath);
+          const content = cursorTransformer.transform(agentData);
+          const filename = cursorTransformer.getFilename(agentData);
+          const targetPath = path.join(targetDir, filename);
+          await fs.writeFile(targetPath, content, 'utf8');
+          copiedFiles.push(targetPath);
+        } catch (transformError) {
+          const targetPath = path.join(targetDir, `${agentName}.mdc`);
+          const rawContent = await fs.readFile(sourcePath, 'utf8');
+          const fallbackContent = createCursorMdcFallbackContent(agentName, rawContent);
+          await fs.writeFile(targetPath, fallbackContent, 'utf8');
+          copiedFiles.push(targetPath);
+          console.warn(`Cursor transform fallback used for ${file}: ${transformError.message}`);
+        }
       } else if (ideConfig && ideConfig.agentFolder && ideConfig.agentFolder.includes('.github')) {
         // GitHub Copilot: apply transformer for .agent.md format with YAML frontmatter
         try {
@@ -427,7 +478,7 @@ async function createAntiGravityConfigJson(projectRoot, ideConfig) {
  *
  * @example
  * const result = await generateIDEConfigs(['cursor', 'github-copilot'], wizardState);
- * console.log(result.files); // ['.cursorrules', '.github/copilot-instructions.md']
+ * console.log(result.files); // ['.cursor/rules/aiox-global.mdc', '.github/copilot-instructions.md']
  */
 async function generateIDEConfigs(selectedIDEs, wizardState, options = {}) {
   const projectRoot = options.projectRoot || process.cwd();
@@ -1312,6 +1363,7 @@ module.exports = {
   copyClaudeNativeAgentsFolder,
   shouldCopyProHooks,
   createClaudeSettingsLocal,
+  createCursorMdcFallbackContent,
   copySkillFiles,
   generateCodexSkills,
   copyExtraCommandFiles,

--- a/packages/installer/tests/unit/merger/strategies.test.js
+++ b/packages/installer/tests/unit/merger/strategies.test.js
@@ -35,6 +35,11 @@ describe('getMergeStrategy', () => {
     expect(merger).toBeInstanceOf(MarkdownMerger);
   });
 
+  it('should return MarkdownMerger for Cursor .mdc files', () => {
+    const merger = getMergeStrategy('.cursor/rules/aiox-global.mdc');
+    expect(merger).toBeInstanceOf(MarkdownMerger);
+  });
+
   it('should return MarkdownMerger for README.md', () => {
     const merger = getMergeStrategy('README.md');
     expect(merger).toBeInstanceOf(MarkdownMerger);
@@ -70,6 +75,10 @@ describe('hasMergeStrategy', () => {
     expect(hasMergeStrategy('CLAUDE.md')).toBe(true);
   });
 
+  it('should return true for .mdc files', () => {
+    expect(hasMergeStrategy('.cursor/rules/aiox-global.mdc')).toBe(true);
+  });
+
   it('should return false for unsupported files', () => {
     expect(hasMergeStrategy('config.toml')).toBe(false);
   });
@@ -96,6 +105,11 @@ describe('getSupportedTypes', () => {
   it('should include .md in extensions', () => {
     const types = getSupportedTypes();
     expect(types.extensions).toContain('.md');
+  });
+
+  it('should include .mdc in extensions', () => {
+    const types = getSupportedTypes();
+    expect(types.extensions).toContain('.mdc');
   });
 
   it('should include .env in filenames', () => {
@@ -149,5 +163,46 @@ describe('ReplaceMerger', () => {
 
   it('should report canMerge as false', () => {
     expect(merger.canMerge('', '')).toBe(false);
+  });
+});
+
+describe('MarkdownMerger', () => {
+  let merger;
+
+  beforeEach(() => {
+    merger = new MarkdownMerger();
+  });
+
+  it('should preserve MDC frontmatter during legacy migrations', async () => {
+    const existing = `---
+description: 'Existing Cursor rule'
+alwaysApply: false
+---
+
+# Existing rule
+`;
+    const template = `<!-- AIOX-MANAGED-START: cursor-rule -->
+Generated Cursor rule content
+<!-- AIOX-MANAGED-END: cursor-rule -->
+`;
+
+    const result = await merger.merge(existing, template);
+
+    expect(result.content).toContain("description: 'Existing Cursor rule'");
+    expect(result.content).toMatch(/# Existing rule\n{2,}<!-- AIOX-MANAGED SECTIONS -->/);
+    expect(result.content).not.toContain('# Existing rule\n\n---\n\n<!-- AIOX-MANAGED SECTIONS -->');
+    expect(result.content.match(/^---$/gm)).toHaveLength(2);
+  });
+
+  it('should keep the legacy separator for markdown without frontmatter', async () => {
+    const existing = '# Existing rule\n';
+    const template = `<!-- AIOX-MANAGED-START: cursor-rule -->
+Generated Cursor rule content
+<!-- AIOX-MANAGED-END: cursor-rule -->
+`;
+
+    const result = await merger.merge(existing, template);
+
+    expect(result.content).toContain('# Existing rule\n\n---\n\n<!-- AIOX-MANAGED SECTIONS -->');
   });
 });

--- a/tests/ide-sync/transformers.test.js
+++ b/tests/ide-sync/transformers.test.js
@@ -3,9 +3,17 @@
  * @story 6.19 - IDE Command Auto-Sync System
  */
 
+const path = require('path');
+
 const claudeCode = require('../../.aiox-core/infrastructure/scripts/ide-sync/transformers/claude-code');
 const cursor = require('../../.aiox-core/infrastructure/scripts/ide-sync/transformers/cursor');
 const antigravity = require('../../.aiox-core/infrastructure/scripts/ide-sync/transformers/antigravity');
+const {
+  generateRedirect,
+  generateRedirectContent,
+  getRedirectFilenames,
+  sanitizeRedirectId,
+} = require('../../.aiox-core/infrastructure/scripts/ide-sync/redirect-generator');
 
 describe('IDE Transformers', () => {
   // Sample agent data for testing
@@ -139,6 +147,7 @@ describe('IDE Transformers', () => {
   describe('cursor transformer', () => {
     it('should generate condensed format', () => {
       const result = cursor.transform(sampleAgent);
+      expect(result).toMatch(/^---\ndescription: 'AIOX agent @dev - Full Stack Developer'\nalwaysApply: false\n---/);
       expect(result).toContain('# Dex (@dev)');
       expect(result).toContain('💻 **Full Stack Developer**');
       expect(result).toContain('Builder');
@@ -169,6 +178,36 @@ describe('IDE Transformers', () => {
 
     it('should have correct format identifier', () => {
       expect(cursor.format).toBe('condensed-rules');
+    });
+
+    it('should return Cursor .mdc filenames', () => {
+      expect(cursor.getFilename(sampleAgent)).toBe('dev.mdc');
+    });
+
+    it('should escape redirect frontmatter values for Cursor MDC files', () => {
+      const result = generateRedirectContent("old'agent\nname", "new'agent", 'condensed-rules');
+
+      expect(result).toContain("description: 'AIOX redirect from @old''agent name to @new''agent'");
+      expect(result).toMatch(/^---\ndescription: 'AIOX redirect/m);
+    });
+
+    it('should sanitize redirect filenames and keep paths inside target dir', () => {
+      const targetDir = path.join(process.cwd(), 'tmp-redirect-target');
+      const result = generateRedirect('../escape/agent', 'dev', targetDir, 'condensed-rules');
+
+      expect(sanitizeRedirectId('../escape/agent')).toBe('escape-agent');
+      expect(result.filename).toBe('escape-agent.mdc');
+      expect(result.path).toBe(path.resolve(targetDir, 'escape-agent.mdc'));
+      expect(path.relative(path.resolve(targetDir), result.path)).toBe('escape-agent.mdc');
+      expect(getRedirectFilenames({ '../escape/agent': 'dev' }, 'condensed-rules')).toEqual([
+        'escape-agent.mdc',
+      ]);
+    });
+
+    it('should reject redirect ids that cannot produce safe filenames', () => {
+      expect(() => generateRedirect('..', 'dev', process.cwd(), 'condensed-rules')).toThrow(
+        'Invalid redirect id'
+      );
     });
   });
 
@@ -219,10 +258,9 @@ describe('IDE Transformers', () => {
     });
 
     it('should return valid filename for all', () => {
-      for (const transformer of transformers) {
-        const filename = transformer.getFilename(sampleAgent);
-        expect(filename).toBe('dev.md');
-      }
+      expect(claudeCode.getFilename(sampleAgent)).toBe('dev.md');
+      expect(cursor.getFilename(sampleAgent)).toBe('dev.mdc');
+      expect(antigravity.getFilename(sampleAgent)).toBe('dev.md');
     });
 
     it('should have format property', () => {

--- a/tests/ide-sync/validator.test.js
+++ b/tests/ide-sync/validator.test.js
@@ -130,6 +130,17 @@ describe('validator', () => {
       expect(result.orphaned[0].filename).toBe('orphan.md');
     });
 
+    it('should detect orphaned Cursor mdc files', () => {
+      fs.writeFileSync(path.join(targetDir, 'expected.mdc'), 'content');
+      fs.writeFileSync(path.join(targetDir, 'orphan.mdc'), 'orphan');
+
+      const expected = [{ filename: 'expected.mdc', content: 'content' }];
+      const result = validateIdeSync(expected, targetDir, {}, 'condensed-rules');
+
+      expect(result.orphaned).toHaveLength(1);
+      expect(result.orphaned[0].filename).toBe('orphan.mdc');
+    });
+
     it('should not count redirect files as orphaned', () => {
       fs.writeFileSync(path.join(targetDir, 'agent.md'), 'content');
       fs.writeFileSync(path.join(targetDir, 'aiox-developer.md'), 'redirect');
@@ -137,6 +148,17 @@ describe('validator', () => {
       const expected = [{ filename: 'agent.md', content: 'content' }];
       const redirects = { 'aiox-developer': 'aiox-master' };
       const result = validateIdeSync(expected, targetDir, redirects);
+
+      expect(result.orphaned).toHaveLength(0);
+    });
+
+    it('should not count Cursor mdc redirect files as orphaned', () => {
+      fs.writeFileSync(path.join(targetDir, 'agent.mdc'), 'content');
+      fs.writeFileSync(path.join(targetDir, 'aiox-developer.mdc'), 'redirect');
+
+      const expected = [{ filename: 'agent.mdc', content: 'content' }];
+      const redirects = { 'aiox-developer': 'aiox-master' };
+      const result = validateIdeSync(expected, targetDir, redirects, 'condensed-rules');
 
       expect(result.orphaned).toHaveLength(0);
     });
@@ -168,12 +190,13 @@ describe('validator', () => {
 
       fs.ensureDirSync(cursorDir);
 
-      fs.writeFileSync(path.join(cursorDir, 'agent.md'), 'cursor content');
+      fs.writeFileSync(path.join(cursorDir, 'agent.mdc'), 'cursor content');
 
       const ideConfigs = {
         cursor: {
-          expectedFiles: [{ filename: 'agent.md', content: 'cursor content' }],
+          expectedFiles: [{ filename: 'agent.mdc', content: 'cursor content' }],
           targetDir: cursorDir,
+          format: 'condensed-rules',
         },
       };
 

--- a/tests/integration/wizard-ide-flow.test.js
+++ b/tests/integration/wizard-ide-flow.test.js
@@ -43,18 +43,20 @@ describe('Wizard IDE Flow Integration', () => {
       // Now includes config file + agent files (16+ files)
       expect(result.files.length).toBeGreaterThanOrEqual(1);
 
-      // Verify config file exists (now in .cursor/rules.md)
-      const configPath = path.join(testDir, '.cursor', 'rules.md');
+      // Verify config file exists in Cursor MDC rules format
+      const configPath = path.join(testDir, '.cursor', 'rules', 'aiox-global.mdc');
       expect(await fs.pathExists(configPath)).toBe(true);
 
       // Verify agent folder was created with agents
-      const agentFolder = path.join(testDir, '.cursor', 'rules');
+      const agentFolder = path.join(testDir, '.cursor', 'rules', 'agents');
       expect(await fs.pathExists(agentFolder)).toBe(true);
+      expect(await fs.pathExists(path.join(agentFolder, 'dev.mdc'))).toBe(true);
 
       // Verify content has AIOX branding
       const content = await fs.readFile(configPath, 'utf8');
       expect(content).toContain('Synkra AIOX');
       expect(content).toContain('Development Rules');
+      expect(content).toContain('alwaysApply: true');
     });
 
     it('should complete flow for multiple IDEs', async () => {
@@ -73,14 +75,14 @@ describe('Wizard IDE Flow Integration', () => {
       expect(result.files.length).toBeGreaterThanOrEqual(3);
 
       // Verify all config files exist
-      expect(await fs.pathExists(path.join(testDir, '.cursor', 'rules.md'))).toBe(true);
+      expect(await fs.pathExists(path.join(testDir, '.cursor', 'rules', 'aiox-global.mdc'))).toBe(true);
       expect(await fs.pathExists(path.join(testDir, '.gemini', 'rules.md'))).toBe(true);
       expect(await fs.pathExists(path.join(testDir, '.github', 'copilot-instructions.md'))).toBe(
         true,
       );
 
       // Verify agent folders were created
-      expect(await fs.pathExists(path.join(testDir, '.cursor', 'rules'))).toBe(true);
+      expect(await fs.pathExists(path.join(testDir, '.cursor', 'rules', 'agents'))).toBe(true);
       expect(await fs.pathExists(path.join(testDir, '.gemini', 'rules', 'AIOX', 'agents'))).toBe(true);
       expect(await fs.pathExists(path.join(testDir, '.github', 'agents'))).toBe(true);
     });
@@ -167,10 +169,14 @@ describe('Wizard IDE Flow Integration', () => {
 
       expect(result.success).toBe(true);
 
-      // Check Cursor content (now in .cursor/rules.md)
-      const cursorContent = await fs.readFile(path.join(testDir, '.cursor', 'rules.md'), 'utf8');
+      // Check Cursor content
+      const cursorContent = await fs.readFile(
+        path.join(testDir, '.cursor', 'rules', 'aiox-global.mdc'),
+        'utf8',
+      );
       expect(cursorContent).toContain('Synkra AIOX');
       expect(cursorContent).toContain('Story-Driven Development');
+      expect(cursorContent).toContain('alwaysApply: true');
 
       // Check Gemini content
       const geminiContent = await fs.readFile(path.join(testDir, '.gemini', 'rules.md'), 'utf8');
@@ -254,7 +260,10 @@ describe('Wizard IDE Flow Integration', () => {
       expect(result.files.length).toBeGreaterThanOrEqual(3);
 
       // All formats should be text (markdown)
-      const cursorContent = await fs.readFile(path.join(testDir, '.cursor', 'rules.md'), 'utf8');
+      const cursorContent = await fs.readFile(
+        path.join(testDir, '.cursor', 'rules', 'aiox-global.mdc'),
+        'utf8',
+      );
       expect(typeof cursorContent).toBe('string');
 
       const copilotContent = await fs.readFile(
@@ -283,13 +292,14 @@ describe('Wizard IDE Flow Integration', () => {
         projectRoot: testDir,
       });
 
-      const configPath = path.join(testDir, '.cursor', 'rules.md');
+      const configPath = path.join(testDir, '.cursor', 'rules', 'aiox-global.mdc');
       const content = await fs.readFile(configPath, 'utf8');
 
       // Template should be generated with AIOX content
       expect(content).toContain('Synkra AIOX');
       expect(content).toContain('Development Rules');
       expect(content).toContain('Story-Driven Development');
+      expect(content).toContain('alwaysApply: true');
       expect(content).not.toContain('{{'); // No uninterpolated variables
     });
 
@@ -302,7 +312,7 @@ describe('Wizard IDE Flow Integration', () => {
 
       expect(result.success).toBe(true);
 
-      const configPath = path.join(testDir, '.cursor', 'rules.md');
+      const configPath = path.join(testDir, '.cursor', 'rules', 'aiox-global.mdc');
       const content = await fs.readFile(configPath, 'utf8');
 
       // Template should be generated without errors

--- a/tests/unit/config/ide-configs.test.js
+++ b/tests/unit/config/ide-configs.test.js
@@ -8,6 +8,8 @@
  * - Claude Code, Codex CLI, Gemini CLI, Cursor, GitHub Copilot, AntiGravity
  */
 
+const path = require('path');
+
 const {
   IDE_CONFIGS,
   getIDEKeys,
@@ -80,7 +82,7 @@ describe('IDE Configs', () => {
       expect(IDE_CONFIGS['claude-code'].configFile).toContain('.claude');
       expect(IDE_CONFIGS.codex.configFile).toBe('AGENTS.md');
       expect(IDE_CONFIGS.gemini.configFile).toContain('.gemini');
-      expect(IDE_CONFIGS.cursor.configFile).toContain('.cursor');
+      expect(IDE_CONFIGS.cursor.configFile).toBe(path.join('.cursor', 'rules', 'aiox-global.mdc'));
       expect(IDE_CONFIGS['github-copilot'].configFile).toContain('.github');
       expect(IDE_CONFIGS.antigravity.configFile).toContain('.antigravity');
     });
@@ -103,8 +105,7 @@ describe('IDE Configs', () => {
       expect(IDE_CONFIGS.codex.agentFolder).toContain('agents');
       expect(IDE_CONFIGS.gemini.agentFolder).toContain('.gemini');
       expect(IDE_CONFIGS.gemini.agentFolder).toContain('agents');
-      expect(IDE_CONFIGS.cursor.agentFolder).toContain('.cursor');
-      expect(IDE_CONFIGS.cursor.agentFolder).toContain('rules');
+      expect(IDE_CONFIGS.cursor.agentFolder).toBe(path.join('.cursor', 'rules', 'agents'));
       expect(IDE_CONFIGS['github-copilot'].agentFolder).toContain('.github');
       expect(IDE_CONFIGS['github-copilot'].agentFolder).toContain('agents');
       // AntiGravity uses .agent/workflows instead of .antigravity/agents

--- a/tests/unit/wizard/ide-config-generator.test.js
+++ b/tests/unit/wizard/ide-config-generator.test.js
@@ -13,6 +13,7 @@ const {
   generateTemplateVariables,
   generateIDEConfigs,
   generateCodexSkills,
+  createCursorMdcFallbackContent,
   linkGeminiExtension,
   HOOK_EVENT_MAP,
 } = require('../../../packages/installer/src/wizard/ide-config-generator');
@@ -57,6 +58,15 @@ describe('IDE Config Generator', () => {
       const result = renderTemplate(template, variables);
 
       expect(result).toBe('Hello {{name}}!');
+    });
+  });
+
+  describe('createCursorMdcFallbackContent', () => {
+    it('should wrap raw agent markdown in valid Cursor MDC frontmatter', () => {
+      const result = createCursorMdcFallbackContent("dev'ops\nlead", '# Raw agent');
+
+      expect(result).toMatch(/^---\ndescription: 'AIOX agent @dev''ops lead'\nalwaysApply: false\n---/);
+      expect(result).toContain('# Raw agent');
     });
   });
 
@@ -165,13 +175,17 @@ describe('IDE Config Generator', () => {
       // Now includes config file + agent files
       expect(result.files.length).toBeGreaterThanOrEqual(1);
 
-      // v2.1: Cursor uses .cursor/rules.md (not .cursorrules)
-      const configPath = path.join(testDir, '.cursor', 'rules.md');
+      // Cursor uses project rules in .mdc format.
+      const configPath = path.join(testDir, '.cursor', 'rules', 'aiox-global.mdc');
       expect(await fs.pathExists(configPath)).toBe(true);
 
       // Agent folder should also exist
-      const agentFolder = path.join(testDir, '.cursor', 'rules');
+      const agentFolder = path.join(testDir, '.cursor', 'rules', 'agents');
       expect(await fs.pathExists(agentFolder)).toBe(true);
+      expect(await fs.pathExists(path.join(agentFolder, 'dev.mdc'))).toBe(true);
+
+      const agentContent = await fs.readFile(path.join(agentFolder, 'dev.mdc'), 'utf8');
+      expect(agentContent).toContain('alwaysApply: false');
     });
 
     it('should create config files for multiple IDEs', async () => {
@@ -186,12 +200,12 @@ describe('IDE Config Generator', () => {
       // Now includes config files + agent files for each IDE
       expect(result.files.length).toBeGreaterThanOrEqual(2);
 
-      // v2.1: Cursor and Gemini use directory-based rules files
-      expect(await fs.pathExists(path.join(testDir, '.cursor', 'rules.md'))).toBe(true);
+      // Cursor and Gemini use directory-based rules files
+      expect(await fs.pathExists(path.join(testDir, '.cursor', 'rules', 'aiox-global.mdc'))).toBe(true);
       expect(await fs.pathExists(path.join(testDir, '.gemini', 'rules.md'))).toBe(true);
 
       // Agent folders should also exist
-      expect(await fs.pathExists(path.join(testDir, '.cursor', 'rules'))).toBe(true);
+      expect(await fs.pathExists(path.join(testDir, '.cursor', 'rules', 'agents'))).toBe(true);
       expect(await fs.pathExists(path.join(testDir, '.gemini', 'rules', 'AIOX', 'agents'))).toBe(true);
     });
 
@@ -243,14 +257,15 @@ describe('IDE Config Generator', () => {
         projectRoot: testDir,
       });
 
-      // v2.1: Cursor uses .cursor/rules.md (not .cursorrules)
-      const configPath = path.join(testDir, '.cursor', 'rules.md');
+      // Cursor uses .cursor/rules/aiox-global.mdc.
+      const configPath = path.join(testDir, '.cursor', 'rules', 'aiox-global.mdc');
       const content = await fs.readFile(configPath, 'utf8');
 
       // v2.1 templates use static content from .aiox-core/templates/ide-rules/
       // They contain Synkra AIOX standard rules
       expect(content).toContain('Synkra AIOX');
       expect(content).toContain('Development Rules');
+      expect(content).toContain('alwaysApply: true');
     });
 
     it('should create github-copilot config in .github directory', async () => {


### PR DESCRIPTION
## Summary
- Supersedes stale #465 with the current aiox-core paths instead of legacy .aios/.cursorrules.
- Generates Cursor global rules at `.cursor/rules/aiox-global.mdc` and Cursor agents at `.cursor/rules/agents/*.mdc`.
- Adds Cursor MDC front matter to generated rules, redirects, validator orphan detection, and brownfield merge strategy support for `.mdc`.
- Bumps core to 5.1.15 and regenerates the install manifest.

## Validation
- `node -c packages/installer/src/config/ide-configs.js`
- `node -c packages/installer/src/wizard/ide-config-generator.js`
- `node -c .aiox-core/infrastructure/scripts/ide-sync/transformers/cursor.js`
- `node -c .aiox-core/infrastructure/scripts/ide-sync/redirect-generator.js`
- `node -c .aiox-core/infrastructure/scripts/ide-sync/validator.js`
- `node -c bin/aiox-init.js`
- `node -c packages/installer/src/merger/index.js`
- `node -c packages/installer/src/merger/strategies/index.js`
- `npm test -- tests/ide-sync/transformers.test.js tests/ide-sync/validator.test.js tests/unit/config/ide-configs.test.js tests/unit/wizard/ide-config-generator.test.js tests/integration/wizard-ide-flow.test.js --runInBand --forceExit`
- `npm test -- packages/installer/tests/unit/merger/strategies.test.js tests/unit/wizard/ide-config-generator.test.js tests/integration/wizard-ide-flow.test.js --runInBand --forceExit`
- `npm run generate:manifest`
- `npm run sync:ide:cursor -- --dry-run --verbose`
- `git diff --check`
- `npm run validate:manifest`
- `npm run validate:semantic-lint`
- `npm run validate:publish`
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npm run test:ci`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cursor rules now emit MDC-formatted files (.mdc) with YAML front-matter (description, alwaysApply) and per-agent files under a new agents layout.

* **Refactor**
  * Installer and IDE-sync are format-aware: they produce/recognize .mdc agents and redirects and select extensions per IDE format.

* **Tests**
  * Expanded unit/integration tests cover .mdc outputs, filenames, orphan detection, redirect handling and merge behavior.

* **Chores**
  * Version bumped to 5.1.15; manifests and installer mappings refreshed.

* **Documentation**
  * README/docs updated to reflect MDC format and install/sync expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->