### PR TITLE
fix(ids): drain queued registry updates during active flush

### DIFF
--- a/.aiox-core/core/ids/registry-updater.js
+++ b/.aiox-core/core/ids/registry-updater.js
@@ -203,13 +203,22 @@ class RegistryUpdater {
     const normalized = path.resolve(filePath).replace(/\\/g, '/');
     this._pendingUpdates.set(normalized, { action, filePath: normalized, timestamp: Date.now() });
 
+    this._scheduleFlush('Flush failed');
+  }
+
+  _scheduleFlush(errorLabel) {
     if (this._debounceTimer) {
       clearTimeout(this._debounceTimer);
     }
+
     this._debounceTimer = setTimeout(() => {
+      this._debounceTimer = null;
       this._flushPending().catch((err) => {
-        console.error(`[IDS-Updater] Flush failed: ${err.message}`);
+        console.error(`[IDS-Updater] ${errorLabel}: ${err.message}`);
         this._isProcessing = false;
+        if (this._pendingUpdates.size > 0) {
+          this._scheduleFlush('Deferred flush failed');
+        }
       });
     }, this._debounceMs);
   }
@@ -219,14 +228,7 @@ class RegistryUpdater {
 
     if (this._isProcessing) {
       // Re-schedule flush — don't drop pending updates
-      if (!this._debounceTimer) {
-        this._debounceTimer = setTimeout(() => {
-          this._flushPending().catch((err) => {
-            console.error(`[IDS-Updater] Deferred flush failed: ${err.message}`);
-            this._isProcessing = false;
-          });
-        }, this._debounceMs);
-      }
+      this._scheduleFlush('Deferred flush failed');
       return;
     }
 

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.1.15
-generated_at: "2026-05-08T00:32:00.816Z"
+generated_at: "2026-05-08T02:21:46.248Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1104
 files:
@@ -745,9 +745,9 @@ files:
     type: core
     size: 8096
   - path: core/ids/registry-updater.js
-    hash: sha256:4873507324efab32ba59e1ade70aaa79f318f9c5d689bdb747d8721effba38d1
+    hash: sha256:194ecce0795fbf8654a7c69799252765d738d50274dd406f575d796c21c3b754
     type: core
-    size: 24542
+    size: 24513
   - path: core/ids/verification-gate.js
     hash: sha256:96050661c90fa52bfc755911d02c9194ec35c00e71fc6bbc92a13686dd53bb91
     type: core

--- a/tests/core/ids/registry-updater.test.js
+++ b/tests/core/ids/registry-updater.test.js
@@ -703,6 +703,61 @@ describe('RegistryUpdater', () => {
       expect(registry.entities).toBeDefined();
       expect(registry.entities.tasks).toBeDefined();
     });
+
+    it('drains watcher updates queued while a batch is processing', async () => {
+      jest.useFakeTimers();
+
+      try {
+        const updater = createUpdater({ debounceMs: 10 });
+        const batches = [];
+        let releaseFirstBatch;
+        const firstBatchGate = new Promise((resolve) => {
+          releaseFirstBatch = resolve;
+        });
+
+        updater._executeBatch = jest.fn(async (batch) => {
+          batches.push(batch.map((item) => path.basename(item.filePath)));
+          updater._isProcessing = true;
+
+          try {
+            if (batches.length === 1) {
+              await firstBatchGate;
+            }
+            return { updated: batch.length, errors: [] };
+          } finally {
+            updater._isProcessing = false;
+          }
+        });
+
+        const firstFile = createTempFile(
+          '.aiox-core/development/tasks/queued-a.md',
+          '# Queued A\n\n## Purpose\nFirst queued update.\n',
+        );
+        updater._queueUpdate('add', firstFile);
+        await jest.advanceTimersByTimeAsync(10);
+
+        expect(batches).toEqual([['queued-a.md']]);
+
+        const secondFile = createTempFile(
+          '.aiox-core/development/tasks/queued-b.md',
+          '# Queued B\n\n## Purpose\nSecond queued update.\n',
+        );
+        updater._queueUpdate('add', secondFile);
+        await jest.advanceTimersByTimeAsync(10);
+
+        expect(updater.getStats().pendingUpdates).toBe(1);
+
+        releaseFirstBatch();
+        await Promise.resolve();
+        await jest.advanceTimersByTimeAsync(10);
+
+        expect(updater._executeBatch).toHaveBeenCalledTimes(2);
+        expect(batches).toEqual([['queued-a.md'], ['queued-b.md']]);
+        expect(updater.getStats().pendingUpdates).toBe(0);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
   });
 
   describe('Performance (AC: 7)', () => {


### PR DESCRIPTION
## Summary
- fixes a RegistryUpdater watcher-queue edge case where updates queued during an active batch could remain pending forever
- treats debounce timers as consumed before flush execution and re-schedules while processing is still active
- adds a regression test for queued watcher updates during an in-flight batch

## Validation
- NODE_PATH=/Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules /Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules/.bin/jest tests/core/ids/registry-updater.test.js --runInBand --forceExit
  - 40 passed
- git diff --check
- NODE_PATH=/Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules /Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules/.bin/eslint . --cache --cache-location .eslintcache
  - 0 errors, 114 baseline warnings
- NODE_PATH=/Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules /Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules/.bin/tsc --noEmit
- NODE_PATH=/Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules /Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules/.bin/jest --runInBand --forceExit
  - Test Suites: 12 skipped, 327 passed, 327 of 339 total
  - Tests: 170 skipped, 8294 passed, 8464 total

Refs #621

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized debounced update scheduling and error recovery so processing state is cleared on failure, errors are logged consistently, and pending updates are rescheduled.

* **Tests**
  * Added tests ensuring updates queued during an active batch are drained correctly and processing state remains consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->