### PR TITLE
chore(lint): fix Kimi transformer warnings

### DIFF
--- a/tests/ide-sync/kimi-transformer.test.js
+++ b/tests/ide-sync/kimi-transformer.test.js
@@ -20,7 +20,7 @@ const kimi = require(path.resolve(
   'scripts',
   'ide-sync',
   'transformers',
-  'kimi'
+  'kimi',
 ));
 const { syncIde } = require('../../.aiox-core/infrastructure/scripts/ide-sync/index');
 
@@ -79,7 +79,7 @@ describe('kimi transformer', () => {
     });
     expect(skillId).toBe('aios-team-danger-agent');
     expect(kimi.getDirname({ id: '..', agent: { preferredActivationAlias: '../../' } })).toBe(
-      'aios-agent'
+      'aios-agent',
     );
   });
 
@@ -180,7 +180,7 @@ describe('kimi transformer', () => {
         { enabled: true, path: '.kimi/skills', format: 'kimi-skill' },
         'kimi',
         tmpRoot,
-        { dryRun: false }
+        { dryRun: false },
       );
 
       expect(result.errors).toHaveLength(1);


### PR DESCRIPTION
## Summary
- add missing trailing commas in tests/ide-sync/kimi-transformer.test.js
- remove the 3 existing comma-dangle lint warnings

## Validation
- npx eslint tests/ide-sync/kimi-transformer.test.js --cache --cache-location /private/tmp/aiox-core-kimi-eslintcache
- npm test -- tests/ide-sync/kimi-transformer.test.js --runInBand
- npm run lint
- npm run typecheck

## Notes
- PR #704 remains blocked by branch policy because the authenticated user is the PR author and the repository requires review from Pedrovaleriolopez or oalanicolas.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Minor formatting and whitespace adjustments in test files with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->