### PR TITLE
test(jest): resolve package-style core imports

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -129,6 +129,7 @@ module.exports = {
   roots: ['<rootDir>'],
   moduleDirectories: ['node_modules', '.'],
   moduleNameMapper: {
+    '^aiox-core/(.*)$': '<rootDir>/.aiox-core/$1',
     '^@aiox-core/(.*)$': '<rootDir>/.aiox-core/$1',
   },
   setupFilesAfterEnv: ['<rootDir>/tests/setup.js'],

--- a/tests/config/jest-module-mapper.test.js
+++ b/tests/config/jest-module-mapper.test.js
@@ -1,0 +1,10 @@
+'use strict';
+
+describe('Jest moduleNameMapper', () => {
+  test('resolves package-style aiox-core imports to framework modules', () => {
+    const LayerProcessor = require('aiox-core/core/synapse/layers/layer-processor');
+
+    expect(typeof LayerProcessor).toBe('function');
+    expect(LayerProcessor.name).toBe('LayerProcessor');
+  });
+});


### PR DESCRIPTION
## Summary\n- Add Jest moduleNameMapper support for package-style `aiox-core/...` imports.\n- Add a regression test resolving a real framework module through the new alias.\n\n## Validation\n- `node -c jest.config.js`\n- `node -c tests/config/jest-module-mapper.test.js`\n- `npm test -- tests/config/jest-module-mapper.test.js --runInBand`\n- `npm run generate:manifest` + `npm run validate:manifest`\n- `git diff --check`\n- `npm run lint` — pass, 0 errors / 114 baseline warnings\n- `npm run typecheck`\n- `node scripts/validate-package-completeness.js` — 34/34 passed\n- `node bin/utils/validate-publish.js` — pass, 4199 files\n- `npm test -- --runInBand --forceExit` — 331 suites passed, 11 skipped; 8352 tests passed, 149 skipped\n\nPart of #621.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite to verify framework module imports are correctly resolved by the test framework.

* **Chores**
  * Enhanced Jest configuration with module name mapping to ensure consistent and reliable import resolution during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->