### PR TITLE
fix: harden Claude CLI prompt execution via stdin

### DIFF
--- a/.aiox-core/core/execution/build-orchestrator.js
+++ b/.aiox-core/core/execution/build-orchestrator.js
@@ -501,9 +501,13 @@ The subtask is complete only when verification passes.
   }
 
   /**
-   * Run Claude CLI with prompt
+   * Run Claude CLI with prompt delivered through stdin.
    */
-  async runClaudeCLI(prompt, workDir, config) {
+  async runClaudeCLI(prompt, workDir, config = {}) {
+    if (!prompt || typeof prompt !== 'string') {
+      throw new Error('runClaudeCLI requires a non-empty string prompt');
+    }
+
     return new Promise((resolve, reject) => {
       const args = [
         '--print', // Non-interactive mode
@@ -514,21 +518,58 @@ The subtask is complete only when verification passes.
         args.push('--model', config.claudeModel);
       }
 
-      // Escape prompt for shell
-      const escapedPrompt = prompt.replace(/'/g, "'\\''");
-
-      const fullCommand = `echo '${escapedPrompt}' | claude ${args.join(' ')}`;
-
       this.log(`Running Claude CLI in ${workDir}`, 'debug');
 
-      const child = spawn('sh', ['-c', fullCommand], {
+      const child = spawn('claude', args, {
         cwd: workDir,
         env: { ...process.env },
         timeout: config.subtaskTimeout,
+        stdio: ['pipe', 'pipe', 'pipe'],
       });
 
       let stdout = '';
       let stderr = '';
+      let stdinError = null;
+      let settled = false;
+
+      const resolveOnce = (result) => {
+        if (settled) return;
+        settled = true;
+        resolve(result);
+      };
+
+      const rejectOnce = (error) => {
+        if (settled) return;
+        settled = true;
+        reject(error);
+      };
+
+      child.on('error', rejectOnce);
+
+      if (!child.stdin || typeof child.stdin.write !== 'function' || typeof child.stdin.end !== 'function') {
+        rejectOnce(new Error('Claude CLI stdin is not available'));
+        return;
+      }
+
+      child.stdin.on('error', (error) => {
+        stdinError = error;
+        this.log(`Claude stdin stream error: ${error.message}`, 'debug');
+      });
+
+      if (child.stdin.writable === false) {
+        child.kill?.();
+        rejectOnce(new Error('Claude CLI stdin is not writable'));
+        return;
+      }
+
+      try {
+        child.stdin.write(prompt);
+        child.stdin.end();
+      } catch (error) {
+        child.kill?.();
+        rejectOnce(new Error(`Claude CLI stdin write failed: ${error.message}`));
+        return;
+      }
 
       child.stdout.on('data', (data) => {
         stdout += data.toString();
@@ -544,16 +585,16 @@ The subtask is complete only when verification passes.
         }
       });
 
-      child.on('close', (code) => {
-        if (code === 0) {
-          resolve({ stdout, stderr, code });
+      child.on('close', (code, signal) => {
+        if (stdinError) {
+          rejectOnce(new Error(`Claude CLI stdin write failed: ${stdinError.message}`));
+        } else if (code === 0) {
+          resolveOnce({ stdout, stderr, code });
+        } else if (signal) {
+          rejectOnce(new Error(`Claude CLI killed by signal ${signal}: ${stderr}`));
         } else {
-          reject(new Error(`Claude CLI exited with code ${code}: ${stderr}`));
+          rejectOnce(new Error(`Claude CLI exited with code ${code}: ${stderr}`));
         }
-      });
-
-      child.on('error', (error) => {
-        reject(error);
       });
     });
   }

--- a/.aiox-core/core/execution/subagent-dispatcher.js
+++ b/.aiox-core/core/execution/subagent-dispatcher.js
@@ -110,6 +110,7 @@ class SubagentDispatcher extends EventEmitter {
     // Retry configuration
     this.maxRetries = config.maxRetries || 2;
     this.retryDelay = config.retryDelay || 2000;
+    this.claudeTimeout = config.claudeTimeout || 10 * 60 * 1000;
 
     // Dependencies
     this.memoryQuery = config.memoryQuery || (MemoryQuery ? new MemoryQuery() : null);
@@ -659,24 +660,68 @@ class SubagentDispatcher extends EventEmitter {
   }
 
   /**
-   * Execute prompt via Claude CLI
+   * Execute prompt via Claude CLI using stdin.
    * @param {string} prompt - Prompt to execute
    * @returns {Promise<Object>} - Execution result
    */
   executeClaude(prompt) {
+    if (!prompt || typeof prompt !== 'string') {
+      return Promise.reject(new Error('executeClaude requires a non-empty string prompt'));
+    }
+
     return new Promise((resolve, reject) => {
       const args = ['--print', '--dangerously-skip-permissions'];
-      const escapedPrompt = prompt.replace(/'/g, "'\\''");
-      const fullCommand = `echo '${escapedPrompt}' | claude ${args.join(' ')}`;
 
-      const child = spawn('sh', ['-c', fullCommand], {
+      const child = spawn('claude', args, {
         cwd: this.rootPath,
         env: { ...process.env },
         stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: this.claudeTimeout,
       });
 
       let stdout = '';
       let stderr = '';
+      let stdinError = null;
+      let settled = false;
+
+      const resolveOnce = (result) => {
+        if (settled) return;
+        settled = true;
+        resolve(result);
+      };
+
+      const rejectOnce = (error) => {
+        if (settled) return;
+        settled = true;
+        reject(error);
+      };
+
+      child.on('error', rejectOnce);
+
+      if (!child.stdin || typeof child.stdin.write !== 'function' || typeof child.stdin.end !== 'function') {
+        rejectOnce(new Error('Claude CLI stdin is not available'));
+        return;
+      }
+
+      child.stdin.on('error', (error) => {
+        stdinError = error;
+        this.log('stdin_write_error', { error: error.message, code: error.code });
+      });
+
+      if (child.stdin.writable === false) {
+        child.kill?.();
+        rejectOnce(new Error('Claude CLI stdin is not writable'));
+        return;
+      }
+
+      try {
+        child.stdin.write(prompt);
+        child.stdin.end();
+      } catch (error) {
+        child.kill?.();
+        rejectOnce(new Error(`Claude CLI stdin write failed: ${error.message}`));
+        return;
+      }
 
       child.stdout.on('data', (data) => {
         stdout += data.toString();
@@ -686,20 +731,20 @@ class SubagentDispatcher extends EventEmitter {
         stderr += data.toString();
       });
 
-      child.on('close', (code) => {
-        if (code === 0) {
-          resolve({
+      child.on('close', (code, signal) => {
+        if (stdinError) {
+          rejectOnce(new Error(`Claude CLI stdin write failed: ${stdinError.message}`));
+        } else if (code === 0) {
+          resolveOnce({
             success: true,
             output: stdout,
             filesModified: this.extractModifiedFiles(stdout),
           });
+        } else if (signal) {
+          rejectOnce(new Error(`Claude CLI killed by signal ${signal}: ${stderr || stdout}`));
         } else {
-          reject(new Error(`Claude CLI exited with code ${code}: ${stderr || stdout}`));
+          rejectOnce(new Error(`Claude CLI exited with code ${code}: ${stderr || stdout}`));
         }
-      });
-
-      child.on('error', (error) => {
-        reject(error);
       });
     });
   }

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.1.15
-generated_at: "2026-05-08T00:07:45.552Z"
+generated_at: "2026-05-08T00:32:00.816Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1104
 files:
@@ -405,9 +405,9 @@ files:
     type: core
     size: 34050
   - path: core/execution/build-orchestrator.js
-    hash: sha256:3698635011a845dfc43c46dfd7f15c0aa3ab488938ea3bd281de29157f5c4687
+    hash: sha256:51aec922a58d5d4121ef156bb961ac7b8f29db711679897fdade6ca71a1635e5
     type: core
-    size: 31780
+    size: 33071
   - path: core/execution/build-state-manager.js
     hash: sha256:415fca3ad3d750db1f41f14f33971cf661ee9d6073a570175d695bb3c1be655c
     type: core
@@ -437,9 +437,9 @@ files:
     type: core
     size: 51556
   - path: core/execution/subagent-dispatcher.js
-    hash: sha256:a69a03b714a39c8daf59ce2bcfb03cc6168f25e1fab07a754bd0ac7c3a91109b
+    hash: sha256:26e2bbc4b30142186e8ad450aced18284f8333677af0fb506e0b19a8324e94f2
     type: core
-    size: 26595
+    size: 28002
   - path: core/execution/wave-executor.js
     hash: sha256:4e2324edb37ae0729062b5ac029f2891e050e7efd3a48d0f4a1dc4f227a6716b
     type: core

--- a/tests/core/claude-execution-robustness.test.js
+++ b/tests/core/claude-execution-robustness.test.js
@@ -1,0 +1,163 @@
+/**
+ * Claude execution robustness.
+ *
+ * Verifies that execution prompts are delivered through stdin instead of shell
+ * interpolation, which keeps quotes, pipes, and other shell-sensitive text safe.
+ */
+
+jest.mock('child_process', () => ({
+  spawn: jest.fn(),
+}));
+
+jest.mock('../../.aiox-core/workflow-intelligence/engine/wave-analyzer', () => null);
+jest.mock('../../.aiox-core/infrastructure/scripts/worktree-manager', () => { throw new Error('not available'); });
+jest.mock('../../.aiox-core/core/memory/gotchas-memory', () => ({ GotchasMemory: jest.fn() }));
+
+const EventEmitter = require('events');
+const childProcess = require('child_process');
+const { mockChildProcess, createMockMemoryQuery, createMockGotchasMemory } = require('./execution-test-helpers');
+const { SubagentDispatcher } = require('../../.aiox-core/core/execution/subagent-dispatcher');
+const { BuildOrchestrator } = require('../../.aiox-core/core/execution/build-orchestrator');
+
+function attachMockStdin(mockProcess) {
+  const stdin = new EventEmitter();
+  stdin.write = jest.fn();
+  stdin.end = jest.fn();
+  stdin.writable = true;
+  mockProcess.stdin = stdin;
+  return stdin;
+}
+
+describe('Claude execution robustness', () => {
+  let mockSpawn;
+  let memoryQuery;
+  let gotchasMemory;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSpawn = mockChildProcess('simulated output', '', 0);
+    attachMockStdin(mockSpawn.process);
+    childProcess.spawn.mockReturnValue(mockSpawn.process);
+
+    memoryQuery = createMockMemoryQuery();
+    gotchasMemory = createMockGotchasMemory();
+  });
+
+  describe('SubagentDispatcher.executeClaude', () => {
+    test('writes prompt through stdin instead of shell interpolation', async () => {
+      const dispatcher = new SubagentDispatcher({
+        rootPath: '/tmp/project',
+        memoryQuery,
+        gotchasMemory,
+      });
+      const prompt = "Do this with 'quotes' and | pipes";
+
+      const promise = dispatcher.executeClaude(prompt);
+      mockSpawn.emitData();
+      const result = await promise;
+
+      expect(childProcess.spawn).toHaveBeenCalledWith(
+        'claude',
+        ['--print', '--dangerously-skip-permissions'],
+        expect.objectContaining({
+          cwd: '/tmp/project',
+          stdio: ['pipe', 'pipe', 'pipe'],
+          timeout: 10 * 60 * 1000,
+        }),
+      );
+      expect(mockSpawn.process.stdin.write).toHaveBeenCalledWith(prompt);
+      expect(mockSpawn.process.stdin.end).toHaveBeenCalled();
+      expect(result).toMatchObject({
+        success: true,
+        output: 'simulated output',
+      });
+    });
+
+    test('rejects invalid prompts before spawning Claude', async () => {
+      const dispatcher = new SubagentDispatcher({ memoryQuery, gotchasMemory });
+
+      await expect(dispatcher.executeClaude('')).rejects.toThrow('non-empty string prompt');
+      await expect(dispatcher.executeClaude(null)).rejects.toThrow('non-empty string prompt');
+      expect(childProcess.spawn).not.toHaveBeenCalled();
+    });
+
+    test('reports stdin write errors before treating process exit as success', async () => {
+      const dispatcher = new SubagentDispatcher({
+        rootPath: '/tmp/project',
+        memoryQuery,
+        gotchasMemory,
+      });
+      const stdin = mockSpawn.process.stdin;
+
+      const promise = dispatcher.executeClaude('test prompt');
+      stdin.emit('error', new Error('EPIPE'));
+      mockSpawn.emitData();
+
+      await expect(promise).rejects.toThrow('Claude CLI stdin write failed: EPIPE');
+    });
+
+    test('reports non-zero exit codes', async () => {
+      mockSpawn = mockChildProcess('', 'command failed', 1);
+      attachMockStdin(mockSpawn.process);
+      childProcess.spawn.mockReturnValue(mockSpawn.process);
+
+      const dispatcher = new SubagentDispatcher({ memoryQuery, gotchasMemory });
+      const promise = dispatcher.executeClaude('test prompt');
+      mockSpawn.emitData();
+
+      await expect(promise).rejects.toThrow('Claude CLI exited with code 1: command failed');
+    });
+  });
+
+  describe('BuildOrchestrator.runClaudeCLI', () => {
+    test('writes prompt through stdin and keeps model override', async () => {
+      const orchestrator = new BuildOrchestrator({ rootPath: '/tmp/project' });
+      const prompt = 'Build this component';
+
+      const promise = orchestrator.runClaudeCLI(prompt, '/tmp/work', {
+        claudeModel: 'claude-3-opus',
+        subtaskTimeout: 5000,
+      });
+      mockSpawn.emitData();
+      const result = await promise;
+
+      expect(childProcess.spawn).toHaveBeenCalledWith(
+        'claude',
+        ['--print', '--dangerously-skip-permissions', '--model', 'claude-3-opus'],
+        expect.objectContaining({
+          cwd: '/tmp/work',
+          stdio: ['pipe', 'pipe', 'pipe'],
+          timeout: 5000,
+        }),
+      );
+      expect(mockSpawn.process.stdin.write).toHaveBeenCalledWith(prompt);
+      expect(result).toMatchObject({
+        stdout: 'simulated output',
+        code: 0,
+      });
+    });
+
+    test('rejects invalid prompts before spawning Claude', async () => {
+      const orchestrator = new BuildOrchestrator({ rootPath: '/tmp/project' });
+
+      await expect(orchestrator.runClaudeCLI(null, '/tmp/work')).rejects.toThrow(
+        'non-empty string prompt',
+      );
+      expect(childProcess.spawn).not.toHaveBeenCalled();
+    });
+
+    test('reports spawn errors', async () => {
+      const errProcess = new EventEmitter();
+      errProcess.stdout = new EventEmitter();
+      errProcess.stderr = new EventEmitter();
+      attachMockStdin(errProcess);
+      childProcess.spawn.mockReturnValue(errProcess);
+
+      const orchestrator = new BuildOrchestrator({ rootPath: '/tmp/project' });
+      const promise = orchestrator.runClaudeCLI('test prompt', '/tmp/work');
+      process.nextTick(() => errProcess.emit('error', new Error('spawn ENOENT')));
+
+      await expect(promise).rejects.toThrow('spawn ENOENT');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces shell interpolation (`echo ... | claude`) with direct `spawn('claude', args)` execution and stdin prompt delivery.
- Adds prompt validation plus explicit handling for spawn errors, stdin write failures, process signals, and non-zero exits.
- Adds regression coverage for shell-sensitive prompt text and stdin failure paths.
- Regenerates install manifest hashes for the modified core execution files.

Supersedes #142 with a fresh branch based on current `main` because the original fork PR is dirty and `maintainerCanModify=false`.

## Validation
- `git diff --check`
- `npm run validate:manifest`
- `npm run lint`
- `npm run typecheck`
- `npm run validate:publish`
- `npm test -- tests/core/claude-execution-robustness.test.js tests/core/subagent-dispatcher.test.js tests/core/build-orchestrator.test.js --runInBand --forceExit` — 3 suites, 93 tests passed
- `npm test -- --runInBand --forceExit` — 319 suites passed, 11 skipped; 7,898 tests passed, 149 skipped

## Notes
- Existing test-suite logs/warnings are pre-existing diagnostic output from older tests; no new failures were introduced.
