### PR TITLE
docs: clarify orchestration lifecycle boundaries

### DIFF
--- a/.aiox-core/development/scripts/workflow-navigator.js
+++ b/.aiox-core/development/scripts/workflow-navigator.js
@@ -10,6 +10,13 @@
  * - State detection from successful command completion
  * - Pre-populated command templates
  * - Numbered list formatting for user selection
+ *
+ * Lifecycle scope:
+ * - Active helper for command suggestions and contextual greetings.
+ * - Does not own persisted workflow/story state.
+ * - Use session-state.js for new persistent epic/story lifecycle state.
+ *
+ * @see .aiox-core/core/orchestration/session-state.js
  */
 
 const fs = require('fs');

--- a/.aiox-core/development/scripts/workflow-state-manager.js
+++ b/.aiox-core/development/scripts/workflow-state-manager.js
@@ -2,9 +2,10 @@
  * Workflow State Manager
  *
  * @deprecated Superseded by session-state.js (Story 11.5).
- * Bob uses SessionState exclusively. This module is maintained for
- * backward compatibility with MasterOrchestrator (Epic 0) only.
- * New code should use: .aiox-core/core/orchestration/session-state.js
+ * This module is maintained for legacy guided workflow tasks and
+ * runtime-first `*next` compatibility only. Bob and new story/epic
+ * lifecycle code must use:
+ * .aiox-core/core/orchestration/session-state.js
  *
  * File-based state persistence for guided workflow automation.
  * Tracks workflow execution progress across Claude Code sessions.

--- a/.aiox-core/development/tasks/next.md
+++ b/.aiox-core/development/tasks/next.md
@@ -5,7 +5,9 @@
 Suggest next commands based on current workflow context using the Workflow Intelligence System (WIS). Helps users navigate workflows efficiently without memorizing command sequences.
 
 AIOX 4.0.4 runtime-first mode adds deterministic next-step recommendation from
-execution signals (story/qa/ci/diff) via `workflow-state-manager`.
+execution signals (story/qa/ci/diff) via `workflow-state-manager`. That module
+is a legacy compatibility helper for `*next`; new persistent story/epic state
+belongs in `.aiox-core/core/orchestration/session-state.js`.
 
 ## Task Definition (AIOX Task Format V1.0)
 

--- a/.aiox-core/development/tasks/run-workflow-engine.md
+++ b/.aiox-core/development/tasks/run-workflow-engine.md
@@ -155,6 +155,7 @@ acceptance-criteria:
 - **Tool:** workflow-state-manager
   - **Purpose:** Create and manage workflow state
   - **Source:** .aiox-core/development/scripts/workflow-state-manager.js
+  - **Lifecycle:** Deprecated for new story/epic lifecycle flows; use `.aiox-core/core/orchestration/session-state.js` outside legacy guided workflow execution
 
 - **Tool:** workflow-validator
   - **Purpose:** Validate workflow before starting

--- a/.aiox-core/development/tasks/run-workflow.md
+++ b/.aiox-core/development/tasks/run-workflow.md
@@ -155,6 +155,7 @@ acceptance-criteria:
 
 - **Tool:** workflow-state-manager
   - **Purpose:** Create, load, save, and query workflow state
+  - **Lifecycle:** Legacy guided workflow state only; new story/epic lifecycle flows use `.aiox-core/core/orchestration/session-state.js`
   - **Implementation:** AI agent reads/writes `.aiox/{instance-id}-state.yaml` files directly
 
 - **Tool:** workflow-validator

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.1.14
-generated_at: "2026-05-07T17:06:48.504Z"
+generated_at: "2026-05-07T19:06:28.424Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1103
 files:
@@ -1713,13 +1713,13 @@ files:
     type: script
     size: 15887
   - path: development/scripts/workflow-navigator.js
-    hash: sha256:45bd9f0317b6a0b9e9577b5b26550f1b7fafec2c45c1b542a6947ffd69a70fec
+    hash: sha256:e9af315c4b6ed0f3a0ccc0956921b04f75865a019ada427bdb1d871a1a059bcb
     type: script
