### PR TITLE
feat(cli): add external executor delegation

### DIFF
--- a/.aiox-core/core/config/schemas/framework-config.schema.json
+++ b/.aiox-core/core/config/schemas/framework-config.schema.json
@@ -112,7 +112,7 @@
         "default_sandbox": {
           "type": "string",
           "enum": ["read-only", "workspace-write", "full-auto", "danger-full-access"],
-          "default": "full-auto"
+          "default": "workspace-write"
         },
         "run_dir": {
           "type": "string",

--- a/.aiox-core/core/config/schemas/framework-config.schema.json
+++ b/.aiox-core/core/config/schemas/framework-config.schema.json
@@ -80,6 +80,47 @@
       },
       "additionalProperties": false
     },
+    "dev": {
+      "type": "object",
+      "description": "Development execution defaults",
+      "properties": {
+        "execution_mode": {
+          "type": "string",
+          "enum": ["native", "delegate"],
+          "default": "native"
+        },
+        "delegate_to": {
+          "type": "string",
+          "description": "Default external executor provider when execution_mode=delegate"
+        },
+        "auto_review": {
+          "type": "boolean",
+          "description": "Require orchestrator review before story state mutation",
+          "default": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "external_executors": {
+      "type": "object",
+      "description": "External executor provider defaults",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": false
+        },
+        "default_sandbox": {
+          "type": "string",
+          "enum": ["read-only", "workspace-write", "full-auto", "danger-full-access"],
+          "default": "full-auto"
+        },
+        "run_dir": {
+          "type": "string",
+          "default": ".aiox/external-runs"
+        }
+      },
+      "additionalProperties": false
+    },
     "utility_scripts_registry": {
       "type": "object",
       "description": "Registry of utility scripts by category",

--- a/.aiox-core/core/external-executors/delegate-cli.js
+++ b/.aiox-core/core/external-executors/delegate-cli.js
@@ -46,10 +46,11 @@ const PROVIDERS = {
 };
 
 class DelegateCliError extends Error {
-  constructor(message, exitCode = 1) {
+  constructor(message, exitCode = 1, cause = null) {
     super(message);
     this.name = 'DelegateCliError';
     this.exitCode = exitCode;
+    this.cause = cause;
   }
 }
 
@@ -92,7 +93,7 @@ function parseArgs(argv) {
     workdir: process.cwd(),
     model: null,
     profile: null,
-    sandbox: 'full-auto',
+    sandbox: 'workspace-write',
     runDirBase: DEFAULT_RUN_DIR,
     images: [],
     allowDirty: false,
@@ -244,8 +245,28 @@ function resolvePathFrom(baseDir, value) {
 function loadPrompt(options) {
   if (options.promptFile) {
     const promptFile = path.resolve(options.promptFile);
+    let text;
+
+    try {
+      text = fs.readFileSync(promptFile, 'utf8');
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        throw new DelegateCliError(
+          `Prompt file not found: ${promptFile}. Use --prompt for inline text or --prompt-file <path> for an existing file.`,
+          2,
+          error,
+        );
+      }
+
+      throw new DelegateCliError(
+        `Could not read prompt file ${promptFile}: ${error.message}`,
+        2,
+        error,
+      );
+    }
+
     return {
-      text: fs.readFileSync(promptFile, 'utf8'),
+      text,
       source: promptFile,
     };
   }
@@ -409,37 +430,92 @@ function writeRunFiles(plan, pid = null) {
 }
 
 async function spawnExecutor(plan) {
+  fs.mkdirSync(path.dirname(plan.logPath), { recursive: true });
   const logFd = fs.openSync(plan.logPath, 'a');
-  const child = spawn(plan.command, plan.args, {
-    cwd: plan.options.workdir,
-    detached: !plan.options.foreground,
-    stdio: ['pipe', logFd, logFd],
-    env: process.env,
-  });
+  let logClosed = false;
+  let child;
 
-  child.stdin.write(plan.prompt.text);
-  child.stdin.end();
+  const closeLog = () => {
+    if (!logClosed) {
+      fs.closeSync(logFd);
+      logClosed = true;
+    }
+  };
 
-  writeRunFiles(plan, child.pid);
+  const recordSpawnError = (error) => {
+    if (!logClosed) {
+      fs.writeSync(logFd, `\n[aiox-delegate] executor error: ${error.message}\n`);
+    }
+  };
 
-  if (!plan.options.foreground) {
-    child.unref();
-    fs.closeSync(logFd);
-    return { status: 'started', pid: child.pid, exitCode: 0 };
+  try {
+    child = spawn(plan.command, plan.args, {
+      cwd: plan.options.workdir,
+      detached: !plan.options.foreground,
+      stdio: ['pipe', logFd, logFd],
+      env: process.env,
+    });
+  } catch (error) {
+    recordSpawnError(error);
+    writeRunFiles(plan, null);
+    closeLog();
+    return { status: 'failed', pid: null, exitCode: 1, error: error.message };
   }
 
-  const exitCode = await new Promise((resolve) => {
-    child.on('close', (code) => {
-      fs.closeSync(logFd);
-      resolve(code || 0);
+  writeRunFiles(plan, child.pid || null);
+
+  const errorResult = new Promise((resolve) => {
+    child.once('error', (error) => {
+      recordSpawnError(error);
+      closeLog();
+      resolve({
+        status: 'failed',
+        pid: child.pid || null,
+        exitCode: 1,
+        error: error.message,
+      });
     });
   });
 
-  return {
-    status: exitCode === 0 ? 'completed' : 'failed',
-    pid: child.pid,
-    exitCode,
-  };
+  if (child.stdin) {
+    child.stdin.end(plan.prompt.text);
+  }
+
+  if (!plan.options.foreground) {
+    const immediateError = await Promise.race([
+      errorResult,
+      new Promise((resolve) => setImmediate(() => resolve(null))),
+    ]);
+
+    if (immediateError) {
+      return immediateError;
+    }
+
+    child.unref();
+    closeLog();
+    return { status: 'started', pid: child.pid, exitCode: 0 };
+  }
+
+  const result = await Promise.race([
+    errorResult,
+    new Promise((resolve) => {
+      child.once('close', (code) => {
+        closeLog();
+        const exitCode = code !== null ? code : 1;
+        resolve({
+          status: exitCode === 0 ? 'completed' : 'failed',
+          pid: child.pid,
+          exitCode,
+        });
+      });
+    }),
+  ]);
+
+  return result;
+}
+
+function sanitizeResultValue(value) {
+  return String(value).replace(/\r?\n/g, ' ');
 }
 
 function printResult(plan, result, output = process.stdout) {
@@ -451,6 +527,7 @@ function printResult(plan, result, output = process.stdout) {
     `OUTPUT=${plan.outputPath}`,
     `PROMPT=${plan.promptPath}`,
     `COMMAND=${plan.displayCommand}`,
+    result.error ? `ERROR=${sanitizeResultValue(result.error)}` : null,
   ].filter(Boolean);
 
   output.write(`${lines.join('\n')}\n`);
@@ -473,7 +550,6 @@ async function runCli(argv, output = process.stdout, _errorOutput = process.stde
 
   assertExecutorAvailable(plan.provider);
   assertGitReady(plan.options);
-  writeRunFiles(plan);
 
   const result = await spawnExecutor(plan);
   printResult(plan, result, output);

--- a/.aiox-core/core/external-executors/delegate-cli.js
+++ b/.aiox-core/core/external-executors/delegate-cli.js
@@ -1,0 +1,509 @@
+const fs = require('fs');
+const path = require('path');
+const { spawn, spawnSync } = require('child_process');
+
+const DEFAULT_RUN_DIR = '.aiox/external-runs';
+const SUPPORTED_SANDBOXES = new Set([
+  'read-only',
+  'workspace-write',
+  'full-auto',
+  'danger-full-access',
+]);
+
+const PROVIDERS = {
+  codex: {
+    id: 'codex',
+    binary: 'codex',
+    buildArgs(options) {
+      const args = [];
+
+      if (options.sandbox === 'danger-full-access') {
+        args.push('--dangerously-bypass-approvals-and-sandbox');
+      } else {
+        const codexSandbox = options.sandbox === 'full-auto' ? 'workspace-write' : options.sandbox;
+        args.push('-a', 'never', '-s', codexSandbox);
+      }
+
+      if (options.model) {
+        args.push('-m', options.model);
+      }
+
+      if (options.profile) {
+        args.push('-p', options.profile);
+      }
+
+      args.push('exec', '-C', options.workdir, '-o', options.outputPath);
+
+      for (const image of options.images) {
+        args.push('-i', image);
+      }
+
+      args.push('-');
+
+      return args;
+    },
+  },
+};
+
+class DelegateCliError extends Error {
+  constructor(message, exitCode = 1) {
+    super(message);
+    this.name = 'DelegateCliError';
+    this.exitCode = exitCode;
+  }
+}
+
+function showHelp(output = process.stdout) {
+  output.write(`AIOX External Executor Delegation
+
+USAGE:
+  aiox-delegate <provider> -t <slug> [-f prompt_file | -p prompt] [options]
+
+PROVIDERS:
+  codex
+
+OPTIONS:
+  -t, --task <slug>          Stable task/story slug for the run directory
+  -f, --prompt-file <path>   Prompt file to send to the external executor
+  -p, --prompt <text>        Inline prompt to send to the external executor
+  -d, --workdir <path>       Working directory for the executor (default: cwd)
+  -m, --model <model>        Provider model override
+      --profile <name>       Provider profile/config override
+      --sandbox <mode>       read-only | workspace-write | full-auto | danger-full-access
+      --run-dir <path>       Base run directory (default: .aiox/external-runs)
+      --image <path>         Image input for providers that support it (repeatable)
+      --allow-dirty          Allow delegation with a dirty git worktree
+      --skip-git-check       Skip git worktree detection and cleanliness check
+      --foreground           Wait for the executor process and return its exit code
+      --dry-run              Print the planned run without creating files or spawning
+  -h, --help                 Show this help
+
+OUTPUT:
+  Prints machine-readable key=value lines: STATUS, RUN_DIR, PID, LOG, OUTPUT, PROMPT, COMMAND.
+`);
+}
+
+function parseArgs(argv) {
+  const options = {
+    provider: null,
+    slug: null,
+    prompt: null,
+    promptFile: null,
+    workdir: process.cwd(),
+    model: null,
+    profile: null,
+    sandbox: 'full-auto',
+    runDirBase: DEFAULT_RUN_DIR,
+    images: [],
+    allowDirty: false,
+    skipGitCheck: false,
+    foreground: false,
+    dryRun: false,
+    help: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    if (!arg.startsWith('-') && !options.provider) {
+      options.provider = arg;
+      continue;
+    }
+
+    const readValue = (name) => {
+      const value = argv[i + 1];
+      if (!value || value.startsWith('-')) {
+        throw new DelegateCliError(`${name} requires a value`, 2);
+      }
+      i += 1;
+      return value;
+    };
+
+    switch (arg) {
+      case '-t':
+      case '--task':
+        options.slug = readValue(arg);
+        break;
+      case '-f':
+      case '--prompt-file':
+        options.promptFile = readValue(arg);
+        break;
+      case '-p':
+      case '--prompt':
+        options.prompt = readValue(arg);
+        break;
+      case '-d':
+      case '--workdir':
+        options.workdir = readValue(arg);
+        break;
+      case '-m':
+      case '--model':
+        options.model = readValue(arg);
+        break;
+      case '--profile':
+        options.profile = readValue(arg);
+        break;
+      case '--sandbox':
+        options.sandbox = readValue(arg);
+        break;
+      case '--run-dir':
+        options.runDirBase = readValue(arg);
+        break;
+      case '--image':
+        options.images.push(readValue(arg));
+        break;
+      case '--allow-dirty':
+        options.allowDirty = true;
+        break;
+      case '--skip-git-check':
+        options.skipGitCheck = true;
+        break;
+      case '--foreground':
+        options.foreground = true;
+        break;
+      case '--dry-run':
+        options.dryRun = true;
+        break;
+      default:
+        throw new DelegateCliError(`Unknown option or extra argument: ${arg}`, 2);
+    }
+  }
+
+  return options;
+}
+
+function validateOptions(options) {
+  if (options.help) {
+    return;
+  }
+
+  if (!options.provider) {
+    throw new DelegateCliError('Provider is required. Use: aiox-delegate <provider> ...', 2);
+  }
+
+  if (!PROVIDERS[options.provider]) {
+    throw new DelegateCliError(`Unsupported provider: ${options.provider}`, 2);
+  }
+
+  if (!options.slug) {
+    throw new DelegateCliError('Task slug is required. Use -t <slug>.', 2);
+  }
+
+  if (options.prompt && options.promptFile) {
+    throw new DelegateCliError('Use either --prompt or --prompt-file, not both.', 2);
+  }
+
+  if (!options.prompt && !options.promptFile) {
+    throw new DelegateCliError('Prompt is required. Use --prompt or --prompt-file.', 2);
+  }
+
+  if (!SUPPORTED_SANDBOXES.has(options.sandbox)) {
+    throw new DelegateCliError(
+      `Unsupported sandbox: ${options.sandbox}. Expected one of: ${Array.from(SUPPORTED_SANDBOXES).join(', ')}`,
+      2,
+    );
+  }
+}
+
+function sanitizeSlug(slug) {
+  const sanitized = String(slug)
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+
+  if (!sanitized) {
+    throw new DelegateCliError('Task slug must contain at least one safe character.', 2);
+  }
+
+  return sanitized;
+}
+
+function formatTimestamp(date = new Date()) {
+  const pad = (n) => String(n).padStart(2, '0');
+  return [
+    date.getUTCFullYear(),
+    pad(date.getUTCMonth() + 1),
+    pad(date.getUTCDate()),
+    '-',
+    pad(date.getUTCHours()),
+    pad(date.getUTCMinutes()),
+    pad(date.getUTCSeconds()),
+  ].join('');
+}
+
+function resolvePathFrom(baseDir, value) {
+  return path.resolve(baseDir, value);
+}
+
+function loadPrompt(options) {
+  if (options.promptFile) {
+    const promptFile = path.resolve(options.promptFile);
+    return {
+      text: fs.readFileSync(promptFile, 'utf8'),
+      source: promptFile,
+    };
+  }
+
+  return {
+    text: options.prompt,
+    source: 'inline',
+  };
+}
+
+function shellQuote(value) {
+  const text = String(value);
+  if (/^[A-Za-z0-9_./:=@%+-]+$/.test(text)) {
+    return text;
+  }
+  const singleQuote = String.fromCharCode(39);
+  const escapedQuote = singleQuote + '\\' + singleQuote + singleQuote;
+  return singleQuote + text.replace(/'/g, escapedQuote) + singleQuote;
+}
+
+function formatCommand(command, args) {
+  return [command, ...args].map(shellQuote).join(' ');
+}
+
+function commandExists(command) {
+  if (process.platform === 'win32') {
+    return spawnSync('where', [command], { stdio: 'ignore' }).status === 0;
+  }
+
+  return spawnSync('sh', ['-c', `command -v ${shellQuote(command)} >/dev/null 2>&1`], {
+    stdio: 'ignore',
+  }).status === 0;
+}
+
+function assertExecutorAvailable(provider) {
+  if (!commandExists(provider.binary)) {
+    throw new DelegateCliError(
+      `Executor binary not found on PATH: ${provider.binary}`,
+      3,
+    );
+  }
+}
+
+function gitStatus(workdir) {
+  const inside = spawnSync('git', ['-C', workdir, 'rev-parse', '--is-inside-work-tree'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (inside.status !== 0 || inside.stdout.trim() !== 'true') {
+    return { inside: false, dirty: false, status: '' };
+  }
+
+  const status = spawnSync('git', ['-C', workdir, 'status', '--porcelain'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (status.status !== 0) {
+    throw new DelegateCliError(`Could not read git status: ${status.stderr.trim()}`, 4);
+  }
+
+  const output = status.stdout.trim();
+  return { inside: true, dirty: output.length > 0, status: output };
+}
+
+function assertGitReady(options) {
+  if (options.skipGitCheck) {
+    return;
+  }
+
+  const status = gitStatus(options.workdir);
+  if (!status.inside) {
+    throw new DelegateCliError(
+      'Workdir is not inside a git repository. Use --skip-git-check only for intentional non-git runs.',
+      4,
+    );
+  }
+
+  if (status.dirty && !options.allowDirty) {
+    throw new DelegateCliError(
+      'Git worktree is dirty. Commit/stash first or pass --allow-dirty for intentional changes.',
+      4,
+    );
+  }
+}
+
+function createDelegatePlan(rawOptions, date = new Date()) {
+  const options = {
+    ...rawOptions,
+    workdir: path.resolve(rawOptions.workdir || process.cwd()),
+    images: rawOptions.images || [],
+  };
+  validateOptions(options);
+
+  const provider = PROVIDERS[options.provider];
+  const slug = sanitizeSlug(options.slug);
+  const timestamp = formatTimestamp(date);
+  const runDirBase = path.isAbsolute(options.runDirBase)
+    ? options.runDirBase
+    : resolvePathFrom(options.workdir, options.runDirBase);
+  const runDir = path.join(runDirBase, `${timestamp}-${slug}`);
+  const promptPath = path.join(runDir, 'prompt.md');
+  const outputPath = path.join(runDir, 'output.md');
+  const logPath = path.join(runDir, `${provider.id}.log`);
+  const metadataPath = path.join(runDir, 'metadata.json');
+  const commandPath = path.join(runDir, 'command.txt');
+  const prompt = loadPrompt(options);
+  const providerOptions = {
+    ...options,
+    outputPath,
+    images: options.images.map((image) => path.resolve(options.workdir, image)),
+  };
+  const args = provider.buildArgs(providerOptions);
+
+  return {
+    provider,
+    options,
+    slug,
+    timestamp,
+    runDir,
+    promptPath,
+    outputPath,
+    logPath,
+    metadataPath,
+    commandPath,
+    prompt,
+    command: provider.binary,
+    args,
+    displayCommand: formatCommand(provider.binary, args),
+  };
+}
+
+function writeRunFiles(plan, pid = null) {
+  fs.mkdirSync(plan.runDir, { recursive: true });
+  fs.writeFileSync(plan.promptPath, plan.prompt.text, 'utf8');
+  fs.writeFileSync(plan.commandPath, `${plan.displayCommand}\n`, 'utf8');
+
+  const metadata = {
+    provider: plan.provider.id,
+    slug: plan.slug,
+    created_at: new Date().toISOString(),
+    workdir: plan.options.workdir,
+    sandbox: plan.options.sandbox,
+    model: plan.options.model || null,
+    profile: plan.options.profile || null,
+    foreground: plan.options.foreground,
+    allow_dirty: plan.options.allowDirty,
+    skip_git_check: plan.options.skipGitCheck,
+    prompt_source: plan.prompt.source,
+    run_dir: plan.runDir,
+    prompt: plan.promptPath,
+    output: plan.outputPath,
+    log: plan.logPath,
+    command: plan.command,
+    args: plan.args,
+    pid,
+  };
+
+  fs.writeFileSync(plan.metadataPath, `${JSON.stringify(metadata, null, 2)}\n`, 'utf8');
+}
+
+async function spawnExecutor(plan) {
+  const logFd = fs.openSync(plan.logPath, 'a');
+  const child = spawn(plan.command, plan.args, {
+    cwd: plan.options.workdir,
+    detached: !plan.options.foreground,
+    stdio: ['pipe', logFd, logFd],
+    env: process.env,
+  });
+
+  child.stdin.write(plan.prompt.text);
+  child.stdin.end();
+
+  writeRunFiles(plan, child.pid);
+
+  if (!plan.options.foreground) {
+    child.unref();
+    fs.closeSync(logFd);
+    return { status: 'started', pid: child.pid, exitCode: 0 };
+  }
+
+  const exitCode = await new Promise((resolve) => {
+    child.on('close', (code) => {
+      fs.closeSync(logFd);
+      resolve(code || 0);
+    });
+  });
+
+  return {
+    status: exitCode === 0 ? 'completed' : 'failed',
+    pid: child.pid,
+    exitCode,
+  };
+}
+
+function printResult(plan, result, output = process.stdout) {
+  const lines = [
+    `STATUS=${result.status}`,
+    `RUN_DIR=${plan.runDir}`,
+    result.pid ? `PID=${result.pid}` : null,
+    `LOG=${plan.logPath}`,
+    `OUTPUT=${plan.outputPath}`,
+    `PROMPT=${plan.promptPath}`,
+    `COMMAND=${plan.displayCommand}`,
+  ].filter(Boolean);
+
+  output.write(`${lines.join('\n')}\n`);
+}
+
+async function runCli(argv, output = process.stdout, _errorOutput = process.stderr) {
+  const options = parseArgs(argv);
+
+  if (options.help) {
+    showHelp(output);
+    return 0;
+  }
+
+  const plan = createDelegatePlan(options);
+
+  if (options.dryRun) {
+    printResult(plan, { status: 'dry-run', pid: null }, output);
+    return 0;
+  }
+
+  assertExecutorAvailable(plan.provider);
+  assertGitReady(plan.options);
+  writeRunFiles(plan);
+
+  const result = await spawnExecutor(plan);
+  printResult(plan, result, output);
+  return result.exitCode;
+}
+
+async function main() {
+  try {
+    const exitCode = await runCli(process.argv.slice(2));
+    process.exit(exitCode);
+  } catch (error) {
+    const exitCode = error.exitCode || 1;
+    process.stderr.write(`ERROR=${error.message}\n`);
+    process.exit(exitCode);
+  }
+}
+
+module.exports = {
+  DEFAULT_RUN_DIR,
+  PROVIDERS,
+  SUPPORTED_SANDBOXES,
+  DelegateCliError,
+  parseArgs,
+  validateOptions,
+  sanitizeSlug,
+  formatTimestamp,
+  createDelegatePlan,
+  formatCommand,
+  gitStatus,
+  runCli,
+  showHelp,
+  main,
+};

--- a/.aiox-core/core/external-executors/index.js
+++ b/.aiox-core/core/external-executors/index.js
@@ -1,6 +1,13 @@
 const delegateCli = require('./delegate-cli');
 
 module.exports = {
-  ...delegateCli,
+  DEFAULT_RUN_DIR: delegateCli.DEFAULT_RUN_DIR,
+  PROVIDERS: delegateCli.PROVIDERS,
+  SUPPORTED_SANDBOXES: delegateCli.SUPPORTED_SANDBOXES,
+  DelegateCliError: delegateCli.DelegateCliError,
+  sanitizeSlug: delegateCli.sanitizeSlug,
+  formatTimestamp: delegateCli.formatTimestamp,
+  createDelegatePlan: delegateCli.createDelegatePlan,
+  formatCommand: delegateCli.formatCommand,
+  gitStatus: delegateCli.gitStatus,
 };
-

--- a/.aiox-core/core/external-executors/index.js
+++ b/.aiox-core/core/external-executors/index.js
@@ -1,0 +1,6 @@
+const delegateCli = require('./delegate-cli');
+
+module.exports = {
+  ...delegateCli,
+};
+

--- a/.aiox-core/core/index.js
+++ b/.aiox-core/core/index.js
@@ -36,6 +36,9 @@ const { ServiceRegistry, getRegistry, loadRegistry } = require('./registry/regis
 // Health Check System
 const healthCheck = require('./health-check');
 
+// External executor delegation
+const externalExecutors = require('./external-executors');
+
 /**
  * Core module exports
  */
@@ -81,6 +84,9 @@ module.exports = {
   CheckStatus: healthCheck.CheckStatus,
   CheckRegistry: healthCheck.CheckRegistry,
   healthCheck,
+
+  // External executors
+  externalExecutors,
 
   // Version info
   version: '2.0.0',

--- a/.aiox-core/development/external-executors/README.md
+++ b/.aiox-core/development/external-executors/README.md
@@ -1,0 +1,19 @@
+# External Executors
+
+External executors let one AIOX runtime keep orchestration authority while another CLI runtime performs the implementation work in an isolated run directory.
+
+This pattern is opt-in. The default development mode remains `native`, where the active AIOX agent plans, implements, validates, and updates story state in the same runtime.
+
+## Contract
+
+- The orchestrator owns story selection, acceptance criteria, scope, review, and story state updates.
+- The external executor owns only the delegated implementation attempt.
+- Run artifacts live under `.aiox/external-runs/<timestamp>-<slug>/`.
+- The orchestrator must read the executor output and inspect the diff before updating checkboxes, File List, or story status.
+
+## Providers
+
+- `codex.md`: reference provider for Codex CLI headless execution.
+
+Future provider files can document `aider`, `cline`, `cursor-cli`, `gemini-cli`, or any other runtime that supports non-interactive execution.
+

--- a/.aiox-core/development/external-executors/codex.md
+++ b/.aiox-core/development/external-executors/codex.md
@@ -1,0 +1,57 @@
+# Codex External Executor Adapter
+
+## Provider ID
+
+`codex`
+
+## Invocation
+
+The `aiox-delegate` wrapper launches Codex in non-interactive exec mode and sends the prompt through stdin:
+
+```bash
+codex -a never -s workspace-write exec -C <workdir> -o <run_dir>/output.md -
+```
+
+For `--sandbox danger-full-access`, the wrapper uses the explicit Codex bypass flag:
+
+```bash
+codex --dangerously-bypass-approvals-and-sandbox exec -C <workdir> -o <run_dir>/output.md -
+```
+
+## Sandbox Mapping
+
+| AIOX sandbox | Codex behavior |
+| --- | --- |
+| `read-only` | `-a never -s read-only` |
+| `workspace-write` | `-a never -s workspace-write` |
+| `full-auto` | `-a never -s workspace-write` |
+| `danger-full-access` | `--dangerously-bypass-approvals-and-sandbox` |
+
+`full-auto` is retained as an AIOX abstraction for background executor runs. On current Codex CLI versions, it maps to `workspace-write` plus `approval=never` rather than bypassing the sandbox.
+
+## Supported Options
+
+- `--model <model>` maps to `codex -m <model>`.
+- `--profile <name>` maps to `codex -p <name>`.
+- `--image <path>` maps to `codex exec -i <path>`.
+- `--workdir <path>` maps to `codex exec -C <path>`.
+- `--prompt` and `--prompt-file` are sent via stdin.
+- `--output-last-message` is managed by the wrapper through `-o <run_dir>/output.md`.
+
+## Exit Code Semantics
+
+- In background mode, `aiox-delegate` returns after a process is spawned and prints the PID.
+- In foreground mode, `aiox-delegate` waits for Codex and returns Codex's exit code.
+- Missing Codex binary is a pre-condition failure.
+- Dirty git worktrees are blocked unless `--allow-dirty` is explicit.
+
+## Run Artifacts
+
+Each run directory contains:
+
+- `prompt.md`: prompt sent to Codex
+- `output.md`: last Codex message, written by Codex
+- `codex.log`: stdout/stderr stream
+- `command.txt`: exact command line
+- `metadata.json`: provider, workdir, sandbox, PID, and artifact paths
+

--- a/.aiox-core/development/tasks/delegate-to-external-executor.md
+++ b/.aiox-core/development/tasks/delegate-to-external-executor.md
@@ -1,0 +1,153 @@
+# delegate-to-external-executor.md
+
+**Task**: Delegate Implementation to External Executor
+
+**Purpose**: Standardize the orchestrator/executor split for AIOX workflows. The active AIOX runtime keeps authority over story interpretation, acceptance criteria validation, constitutional gates, review, and story updates while a separate CLI runtime performs only the implementation attempt.
+
+**When to use**: Use only for `@dev` implementation work where the story scope is clear enough to hand to another runtime. Do not use for PO, QA, SM, DevOps, architecture approval, or release authority.
+
+## Task Definition
+
+```yaml
+task: delegateToExternalExecutor()
+responsavel: Orchestrating agent
+responsavel_type: Agente
+atomic_layer: Organism
+
+inputs:
+  - campo: prompt
+    tipo: string
+    obrigatorio: true
+    validacao: Must cite acceptance criteria, story path, file scope, and explicit non-goals
+  - campo: slug
+    tipo: string
+    obrigatorio: true
+    validacao: Stable filesystem-safe run slug
+  - campo: story_id
+    tipo: string
+    obrigatorio: false
+  - campo: story_path
+    tipo: string
+    obrigatorio: false
+  - campo: workdir
+    tipo: string
+    obrigatorio: false
+    default: Current project root
+  - campo: provider
+    tipo: string
+    obrigatorio: false
+    default: codex
+
+outputs:
+  - campo: run_dir
+    tipo: string
+    destino: Orchestrator
+  - campo: output
+    tipo: file
+    destino: <run_dir>/output.md
+  - campo: log
+    tipo: file
+    destino: <run_dir>/<provider>.log
+  - campo: diff
+    tipo: git-diff
+    destino: Orchestrator review
+```
+
+## Configuration
+
+Delegation is disabled by default.
+
+```yaml
+dev:
+  execution_mode: native       # native | delegate
+  delegate_to: codex
+  auto_review: true
+
+external_executors:
+  enabled: false
+  default_sandbox: full-auto   # read-only | workspace-write | full-auto | danger-full-access
+  run_dir: .aiox/external-runs
+```
+
+## Pre-Conditions
+
+```yaml
+pre_conditions:
+  - [ ] External executor provider is installed and available on PATH.
+  - [ ] Working tree is clean, or existing intentional changes are already committed.
+  - [ ] Prompt cites the story path and acceptance criteria.
+  - [ ] Prompt lists allowed file scope and explicit non-goals.
+  - [ ] Delegated work is implementation work owned by @dev.
+  - [ ] Orchestrator has enough context to review the resulting diff.
+```
+
+## Execution
+
+### 1. Build the Prompt
+
+The orchestrator writes a prompt that contains:
+
+- Story ID and story path
+- Acceptance criteria copied or summarized from the story
+- Allowed file paths or modules
+- Testing expectations
+- Constraints from Constitution and project rules
+- Explicit instruction that the executor must not update story status, checkboxes, File List, PRs, or releases
+
+### 2. Start the Delegate Run
+
+Use the wrapper:
+
+```bash
+aiox-delegate codex -t <slug> -f <prompt_file> -d <workdir>
+```
+
+The wrapper prints:
+
+```text
+STATUS=started
+RUN_DIR=.aiox/external-runs/<timestamp>-<slug>
+PID=<pid>
+LOG=<run_dir>/codex.log
+OUTPUT=<run_dir>/output.md
+PROMPT=<run_dir>/prompt.md
+COMMAND=<provider command>
+```
+
+### 3. Monitor Completion
+
+The orchestrator may tail the log or wait for the PID. Do not mark story progress while the external executor is still running.
+
+### 4. Review Output and Diff
+
+The orchestrator must read:
+
+- `<run_dir>/output.md`
+- `<run_dir>/<provider>.log`
+- `git diff`
+
+Then validate:
+
+```yaml
+review_checklist:
+  - [ ] Every acceptance criterion is satisfied.
+  - [ ] Diff scope matches the story and prompt.
+  - [ ] Article IV No Invention: every change traces to a requirement.
+  - [ ] Tests were added or updated when behavior changed.
+  - [ ] Lint, typecheck, and relevant tests pass.
+  - [ ] No story state was mutated before review approval.
+```
+
+### 5. Accept or Iterate
+
+- **Approved**: orchestrator updates story checkboxes, File List, status, and final validation evidence.
+- **Rejected**: orchestrator writes specific feedback and may start a new run with a new slug or iteration suffix.
+
+## Anti-Patterns
+
+- Marking a story done by trusting the executor summary without reading the diff.
+- Delegating PO/QA/SM/DevOps authority to an external runtime.
+- Letting the executor create PRs, push, release, or mutate story state.
+- Delegating vague work without acceptance criteria and file scope.
+- Running with `danger-full-access` unless the surrounding environment is externally sandboxed.
+

--- a/.aiox-core/development/tasks/delegate-to-external-executor.md
+++ b/.aiox-core/development/tasks/delegate-to-external-executor.md
@@ -65,7 +65,7 @@ dev:
 
 external_executors:
   enabled: false
-  default_sandbox: full-auto   # read-only | workspace-write | full-auto | danger-full-access
+  default_sandbox: workspace-write   # read-only | workspace-write | full-auto | danger-full-access
   run_dir: .aiox/external-runs
 ```
 
@@ -150,4 +150,3 @@ review_checklist:
 - Letting the executor create PRs, push, release, or mutate story state.
 - Delegating vague work without acceptance criteria and file scope.
 - Running with `danger-full-access` unless the surrounding environment is externally sandboxed.
-

--- a/.aiox-core/framework-config.yaml
+++ b/.aiox-core/framework-config.yaml
@@ -54,7 +54,7 @@ dev:
 
 external_executors:
   enabled: false
-  default_sandbox: full-auto # read-only | workspace-write | full-auto | danger-full-access
+  default_sandbox: workspace-write # read-only | workspace-write | full-auto | danger-full-access
   run_dir: .aiox/external-runs
 
 # --- Utility Scripts Registry (Section 11) ---

--- a/.aiox-core/framework-config.yaml
+++ b/.aiox-core/framework-config.yaml
@@ -46,6 +46,17 @@ performance_defaults:
     show_config_warning: true
     cache_time_seconds: 300
 
+# --- Development Execution Defaults (Section 6.5) ---
+dev:
+  execution_mode: native # native | delegate
+  delegate_to: codex
+  auto_review: true
+
+external_executors:
+  enabled: false
+  default_sandbox: full-auto # read-only | workspace-write | full-auto | danger-full-access
+  run_dir: .aiox/external-runs
+
 # --- Utility Scripts Registry (Section 11) ---
 utility_scripts_registry:
   # Agent Helper utilities (28) — Used directly by agents

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.1.15
-generated_at: "2026-05-08T02:37:02.457Z"
+generated_at: "2026-05-08T02:58:22.301Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1109
 files:
@@ -265,9 +265,9 @@ files:
     type: core
     size: 8156
   - path: core/config/schemas/framework-config.schema.json
-    hash: sha256:22ae35c20a7fb0ec7240ac943ecee2b860111f9d11a9d05047aaf1e17c376b4b
+    hash: sha256:1becd882f8077e0f8c95ce1ca395b05bf03fa7a1726f67c0bc5fed0ae59c3f27
     type: core
-    size: 7457
+    size: 7463
   - path: core/config/schemas/local-config.schema.json
     hash: sha256:0349e44aea7b3dfe051ce586eb201f25edab8a7ea6d054704034f877848aa43f
     type: core
@@ -445,13 +445,13 @@ files:
     type: core
     size: 11060
   - path: core/external-executors/delegate-cli.js
-    hash: sha256:ad4fc2d186a8e1ffc31c0bdd5f33db6bbb9e245d913b2f2f0228f1c60f070340
+    hash: sha256:3f4bb7d4edd742ad13dc91ebdc7296b94ac762caa50ea6943429d93cd65c0ce1
     type: core
-    size: 13259
+    size: 15069
   - path: core/external-executors/index.js
-    hash: sha256:34665b4bfc2851b74e2907dee8bfd8a4a5cfd68d4ffc59cecb2b2704db4ad487
+    hash: sha256:db61bee165e4a7dba3627275d52d6b162e3b2cbf47d31d88beb38682cb8352db
     type: core
-    size: 89
+    size: 484
   - path: core/graph-dashboard/cli.js
     hash: sha256:29f273a06fecc77eb3e39162ba1aaf28e1cbadb2a000158f009817021a30b4d1
     type: core
@@ -2005,9 +2005,9 @@ files:
     type: task
     size: 11488
   - path: development/tasks/delegate-to-external-executor.md
-    hash: sha256:c7bf9d7ab87a78a3ced1a524c098bc42f68e4b639048c03c95964ca49cd285cc
+    hash: sha256:68c73a78e4eeebcb551f69bc8c13f37157be253b91a3d3d80ea9bc52c5330808
     type: task
-    size: 4395
+    size: 4400
   - path: development/tasks/deprecate-component.md
     hash: sha256:72dfca4d222b990ed868e5fd4c0d5793848cd1a9fda6d48fb7caec93e02c59ed
     type: task

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,9 +8,9 @@
 # - File types for categorization
 #
 version: 5.1.15
-generated_at: "2026-05-08T02:21:46.248Z"
+generated_at: "2026-05-08T02:37:02.457Z"
 generator: scripts/generate-install-manifest.js
-file_count: 1104
+file_count: 1109
 files:
   - path: cli/commands/config/index.js
     hash: sha256:25c4b9bf4e0241abf7754b55153f49f1a214f1fb5fe904a576675634cb7b3da9
@@ -265,9 +265,9 @@ files:
     type: core
     size: 8156
   - path: core/config/schemas/framework-config.schema.json
-    hash: sha256:101ca2cddca9df4db30a8a4220fd3083a24f9ff30bc23df695d19e2f9382335d
+    hash: sha256:22ae35c20a7fb0ec7240ac943ecee2b860111f9d11a9d05047aaf1e17c376b4b
     type: core
-    size: 6259
+    size: 7457
   - path: core/config/schemas/local-config.schema.json
     hash: sha256:0349e44aea7b3dfe051ce586eb201f25edab8a7ea6d054704034f877848aa43f
     type: core
@@ -444,6 +444,14 @@ files:
     hash: sha256:4e2324edb37ae0729062b5ac029f2891e050e7efd3a48d0f4a1dc4f227a6716b
     type: core
     size: 11060
+  - path: core/external-executors/delegate-cli.js
+    hash: sha256:ad4fc2d186a8e1ffc31c0bdd5f33db6bbb9e245d913b2f2f0228f1c60f070340
+    type: core
+    size: 13259
+  - path: core/external-executors/index.js
+    hash: sha256:34665b4bfc2851b74e2907dee8bfd8a4a5cfd68d4ffc59cecb2b2704db4ad487
+    type: core
+    size: 89
   - path: core/graph-dashboard/cli.js
     hash: sha256:29f273a06fecc77eb3e39162ba1aaf28e1cbadb2a000158f009817021a30b4d1
     type: core
@@ -757,9 +765,9 @@ files:
     type: core
     size: 1486
   - path: core/index.js
-    hash: sha256:970b617b0e723e8248065f698eca2298a5a0b72e3e43ee820ea85294555736e2
+    hash: sha256:7258643ec31b5389e1abb0f0af48e9f5e569336f5548c31cfe22e229e7254e13
     type: core
-    size: 2585
+    size: 2723
   - path: core/manifest/manifest-generator.js
     hash: sha256:81b796990dd747bbb9785d205dbe5f6d5556754fc51745fb84b7ce4675acbdbf
     type: core
@@ -1444,6 +1452,14 @@ files:
     hash: sha256:2931ccff24f5b773f137ef590674d17dc0374f51ee2d8dbc82f74931ba2cb398
     type: data
     size: 11110
+  - path: development/external-executors/codex.md
+    hash: sha256:55889e0365e6f971746bc924b9124c92494788fa8d70efb4a73a67b7841f2a41
+    type: development
+    size: 1911
+  - path: development/external-executors/README.md
+    hash: sha256:f61cc24abc82d7bd07f7e7c573ae908d1961d64cf082ba76d2f6246f55959c26
+    type: development
+    size: 966
   - path: development/README.md
     hash: sha256:7239119d2b958c15f14c9e184e9459b6e31479a6705f58af45a07981fa4d62cd
     type: development
@@ -1988,6 +2004,10 @@ files:
     hash: sha256:478a1f94e0e4d9da5488ce5df41538308454a64e534d587d5d8361dbd9cff701
     type: task
     size: 11488
+  - path: development/tasks/delegate-to-external-executor.md
+    hash: sha256:c7bf9d7ab87a78a3ced1a524c098bc42f68e4b639048c03c95964ca49cd285cc
+    type: task
+    size: 4395
   - path: development/tasks/deprecate-component.md
     hash: sha256:72dfca4d222b990ed868e5fd4c0d5793848cd1a9fda6d48fb7caec93e02c59ed
     type: task

--- a/bin/aiox-delegate.js
+++ b/bin/aiox-delegate.js
@@ -1,6 +1,16 @@
 #!/usr/bin/env node
 
-const { main } = require('../.aiox-core/core/external-executors/delegate-cli');
+const path = require('path');
+const { main } = require(path.join(
+  __dirname,
+  '..',
+  '.aiox-core',
+  'core',
+  'external-executors',
+  'delegate-cli',
+));
 
-main();
-
+main().catch((error) => {
+  process.stderr.write(`ERROR=${error.message || error}\n`);
+  process.exit(error.exitCode || 1);
+});

--- a/bin/aiox-delegate.js
+++ b/bin/aiox-delegate.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+const { main } = require('../.aiox-core/core/external-executors/delegate-cli');
+
+main();
+

--- a/bin/aiox.js
+++ b/bin/aiox.js
@@ -74,6 +74,7 @@ USAGE:
   npx aiox-core@latest validate     # Validate installation integrity
   npx aiox-core@latest info         # Show system info
   npx aiox-core@latest doctor       # Run diagnostics
+  aiox-delegate codex -t <slug>     # Delegate implementation to external executor
   npx aiox-core@latest --version    # Show version
   npx aiox-core@latest --version -d # Show detailed version info
   npx aiox-core@latest --help       # Show this help
@@ -104,6 +105,10 @@ SERVICE DISCOVERY:
   aiox workers search "json" --category=data
   aiox workers search "transform" --tags=etl,data
   aiox workers search "api" --format=json
+
+EXTERNAL EXECUTION:
+  aiox-delegate codex -t story-4.3 -f prompt.md
+  aiox-delegate codex -t story-4.3 -p "Implement AC1" --dry-run
 
 EXAMPLES:
   # Install in current directory

--- a/jest.config.js
+++ b/jest.config.js
@@ -128,6 +128,9 @@ module.exports = {
   verbose: true,
   roots: ['<rootDir>'],
   moduleDirectories: ['node_modules', '.'],
+  moduleNameMapper: {
+    '^@aiox-core/(.*)$': '<rootDir>/.aiox-core/$1',
+  },
   setupFilesAfterEnv: ['<rootDir>/tests/setup.js'],
 
   // Cross-platform config from REMOTE

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "aiox": "bin/aiox.js",
     "aiox-core": "bin/aiox.js",
     "aiox-minimal": "bin/aiox-minimal.js",
-    "aiox-graph": "bin/aiox-graph.js"
+    "aiox-graph": "bin/aiox-graph.js",
+    "aiox-delegate": "bin/aiox-delegate.js"
   },
   "preferGlobal": false,
   "workspaces": [

--- a/scripts/validate-package-completeness.js
+++ b/scripts/validate-package-completeness.js
@@ -75,7 +75,7 @@ const REQUIRED_FILES_ENTRIES = [
 /**
  * Bin entries that must point to existing files.
  */
-const REQUIRED_BIN_ENTRIES = ['aiox', 'aiox-core'];
+const REQUIRED_BIN_ENTRIES = ['aiox', 'aiox-core', 'aiox-delegate'];
 
 /**
  * Runtime dependencies that must be present.

--- a/tests/cli/aiox-delegate.test.js
+++ b/tests/cli/aiox-delegate.test.js
@@ -1,0 +1,128 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const {
+  createDelegatePlan,
+  parseArgs,
+  sanitizeSlug,
+  DelegateCliError,
+} = require('../../.aiox-core/core/external-executors/delegate-cli');
+
+describe('aiox-delegate external executor CLI', () => {
+  const fixedDate = new Date(Date.UTC(2026, 4, 8, 2, 30, 45));
+
+  test('parses codex delegation arguments', () => {
+    const options = parseArgs([
+      'codex',
+      '-t',
+      'story-4.3',
+      '-p',
+      'Implement AC1',
+      '-d',
+      '/tmp/work',
+      '--model',
+      'gpt-5.4',
+      '--dry-run',
+    ]);
+
+    expect(options.provider).toBe('codex');
+    expect(options.slug).toBe('story-4.3');
+    expect(options.prompt).toBe('Implement AC1');
+    expect(options.workdir).toBe('/tmp/work');
+    expect(options.model).toBe('gpt-5.4');
+    expect(options.dryRun).toBe(true);
+  });
+
+  test('creates a codex plan with full-auto mapped to workspace-write', () => {
+    const plan = createDelegatePlan(
+      parseArgs(['codex', '-t', 'story 4.3', '-p', 'Implement AC1', '-d', '/tmp/work']),
+      fixedDate,
+    );
+
+    expect(plan.slug).toBe('story-4.3');
+    expect(plan.runDir).toBe('/tmp/work/.aiox/external-runs/20260508-023045-story-4.3');
+    expect(plan.command).toBe('codex');
+    expect(plan.args).toEqual(
+      expect.arrayContaining(['-a', 'never', '-s', 'workspace-write', 'exec', '-C', '/tmp/work']),
+    );
+    expect(plan.args.at(-1)).toBe('-');
+    expect(plan.outputPath).toBe(path.join(plan.runDir, 'output.md'));
+  });
+
+  test('maps danger-full-access to the explicit Codex bypass flag', () => {
+    const plan = createDelegatePlan(
+      parseArgs([
+        'codex',
+        '-t',
+        'story-4.3',
+        '-p',
+        'Implement AC1',
+        '-d',
+        '/tmp/work',
+        '--sandbox',
+        'danger-full-access',
+      ]),
+      fixedDate,
+    );
+
+    expect(plan.args).toContain('--dangerously-bypass-approvals-and-sandbox');
+    expect(plan.args).not.toContain('-s');
+  });
+
+  test('rejects mutually exclusive prompt inputs', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aiox-delegate-'));
+    const promptFile = path.join(tmpDir, 'prompt.md');
+    fs.writeFileSync(promptFile, 'prompt', 'utf8');
+
+    expect(() =>
+      createDelegatePlan(
+        parseArgs(['codex', '-t', 'story-4.3', '-p', 'inline', '-f', promptFile]),
+        fixedDate,
+      ),
+    ).toThrow(DelegateCliError);
+  });
+
+  test('sanitizes unsafe slugs', () => {
+    expect(sanitizeSlug(' Story 4.3 / AC1 ')).toBe('Story-4.3-AC1');
+  });
+
+  test('dry-run prints machine-readable run metadata without creating run directory', (done) => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aiox-delegate-'));
+    const binPath = path.join(__dirname, '../../bin/aiox-delegate.js');
+    const child = spawn('node', [
+      binPath,
+      'codex',
+      '-t',
+      'story-4.3',
+      '-p',
+      'Implement AC1',
+      '-d',
+      tmpDir,
+      '--dry-run',
+    ]);
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    child.stderr.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    child.on('close', (code) => {
+      expect(code).toBe(0);
+      expect(stderr).toBe('');
+      expect(stdout).toContain('STATUS=dry-run');
+      expect(stdout).toContain(`RUN_DIR=${path.join(tmpDir, '.aiox/external-runs')}`);
+      expect(stdout).toContain('COMMAND=codex -a never -s workspace-write exec');
+      expect(fs.existsSync(path.join(tmpDir, '.aiox'))).toBe(false);
+      done();
+    });
+  });
+});
+

--- a/tests/cli/aiox-delegate.test.js
+++ b/tests/cli/aiox-delegate.test.js
@@ -8,7 +8,7 @@ const {
   parseArgs,
   sanitizeSlug,
   DelegateCliError,
-} = require('../../.aiox-core/core/external-executors/delegate-cli');
+} = require('@aiox-core/core/external-executors/delegate-cli');
 
 describe('aiox-delegate external executor CLI', () => {
   const fixedDate = new Date(Date.UTC(2026, 4, 8, 2, 30, 45));
@@ -35,7 +35,7 @@ describe('aiox-delegate external executor CLI', () => {
     expect(options.dryRun).toBe(true);
   });
 
-  test('creates a codex plan with full-auto mapped to workspace-write', () => {
+  test('creates a codex plan with workspace-write sandbox by default', () => {
     const plan = createDelegatePlan(
       parseArgs(['codex', '-t', 'story 4.3', '-p', 'Implement AC1', '-d', '/tmp/work']),
       fixedDate,
@@ -49,6 +49,27 @@ describe('aiox-delegate external executor CLI', () => {
     );
     expect(plan.args.at(-1)).toBe('-');
     expect(plan.outputPath).toBe(path.join(plan.runDir, 'output.md'));
+  });
+
+  test('maps full-auto abstraction to Codex workspace-write sandbox', () => {
+    const plan = createDelegatePlan(
+      parseArgs([
+        'codex',
+        '-t',
+        'story-4.3',
+        '-p',
+        'Implement AC1',
+        '-d',
+        '/tmp/work',
+        '--sandbox',
+        'full-auto',
+      ]),
+      fixedDate,
+    );
+
+    expect(plan.args).toEqual(
+      expect.arrayContaining(['-a', 'never', '-s', 'workspace-write', 'exec', '-C', '/tmp/work']),
+    );
   });
 
   test('maps danger-full-access to the explicit Codex bypass flag', () => {
@@ -74,55 +95,82 @@ describe('aiox-delegate external executor CLI', () => {
   test('rejects mutually exclusive prompt inputs', () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aiox-delegate-'));
     const promptFile = path.join(tmpDir, 'prompt.md');
-    fs.writeFileSync(promptFile, 'prompt', 'utf8');
+
+    try {
+      fs.writeFileSync(promptFile, 'prompt', 'utf8');
+
+      expect(() =>
+        createDelegatePlan(
+          parseArgs(['codex', '-t', 'story-4.3', '-p', 'inline', '-f', promptFile]),
+          fixedDate,
+        ),
+      ).toThrow(DelegateCliError);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('wraps missing prompt files in a CLI input error', () => {
+    const missingPath = path.join(os.tmpdir(), `aiox-missing-prompt-${process.pid}-${Date.now()}.md`);
 
     expect(() =>
       createDelegatePlan(
-        parseArgs(['codex', '-t', 'story-4.3', '-p', 'inline', '-f', promptFile]),
+        parseArgs(['codex', '-t', 'story-4.3', '-f', missingPath]),
         fixedDate,
       ),
-    ).toThrow(DelegateCliError);
+    ).toThrow(/Prompt file not found/);
   });
 
   test('sanitizes unsafe slugs', () => {
     expect(sanitizeSlug(' Story 4.3 / AC1 ')).toBe('Story-4.3-AC1');
   });
 
-  test('dry-run prints machine-readable run metadata without creating run directory', (done) => {
+  test('dry-run prints machine-readable run metadata without creating run directory', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aiox-delegate-'));
     const binPath = path.join(__dirname, '../../bin/aiox-delegate.js');
-    const child = spawn('node', [
-      binPath,
-      'codex',
-      '-t',
-      'story-4.3',
-      '-p',
-      'Implement AC1',
-      '-d',
-      tmpDir,
-      '--dry-run',
-    ]);
 
-    let stdout = '';
-    let stderr = '';
+    try {
+      await new Promise((resolve, reject) => {
+        const child = spawn('node', [
+          binPath,
+          'codex',
+          '-t',
+          'story-4.3',
+          '-p',
+          'Implement AC1',
+          '-d',
+          tmpDir,
+          '--dry-run',
+        ]);
 
-    child.stdout.on('data', (data) => {
-      stdout += data.toString();
-    });
+        let stdout = '';
+        let stderr = '';
 
-    child.stderr.on('data', (data) => {
-      stderr += data.toString();
-    });
+        child.stdout.on('data', (data) => {
+          stdout += data.toString();
+        });
 
-    child.on('close', (code) => {
-      expect(code).toBe(0);
-      expect(stderr).toBe('');
-      expect(stdout).toContain('STATUS=dry-run');
-      expect(stdout).toContain(`RUN_DIR=${path.join(tmpDir, '.aiox/external-runs')}`);
-      expect(stdout).toContain('COMMAND=codex -a never -s workspace-write exec');
-      expect(fs.existsSync(path.join(tmpDir, '.aiox'))).toBe(false);
-      done();
-    });
+        child.stderr.on('data', (data) => {
+          stderr += data.toString();
+        });
+
+        child.on('error', reject);
+        child.on('close', (code) => {
+          try {
+            expect(code).toBe(0);
+            expect(stderr).toBe('');
+            expect(stdout).toContain('STATUS=dry-run');
+            expect(stdout).toContain(`RUN_DIR=${path.join(tmpDir, '.aiox/external-runs')}`);
+            expect(stdout).toContain('COMMAND=codex -a never -s workspace-write exec');
+            expect(fs.existsSync(path.join(tmpDir, '.aiox'))).toBe(false);
+            resolve();
+          } catch (error) {
+            reject(error);
+          }
+        });
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });
-

--- a/tests/config/schema-validation.test.js
+++ b/tests/config/schema-validation.test.js
@@ -56,6 +56,8 @@ describe('schema-validation — enriched schemas', () => {
         'markdownExploder',
         'resource_locations',
         'performance_defaults',
+        'dev',
+        'external_executors',
         'utility_scripts_registry',
         'ide_sync_system',
         'template_overrides',
@@ -109,6 +111,15 @@ describe('schema-validation — enriched schemas', () => {
       expect(tmpl.type).toBe('object');
       expect(tmpl.properties.story.properties).toHaveProperty('sections_order');
       expect(tmpl.properties.story.properties).toHaveProperty('optional_sections');
+    });
+
+    test('external executor schema keeps delegation opt-in and sandboxed by default', () => {
+      expect(schema.properties.dev.properties.execution_mode.enum).toEqual(['native', 'delegate']);
+      expect(schema.properties.external_executors.properties.default_sandbox.enum).toContain('full-auto');
+
+      const data = loadYaml('framework-config.yaml');
+      expect(data.dev.execution_mode).toBe('native');
+      expect(data.external_executors.enabled).toBe(false);
     });
   });
 

--- a/tests/config/schema-validation.test.js
+++ b/tests/config/schema-validation.test.js
@@ -40,9 +40,11 @@ describe('schema-validation — enriched schemas', () => {
   // AC1: Framework schema enriched with all L1 keys
   describe('framework-config.schema.json (L1)', () => {
     let schema;
+    let frameworkConfig;
 
     beforeAll(() => {
       schema = loadSchema('framework-config.schema.json');
+      frameworkConfig = loadYaml('framework-config.yaml');
     });
 
     test('schema is valid JSON Schema draft-07', () => {
@@ -80,9 +82,8 @@ describe('schema-validation — enriched schemas', () => {
     });
 
     test('validates real framework-config.yaml without errors', () => {
-      const data = loadYaml('framework-config.yaml');
       const validate = ajv.compile(schema);
-      const isValid = validate(data);
+      const isValid = validate(frameworkConfig);
       if (!isValid) {
          
         console.log('Validation errors:', validate.errors);
@@ -117,9 +118,9 @@ describe('schema-validation — enriched schemas', () => {
       expect(schema.properties.dev.properties.execution_mode.enum).toEqual(['native', 'delegate']);
       expect(schema.properties.external_executors.properties.default_sandbox.enum).toContain('full-auto');
 
-      const data = loadYaml('framework-config.yaml');
-      expect(data.dev.execution_mode).toBe('native');
-      expect(data.external_executors.enabled).toBe(false);
+      expect(frameworkConfig.dev.execution_mode).toBe('native');
+      expect(frameworkConfig.external_executors.enabled).toBe(false);
+      expect(frameworkConfig.external_executors.default_sandbox).toBe('workspace-write');
     });
   });
 


### PR DESCRIPTION
## Summary
- Adds the opt-in External Executor pattern requested in #638.
- Adds `aiox-delegate` as a package bin for Codex-backed implementation delegation with run directory/log/output metadata.
- Adds the formal task definition and Codex provider adapter docs.
- Adds framework config defaults and schema coverage while keeping `dev.execution_mode: native` and `external_executors.enabled: false` by default.
- Extends package completeness validation to assert the new bin entry.

## Validation
- `NODE_PATH=/Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules /Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules/.bin/jest tests/cli/aiox-delegate.test.js tests/config/schema-validation.test.js --runInBand --forceExit`
- `NODE_PATH=/Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules /Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules/.bin/eslint . --cache --cache-location .eslintcache` (0 errors, 114 baseline warnings)
- `NODE_PATH=/Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules /Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules/.bin/tsc --noEmit`
- `NODE_PATH=/Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules node scripts/validate-manifest.js`
- `NODE_PATH=/Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules /Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules/.bin/jest --runInBand --forceExit`
- `PATH=/Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules/.bin:$PATH NODE_PATH=/Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules node bin/utils/validate-publish.js`
- `PATH=/Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules/.bin:$PATH NODE_PATH=/Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules node scripts/validate-package-completeness.js`
- `git diff --check`

Refs #638


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an aiox-delegate CLI to run tasks via external executors (Codex supported) and integrated external-execution options into the main core.

* **Documentation**
  * Added external executor pattern guide, Codex provider guide, and delegation workflow/task documentation.

* **Bug Fixes / Chores**
  * Added framework config defaults for dev and external-executors (sandbox, run dir, execution mode).
  * Updated CLI help, package bin mapping, install manifest, validation checks, and tests for delegation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->