### PR TITLE
fix(core): make build attempt logs JSON-safe

### DIFF
--- a/.aiox-core/core/execution/build-state-manager.js
+++ b/.aiox-core/core/execution/build-state-manager.js
@@ -87,6 +87,119 @@ const NotificationType = {
   ABANDONED: 'abandoned',
 };
 
+/**
+ * Converts arbitrary values into stable, JSON-safe log data.
+ *
+ * @param {*} value - Value to sanitize.
+ * @param {WeakSet<object>} [seen=new WeakSet()] - Objects in the current path.
+ * @returns {*} Data-only representation that JSON.stringify can serialize.
+ */
+function sanitizeLogValue(value, seen = new WeakSet()) {
+  if (value === undefined || value === null) {
+    return value;
+  }
+
+  const valueType = typeof value;
+
+  if (valueType === 'bigint') {
+    return value.toString();
+  }
+
+  if (valueType === 'function' || valueType === 'symbol') {
+    return String(value);
+  }
+
+  if (valueType !== 'object') {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return '[Circular]';
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? value.toString() : value.toISOString();
+  }
+
+  if (value instanceof RegExp) {
+    return value.toString();
+  }
+
+  if (value instanceof Error) {
+    const safeError = {
+      name: value.name,
+      message: value.message,
+      stack: value.stack,
+    };
+
+    seen.add(value);
+
+    try {
+      Object.getOwnPropertyNames(value).forEach((key) => {
+        if (key === 'name' || key === 'message' || key === 'stack') {
+          return;
+        }
+
+        try {
+          safeError[key] = sanitizeLogValue(value[key], seen);
+        } catch (error) {
+          safeError[key] = `[Unserializable: ${error.message}]`;
+        }
+      });
+
+      return safeError;
+    } finally {
+      seen.delete(value);
+    }
+  }
+
+  seen.add(value);
+
+  try {
+    if (value instanceof Map) {
+      return Array.from(value.entries()).map(([key, entryValue]) => [
+        sanitizeLogValue(key, seen),
+        sanitizeLogValue(entryValue, seen),
+      ]);
+    }
+
+    if (value instanceof Set) {
+      return Array.from(value.values()).map((entryValue) => sanitizeLogValue(entryValue, seen));
+    }
+
+    if (Array.isArray(value)) {
+      return value.map((entryValue) => sanitizeLogValue(entryValue, seen));
+    }
+
+    return Object.keys(value).reduce((safeValue, key) => {
+      try {
+        safeValue[key] = sanitizeLogValue(value[key], seen);
+      } catch (error) {
+        safeValue[key] = `[Unserializable: ${error.message}]`;
+      }
+      return safeValue;
+    }, {});
+  } catch (error) {
+    return `[Unserializable: ${error.message}]`;
+  } finally {
+    seen.delete(value);
+  }
+}
+
+/**
+ * Stringifies attempt log details without allowing log formatting to throw.
+ *
+ * @param {*} value - Value to stringify.
+ * @returns {string} JSON string or a fallback marker.
+ */
+function stringifyLogDetails(value) {
+  try {
+    return JSON.stringify(sanitizeLogValue(value));
+  } catch (error) {
+    return JSON.stringify(`[Unserializable: ${error.message}]`);
+  }
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════════
 //                              SCHEMA VALIDATION
 // ═══════════════════════════════════════════════════════════════════════════════════
@@ -927,7 +1040,7 @@ class BuildStateManager {
     };
 
     // Format log line
-    const logLine = `[${entry.timestamp}] [${this.storyId}] [${subtaskId}] ${action}: ${JSON.stringify(details)}\n`;
+    const logLine = `[${entry.timestamp}] [${this.storyId}] [${subtaskId}] ${action}: ${stringifyLogDetails(details)}\n`;
 
     this._logBuffer.push(logLine);
 

--- a/.aiox-core/core/execution/build-state-manager.js
+++ b/.aiox-core/core/execution/build-state-manager.js
@@ -129,7 +129,7 @@ function sanitizeLogValue(value, seen = new WeakSet()) {
     const safeError = {
       name: value.name,
       message: value.message,
-      stack: value.stack,
+      stack: shouldExposeLogErrorStack() ? value.stack : '[redacted]',
     };
 
     seen.add(value);
@@ -184,6 +184,16 @@ function sanitizeLogValue(value, seen = new WeakSet()) {
   } finally {
     seen.delete(value);
   }
+}
+
+/**
+ * Checks whether persisted attempt logs may include raw error stack traces.
+ *
+ * @returns {boolean} True when stack trace logging is explicitly enabled.
+ */
+function shouldExposeLogErrorStack() {
+  const stackFlag = process.env.DEBUG_ERROR_STACKS || process.env.DEBUG_STACKS || '';
+  return ['1', 'true', 'yes', 'on'].includes(String(stackFlag).toLowerCase());
 }
 
 /**

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.1.15
-generated_at: "2026-05-08T03:56:46.901Z"
+generated_at: "2026-05-08T04:14:50.631Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1111
 files:
@@ -409,9 +409,9 @@ files:
     type: core
     size: 33071
   - path: core/execution/build-state-manager.js
-    hash: sha256:415fca3ad3d750db1f41f14f33971cf661ee9d6073a570175d695bb3c1be655c
+    hash: sha256:38926431dc75a750c433c6f706491778f8aebd27c88c6534dfcc05ae110cf369
     type: core
-    size: 48976
+    size: 51697
   - path: core/execution/context-injector.js
     hash: sha256:7654f6e6c3d555f3963369e71edf84b15c0fdec53bd161800b71782f78275244
     type: core

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.1.15
-generated_at: "2026-05-08T04:14:50.631Z"
+generated_at: "2026-05-08T04:27:49.896Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1111
 files:
@@ -409,9 +409,9 @@ files:
     type: core
     size: 33071
   - path: core/execution/build-state-manager.js
-    hash: sha256:38926431dc75a750c433c6f706491778f8aebd27c88c6534dfcc05ae110cf369
+    hash: sha256:a6a3ed85ff040fd8338ec31eaf8729050e58216c873f5e0e80f2fbda89234b73
     type: core
-    size: 51697
+    size: 52112
   - path: core/execution/context-injector.js
     hash: sha256:7654f6e6c3d555f3963369e71edf84b15c0fdec53bd161800b71782f78275244
     type: core

--- a/tests/core/build-state-manager.test.js
+++ b/tests/core/build-state-manager.test.js
@@ -587,9 +587,10 @@ describe('BuildStateManager', () => {
       const content = fs.readFileSync(path.join(testDir, 'plan', 'build-attempts.log'), 'utf-8');
       expect(content).toContain('"name":"TypeError"');
       expect(content).toContain('"message":"boom"');
+      expect(content).toContain('"stack":"[redacted]"');
       expect(content).toContain('[["attempt","3"]]');
       expect(content).toContain('"set":["2"]');
-      expect(content).toContain('"callback":"() => \'ignored\'"');
+      expect(content).toMatch(/"callback":"[^"]*ignored[^"]*"/);
     });
   });
 

--- a/tests/core/build-state-manager.test.js
+++ b/tests/core/build-state-manager.test.js
@@ -554,6 +554,43 @@ describe('BuildStateManager', () => {
 
       expect(logs.length).toBe(3);
     });
+
+    test('should serialize circular log details without throwing', () => {
+      const details = { step: 'circular-log' };
+      details.self = details;
+
+      expect(() => {
+        manager._logAttempt('1.circular', 'debug', details);
+        manager.saveState();
+      }).not.toThrow();
+
+      const content = fs.readFileSync(path.join(testDir, 'plan', 'build-attempts.log'), 'utf-8');
+      expect(content).toContain('1.circular');
+      expect(content).toContain('"self":"[Circular]"');
+    });
+
+    test('should serialize non-JSON log values into stable data shapes', () => {
+      const cause = new Error('nested cause');
+      const error = new TypeError('boom');
+      error.cause = cause;
+      error.details = new Map([['attempt', 3n]]);
+
+      expect(() => {
+        manager._logAttempt('1.non-json', 'debug', {
+          error,
+          set: new Set([2n]),
+          callback: () => 'ignored',
+        });
+        manager.saveState();
+      }).not.toThrow();
+
+      const content = fs.readFileSync(path.join(testDir, 'plan', 'build-attempts.log'), 'utf-8');
+      expect(content).toContain('"name":"TypeError"');
+      expect(content).toContain('"message":"boom"');
+      expect(content).toContain('[["attempt","3"]]');
+      expect(content).toContain('"set":["2"]');
+      expect(content).toContain('"callback":"() => \'ignored\'"');
+    });
   });
 
   // ─────────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add JSON-safe log detail serialization for BuildStateManager attempt logs.
- Preserve circular references as `[Circular]` and normalize Error, Map, Set, BigInt, Date, RegExp, function, and symbol values into stable data shapes.
- Add focused regression coverage for circular and non-JSON log details.
- Regenerate `.aiox-core/install-manifest.yaml` for the changed core file hash.

## Issue
Contributes to #621 by delivering the Data Integrity slice for circular reference serialization in build attempt JSON logs.

## Validation
- `node -c .aiox-core/core/execution/build-state-manager.js`
- `jest tests/core/build-state-manager.test.js --runInBand`
- `npm run generate:manifest`
- `npm run validate:manifest`
- `git diff --check`
- `npm run lint` (0 errors, 114 baseline warnings)
- `npm run typecheck`
- `node scripts/validate-package-completeness.js` (34/34 passed after initializing `pro` submodule)
- `node bin/utils/validate-publish.js` (PASS after initializing `pro` submodule)
- `npm test -- --runInBand --forceExit` (11 skipped, 330 passed, 330/341 suites; 149 skipped, 8336 passed, 8485 tests)

## Notes
- `.aiox-core/data/entity-registry.yaml` was touched by test/pre-commit hooks and intentionally restored before push as a volatile generated artifact.
- The pre-push registry hook reported a non-blocking missing `js-yaml` in this temp worktree, but the same validation was run successfully with canonical `NODE_PATH` before publication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attempt logging to safely handle complex/non-JSON values (circular references, errors, BigInt, Date, RegExp, Map/Set, functions), preventing logging failures and ensuring stable, readable log output.

* **Tests**
  * Added tests verifying resilient serialization of circular references and various non-serializable data types in attempt logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->