-    size: 9847
+    size: 10120
   - path: development/scripts/workflow-state-manager.js
-    hash: sha256:3a896079b32b8efb8c532c0626c4ce14fb52cc92afbb086f6f2d2a0367d60dec
+    hash: sha256:34b249724bb9b4625b4c6e0c67f412d341927323278867367faf8999d09e741c
     type: script
-    size: 20129
+    size: 20137
   - path: development/scripts/workflow-validator.js
     hash: sha256:abb16e5cd34ec06bbca0a31af3fc500c3a5c98f66d0a72546e4a2827653abcd3
     type: script
@@ -2205,9 +2205,9 @@ files:
     type: task
     size: 13356
   - path: development/tasks/next.md
-    hash: sha256:f3f685218c1df95ef399a9ba3c8ea7c29607e591acc2a7fbc2847a2883f08e02
+    hash: sha256:bc65cd39c47607cef82f4d72e21f80b69ee4d5b1c42f3ffc317d91910fbae4ae
     type: task
-    size: 7641
+    size: 7792
   - path: development/tasks/orchestrate-resume.md
     hash: sha256:c15ca8e699269246cc48a581ca6a956acf6ba9b717024274836d6447cfbccc76
     type: task
@@ -2393,13 +2393,13 @@ files:
     type: task
     size: 16130
   - path: development/tasks/run-workflow-engine.md
-    hash: sha256:885b63bbfb3506740398768bc4979947acfc4063c5638d89566f6e6da74aaabb
+    hash: sha256:c1f10d20c25283675ca8b7f3644699c17298d7ffd2745640e252aa40bb654397
     type: task
-    size: 26147
+    size: 26307
   - path: development/tasks/run-workflow.md
-    hash: sha256:01a7addd0554399249541012f93f3ab2dd46e69336ba4f96737bc4e271b22b4b
+    hash: sha256:484bb719fc4b4584875370647c59c04bdc24b57eaaf6b99460404b57f80772b1
     type: task
-    size: 10587
+    size: 10725
   - path: development/tasks/search-mcp.md
     hash: sha256:4c7d9239c740b250baf9d82a5aa3baf1cd0bb8c671f0889c9a6fc6c0a668ac9c
     type: task

--- a/.gitignore
+++ b/.gitignore
@@ -247,7 +247,9 @@ docs/handoffs/
 docs/requirements/
 docs/releases/
 docs/standards/
-docs/architecture/
+docs/architecture/*
+!docs/architecture/
+!docs/architecture/orchestration-hierarchy.md
 docs/agents/
 docs/private/
 

--- a/docs/architecture/orchestration-hierarchy.md
+++ b/docs/architecture/orchestration-hierarchy.md
@@ -1,0 +1,76 @@
+# Orchestration Hierarchy
+
+This document defines the current ownership boundaries for AIOX orchestration
+modules and the lifecycle status of legacy workflow scripts.
+
+## Decision Summary
+
+New story and epic lifecycle state must use
+`.aiox-core/core/orchestration/session-state.js`.
+
+`.aiox-core/development/scripts/workflow-state-manager.js` is deprecated for new
+lifecycle work. It remains available only for legacy guided workflow tasks and
+`*next` compatibility until those entry points are migrated.
+
+`.aiox-core/development/scripts/workflow-navigator.js` is not deprecated. It is
+an active read-only suggestion helper and must not become the owner of persisted
+state.
+
+## Module Boundaries
+
+| Module | Status | Owns | Should Be Used For | Should Not Be Used For |
+| --- | --- | --- | --- | --- |
+| `BobOrchestrator` | Active | Project-state decision tree for Bob/PM flows | Greenfield and brownfield routing, story-driven development orchestration, observability callbacks | Generic YAML workflow execution or ADE Epic 0 compatibility |
+| `MasterOrchestrator` | Active legacy/ADE | Epic 0 autonomous development pipeline | Coordinating ADE epics, gates, recovery, and agent invocation | Bob project-state routing or new Bob session persistence |
+| `WorkflowOrchestrator` | Active | Generic YAML workflow execution | Multi-agent workflow phases loaded from workflow YAML | Bob decision-tree routing or story/epic session persistence |
+| `SessionState` | Canonical | Persistent epic/story lifecycle state | Crash recovery, Bob progress tracking, story/epic resume state | Stateless command suggestions |
+| `WorkflowNavigator` | Active helper | Command suggestions from workflow patterns and context | Greeting-time suggestions, next-step hints, read-only navigation | Persisting or mutating workflow/story state |
+| `WorkflowStateManager` | Deprecated compatibility | Legacy guided workflow state files | Existing `run-workflow`, `run-workflow-engine`, and `next` compatibility | New Bob, story, or epic lifecycle state |
+
+## State Ownership
+
+| State Surface | Owner | Path | Notes |
+| --- | --- | --- | --- |
+| Bob/story/epic session state | `SessionState` | `docs/stories/.session-state.yaml` | Canonical for new persistent lifecycle state |
+| Legacy guided workflow state | `WorkflowStateManager` | `.aiox/{instance-id}-state.yaml` | Deprecated compatibility surface |
+| Legacy workflow-state directory | `SessionState` migrator | `.aiox/workflow-state/` | Migration input for ADR-011 compatibility |
+| Contextual command suggestions | `WorkflowNavigator` | None | Reads patterns/context and returns suggestions only |
+
+## Import Rules
+
+- New orchestration code must import `SessionState` for persistent story or epic
+  lifecycle state.
+- New code may import `WorkflowNavigator` only for read-only command suggestions.
+- New imports of `workflow-state-manager.js` are allowed only when maintaining
+  legacy `run-workflow`, `run-workflow-engine`, or `next` compatibility.
+- Task files that reference `workflow-state-manager.js` must include a fallback
+  note pointing new lifecycle work to `session-state.js`.
+- No orchestration module should import deprecated state helpers without a
+  compatibility reason documented near the reference.
+
+## Current Relationships
+
+```mermaid
+graph TD
+    Bob[BobOrchestrator] --> SessionState[SessionState]
+    Bob --> WorkflowExecutor[WorkflowExecutor]
+    Master[MasterOrchestrator] --> Gates[GateEvaluator]
+    Master --> Recovery[RecoveryHandler]
+    Master --> AgentInvoker[AgentInvoker]
+    WorkflowOrchestrator[WorkflowOrchestrator] --> ContextManager[ContextManager]
+    WorkflowOrchestrator --> ParallelExecutor[ParallelExecutor]
+    Greeting[GreetingBuilder] --> Navigator[WorkflowNavigator]
+    RunWorkflow[run-workflow tasks] --> LegacyState[WorkflowStateManager]
+    Next[next task] --> LegacyState
+    SessionState -. migrates .-> LegacyDir[.aiox/workflow-state]
+```
+
+## Migration Guidance
+
+When touching legacy guided workflow execution, keep changes narrow and preserve
+compatibility. Do not rename legacy state files unless the caller has an
+explicit migration path.
+
+When building new Bob or story-driven development behavior, skip
+`WorkflowStateManager` entirely and store lifecycle information through
+`SessionState`.

--- a/docs/architecture/orchestration-hierarchy.md
+++ b/docs/architecture/orchestration-hierarchy.md
@@ -67,7 +67,7 @@ graph TD
 
 ## Migration Guidance
 
-When touching legacy guided workflow execution, keep changes narrow and preserve
+When touching legacy-guided workflow execution, keep changes narrow and preserve
 compatibility. Do not rename legacy state files unless the caller has an
 explicit migration path.
 

--- a/docs/core-architecture.md
+++ b/docs/core-architecture.md
@@ -84,6 +84,7 @@ The `aiox-core` directory contains all the definitions and resources that give t
 
 - **Purpose**: Workflows are YAML files (e.g., `greenfield-fullstack.yaml`) that define a prescribed sequence of steps and agent interactions for a specific project type. They act as a strategic guide for the user and the `aiox-orchestrator` agent.
 - **Structure**: A workflow defines sequences for both complex and simple projects, lists the agents involved at each step, the artifacts they create, and the conditions for moving from one step to the next. It often includes a Mermaid diagram for visualization.
+- **Orchestration hierarchy**: See [Orchestration Hierarchy](./architecture/orchestration-hierarchy.md) for the boundary between `BobOrchestrator`, `MasterOrchestrator`, `WorkflowOrchestrator`, `WorkflowNavigator`, `SessionState`, and the deprecated `workflow-state-manager`.
 
 ### 3.4. Reusable Resources (`templates`, `tasks`, `checklists`, `data`)
 

--- a/docs/guides/workflows/xref-phase3-scripts.md
+++ b/docs/guides/workflows/xref-phase3-scripts.md
@@ -45,8 +45,8 @@
 | 21 | `task-identifier-resolver.js` | Resolves `{TODO: task identifier}` placeholders in 114 task files | `fs`, `path` | `install-manifest.yaml` | One-time migration tool | Low-use |
 | 22 | `validate-task-v2.js` | Validates task files against V2.0 specification (11 compliance rules) | `fs`, `path` | 9 files: `migrate-task-to-v2.js`, docs | @qa, @dev | No |
 | 23 | `migrate-task-to-v2.js` | Semi-automated V1.0 to V2.0 task migration helper | `fs`, `path` | 9 files: `validate-task-v2.js`, docs | @dev migration | Low-use |
-| 24 | `workflow-navigator.js` | Provides intelligent next-step command suggestions from workflow patterns | `fs`, `path`, `js-yaml` | 18 files: `greeting-builder.js`, tasks, docs | All (via greeting-builder) | No |
-| 25 | `workflow-state-manager.js` | File-based state persistence for guided workflow automation across sessions | `fs.promises`, `path`, `js-yaml` | 18 files: `run-workflow.md`, `run-workflow-engine.md`, tasks | @sm, @pm | No |
+| 24 | `workflow-navigator.js` | Active helper for next-step command suggestions from workflow patterns; does not own persisted state | `fs`, `path`, `js-yaml` | 18 files: `greeting-builder.js`, tasks, docs | All (via greeting-builder) | No |
+| 25 | `workflow-state-manager.js` | Deprecated compatibility helper for legacy guided workflow state; new story/epic lifecycle state uses `session-state.js` | `fs.promises`, `path`, `js-yaml` | Legacy `run-workflow`, `run-workflow-engine`, and `next` task compatibility | @sm, @pm | No |
 | 26 | `workflow-validator.js` | Validates workflow YAML files against AIOX conventions (9 checks) | `fs.promises`, `path`, `js-yaml` | 18 files: `validate-workflow.md`, `squad-validator.js`, tasks | @qa, @architect | No |
 | 27 | `verify-workflow-gaps.js` | Verification script for workflow gap fixes (GAP 1, 2, 3) | `fs`, `path`, `js-yaml` | 18 files: docs, `install-manifest.yaml` | Verification tool | Low-use |
 | 28 | `decision-context.js` | (See #13 above -- same file) | -- | -- | -- | -- |


### PR DESCRIPTION
## Summary
- add `docs/architecture/orchestration-hierarchy.md` to clarify orchestration lifecycle boundaries
- align related workflow/task docs and scripts with the documented lifecycle expectations

## Validation
- `git diff --check`
- `npm run validate:paths`
- `python3 scripts/check-markdown-links.py --dir docs/architecture --summary`

## Notes
- focused Jest did not run in this worktree because `node_modules` is absent (`sh: jest: command not found`)

Closes #90


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added orchestration guidance clarifying module boundaries, lifecycle ownership, migration guidance, and import constraints.
  * Deprecated the legacy workflow state helper and directed new workflows to use persistent session-based state management.
  * Clarified the navigator is a read-only suggestion helper for contextual guidance, not for persisted state.
* **Chores**
  * Refined ignore rules and refreshed generated manifest metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->