### PR TITLE
feat: add hierarchical context manager [Story 447.1]

### DIFF
--- a/.aiox-core/core/synapse/context/README.md
+++ b/.aiox-core/core/synapse/context/README.md
@@ -1,0 +1,35 @@
+# SYNAPSE Context Runtime
+
+This directory contains bounded-context helpers for the SYNAPSE runtime.
+
+## HierarchicalContextManager
+
+`HierarchicalContextManager` keeps an LLM-ready message array under a configured
+token budget by moving older short-term messages into long-term summaries.
+Summarization is injectable and has a deterministic local fallback, so the
+manager can run in tests, CLI flows and offline agent loops without a live LLM.
+
+```javascript
+const { HierarchicalContextManager } = require('./.aiox-core/core/synapse/context');
+
+const contextManager = new HierarchicalContextManager({
+  maxTokens: 8192,
+  summarizationThreshold: 0.75,
+  tokenizer: text => Math.ceil(text.length / 4),
+  summarizer: async ({ messages }) => {
+    return messages.map(message => `${message.role}: ${message.content}`).join('\n');
+  },
+});
+
+contextManager.on('swap:complete', data => {
+  console.log(`Compacted ${data.messagesRemoved} message(s).`);
+});
+
+await contextManager.addMessage({ role: 'user', content: 'Build the next task.' });
+const safeContext = contextManager.getContext();
+```
+
+The manager does not call OpenAI, Anthropic, Claude, Gemini, Kimi or OpenRouter
+directly. Inject a summarizer when an agent loop wants model-based compression.
+If that summarizer fails, the manager emits `swap:error` and falls back to a
+local extractive summary instead of crashing the loop.

--- a/.aiox-core/core/synapse/context/hierarchical-context-manager.js
+++ b/.aiox-core/core/synapse/context/hierarchical-context-manager.js
@@ -123,6 +123,7 @@ class HierarchicalContextManager extends EventEmitter {
     this._swapCount = 0;
     this._lastSwap = null;
     this._lastError = null;
+    this._operationQueue = Promise.resolve();
   }
 
   /**
@@ -132,9 +133,11 @@ class HierarchicalContextManager extends EventEmitter {
    * @returns {Promise<object>} Manager stats after insertion.
    */
   async addMessage(message) {
-    this._shortTermMessages.push(this._normalizeMessage(message));
-    await this._compactIfNeeded();
-    return this.getStats();
+    return this._enqueueMutation(async () => {
+      this._shortTermMessages.push(this._normalizeMessage(message));
+      await this._compactIfNeeded();
+      return this.getStats();
+    });
   }
 
   /**
@@ -198,6 +201,13 @@ class HierarchicalContextManager extends EventEmitter {
     this._swapCount = 0;
     this._lastSwap = null;
     this._lastError = null;
+    this._operationQueue = Promise.resolve();
+  }
+
+  _enqueueMutation(operation) {
+    const run = this._operationQueue.then(operation, operation);
+    this._operationQueue = run.catch(() => {});
+    return run;
   }
 
   _normalizeMessage(message) {
@@ -237,9 +247,21 @@ class HierarchicalContextManager extends EventEmitter {
       break;
     }
 
+    await this._fitLongTermSummariesToBudget();
+  }
+
+  async _fitLongTermSummariesToBudget() {
+    if (this._getTotalTokens() <= this.maxTokens || this._longTermSummaries.length === 0) {
+      return;
+    }
+
+    if (this._longTermSummaries.length > 1) {
+      await this._compactLongTermSummaries();
+    }
+
     if (this._getTotalTokens() > this.maxTokens && this._longTermSummaries.length > 0) {
       this._longTermSummaries = [
-        this._truncateSummaryMessage(this._longTermSummaries[this._longTermSummaries.length - 1]),
+        this._truncateSummaryMessage(this._longTermSummaries[0]),
       ];
     }
   }

--- a/.aiox-core/core/synapse/context/hierarchical-context-manager.js
+++ b/.aiox-core/core/synapse/context/hierarchical-context-manager.js
@@ -1,0 +1,510 @@
+/**
+ * Hierarchical Context Manager
+ *
+ * Maintains a bounded LLM-ready message context by compacting older
+ * short-term messages into long-term summaries. Summarization is injectable
+ * and falls back to deterministic local extractive summaries, so tests and
+ * offline agent loops do not require a live LLM provider.
+ *
+ * @module core/synapse/context/hierarchical-context-manager
+ * @version 1.0.0
+ * @created Story 447.1 - Hierarchical Context Manager Contract
+ */
+
+'use strict';
+
+const { EventEmitter } = require('events');
+const { estimateTokens } = require('../utils/tokens');
+
+const DEFAULT_MAX_TOKENS = 8192;
+const DEFAULT_SUMMARIZATION_THRESHOLD = 0.75;
+const DEFAULT_MIN_RECENT_MESSAGES = 1;
+const DEFAULT_SUMMARY_TOKEN_RATIO = 0.25;
+const DEFAULT_SUMMARY_PREFIX = 'Long-term context summary';
+
+function isPositiveNumber(value) {
+  return Number.isFinite(value) && value > 0;
+}
+
+function normalizeThreshold(value) {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return DEFAULT_SUMMARIZATION_THRESHOLD;
+  }
+  if (value <= 0) return DEFAULT_SUMMARIZATION_THRESHOLD;
+  if (value > 1) return 1;
+  return value;
+}
+
+function cloneValue(value) {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return value;
+  }
+}
+
+function normalizeContent(content) {
+  if (content === undefined || content === null) {
+    return '';
+  }
+  return typeof content === 'string' ? content : JSON.stringify(content);
+}
+
+function normalizeTokenCount(value) {
+  if (Array.isArray(value)) {
+    return value.length;
+  }
+  if (isPositiveNumber(value) || value === 0) {
+    return Math.ceil(value);
+  }
+  if (value && isPositiveNumber(value.totalTokens)) {
+    return Math.ceil(value.totalTokens);
+  }
+  if (value && isPositiveNumber(value.tokens)) {
+    return Math.ceil(value.tokens);
+  }
+  return null;
+}
+
+function buildDefaultSummary(messages, options = {}) {
+  const lines = [];
+  const prefix = options.prefix || DEFAULT_SUMMARY_PREFIX;
+
+  lines.push(`${prefix}: ${messages.length} message(s) compacted.`);
+
+  for (const [index, message] of messages.entries()) {
+    const role = message.role || 'unknown';
+    const content = normalizeContent(message.content).replace(/\s+/g, ' ').trim();
+    const excerpt = content.length > 360 ? `${content.slice(0, 357).trimEnd()}...` : content;
+    const label = message.id ? `${index + 1}. ${role}#${message.id}` : `${index + 1}. ${role}`;
+    lines.push(`- ${label}: ${excerpt}`);
+  }
+
+  return lines.join('\n');
+}
+
+class HierarchicalContextManager extends EventEmitter {
+  /**
+   * @param {object} [options={}]
+   * @param {number} [options.maxTokens=8192] - Hard context token limit.
+   * @param {number} [options.summarizationThreshold=0.75] - Swap threshold as maxTokens ratio.
+   * @param {Function|object} [options.tokenizer] - Token counter function or tokenizer object.
+   * @param {Function} [options.summarizer] - Optional sync/async summarizer.
+   * @param {number} [options.minRecentMessages=1] - Messages to keep uncompressed when possible.
+   * @param {Function} [options.onSwap] - Callback for swap:complete.
+   * @param {Function} [options.onSwapError] - Callback for swap:error.
+   */
+  constructor(options = {}) {
+    super();
+
+    this.maxTokens = isPositiveNumber(options.maxTokens)
+      ? Math.floor(options.maxTokens)
+      : DEFAULT_MAX_TOKENS;
+    this.summarizationThreshold = normalizeThreshold(options.summarizationThreshold);
+    this.thresholdTokens = Math.max(1, Math.floor(this.maxTokens * this.summarizationThreshold));
+    this.minRecentMessages = Number.isInteger(options.minRecentMessages) && options.minRecentMessages >= 0
+      ? options.minRecentMessages
+      : DEFAULT_MIN_RECENT_MESSAGES;
+    this.summaryTokenRatio = isPositiveNumber(options.summaryTokenRatio)
+      ? Math.min(options.summaryTokenRatio, 0.9)
+      : DEFAULT_SUMMARY_TOKEN_RATIO;
+    this.summaryPrefix = options.summaryPrefix || DEFAULT_SUMMARY_PREFIX;
+
+    this._tokenizer = options.tokenizer || null;
+    this._summarizer = typeof options.summarizer === 'function' ? options.summarizer : null;
+    this._onSwap = typeof options.onSwap === 'function' ? options.onSwap : null;
+    this._onSwapError = typeof options.onSwapError === 'function' ? options.onSwapError : null;
+
+    this._shortTermMessages = [];
+    this._longTermSummaries = [];
+    this._swapCount = 0;
+    this._lastSwap = null;
+    this._lastError = null;
+  }
+
+  /**
+   * Add one message and compact context if the threshold is crossed.
+   *
+   * @param {object} message - LLM message with role/content/metadata shape.
+   * @returns {Promise<object>} Manager stats after insertion.
+   */
+  async addMessage(message) {
+    this._shortTermMessages.push(this._normalizeMessage(message));
+    await this._compactIfNeeded();
+    return this.getStats();
+  }
+
+  /**
+   * Add multiple messages sequentially.
+   *
+   * @param {object[]} messages - Messages to add.
+   * @returns {Promise<object>} Manager stats after insertion.
+   */
+  async addMessages(messages) {
+    if (!Array.isArray(messages)) {
+      throw new TypeError('addMessages expects an array of messages');
+    }
+
+    for (const message of messages) {
+      await this.addMessage(message);
+    }
+
+    return this.getStats();
+  }
+
+  /**
+   * Return LLM-ready context: long-term summaries first, recent messages next.
+   *
+   * @returns {object[]} Context messages.
+   */
+  getContext() {
+    return this._cloneMessages([...this._longTermSummaries, ...this._shortTermMessages]);
+  }
+
+  /**
+   * Return current context statistics.
+   *
+   * @returns {object}
+   */
+  getStats() {
+    const shortTermTokens = this._countMessagesTokens(this._shortTermMessages);
+    const longTermTokens = this._countMessagesTokens(this._longTermSummaries);
+
+    return {
+      maxTokens: this.maxTokens,
+      summarizationThreshold: this.summarizationThreshold,
+      thresholdTokens: this.thresholdTokens,
+      shortTermMessages: this._shortTermMessages.length,
+      longTermSummaries: this._longTermSummaries.length,
+      totalMessages: this._shortTermMessages.length + this._longTermSummaries.length,
+      shortTermTokens,
+      longTermTokens,
+      totalTokens: shortTermTokens + longTermTokens,
+      swapCount: this._swapCount,
+      lastSwap: cloneValue(this._lastSwap),
+      lastError: this._lastError ? { message: this._lastError.message } : null,
+    };
+  }
+
+  /**
+   * Clear all short-term and long-term state.
+   */
+  clear() {
+    this._shortTermMessages = [];
+    this._longTermSummaries = [];
+    this._swapCount = 0;
+    this._lastSwap = null;
+    this._lastError = null;
+  }
+
+  _normalizeMessage(message) {
+    if (!message || typeof message !== 'object' || Array.isArray(message)) {
+      throw new TypeError('message must be an object with role/content fields');
+    }
+
+    const normalized = { ...message };
+    normalized.role = normalized.role ? String(normalized.role) : 'user';
+    normalized.content = normalizeContent(normalized.content);
+
+    if (message.metadata !== undefined) {
+      normalized.metadata = cloneValue(message.metadata);
+    }
+
+    return normalized;
+  }
+
+  async _compactIfNeeded() {
+    let guard = 0;
+
+    while (this._getTotalTokens() > this.thresholdTokens && guard < 12) {
+      guard += 1;
+
+      if (this._shortTermMessages.length > 0) {
+        const messages = this._selectShortTermMessagesForSwap();
+        if (messages.length === 0) break;
+        await this._swapShortTermMessages(messages);
+        continue;
+      }
+
+      if (this._longTermSummaries.length > 1) {
+        await this._compactLongTermSummaries();
+        continue;
+      }
+
+      break;
+    }
+
+    if (this._getTotalTokens() > this.maxTokens && this._longTermSummaries.length > 0) {
+      this._longTermSummaries = [
+        this._truncateSummaryMessage(this._longTermSummaries[this._longTermSummaries.length - 1]),
+      ];
+    }
+  }
+
+  _selectShortTermMessagesForSwap() {
+    const totalTokens = this._getTotalTokens();
+    const available = this._shortTermMessages.length;
+
+    if (available === 0 || totalTokens <= this.thresholdTokens) {
+      return [];
+    }
+
+    if (available <= this.minRecentMessages && totalTokens <= this.maxTokens) {
+      return [];
+    }
+
+    const tokensToRemove = totalTokens - this.thresholdTokens;
+    const keepRecent = available > 1 ? Math.min(this.minRecentMessages, available - 1) : 0;
+    const maxSelectable = Math.max(1, available - keepRecent);
+    const selected = [];
+    let selectedTokens = 0;
+
+    for (let index = 0; index < maxSelectable; index += 1) {
+      const message = this._shortTermMessages[index];
+      selected.push(message);
+      selectedTokens += this._countMessageTokens(message);
+
+      if (selectedTokens >= tokensToRemove) {
+        break;
+      }
+    }
+
+    return selected;
+  }
+
+  async _swapShortTermMessages(messages) {
+    const beforeTokens = this._getTotalTokens();
+    const summary = await this._summarizeMessages(messages, {
+      source: 'short-term',
+      targetTokens: this._summaryTargetTokens(),
+    });
+
+    this._shortTermMessages.splice(0, messages.length);
+    this._longTermSummaries.push(summary);
+
+    const afterTokens = this._getTotalTokens();
+    this._recordSwap({
+      source: 'short-term',
+      messagesRemoved: messages.length,
+      tokensBefore: beforeTokens,
+      tokensAfter: afterTokens,
+      summaryTokens: this._countMessageTokens(summary),
+    });
+  }
+
+  async _compactLongTermSummaries() {
+    const summaries = this._longTermSummaries;
+    const beforeTokens = this._getTotalTokens();
+    const summary = await this._summarizeMessages(summaries, {
+      source: 'long-term',
+      targetTokens: this._summaryTargetTokens(),
+    });
+
+    this._longTermSummaries = [summary];
+
+    const afterTokens = this._getTotalTokens();
+    this._recordSwap({
+      source: 'long-term',
+      messagesRemoved: summaries.length,
+      tokensBefore: beforeTokens,
+      tokensAfter: afterTokens,
+      summaryTokens: this._countMessageTokens(summary),
+    });
+  }
+
+  async _summarizeMessages(messages, options) {
+    const targetTokens = options.targetTokens || this._summaryTargetTokens();
+    let rawSummary = null;
+    let fallbackUsed = false;
+
+    if (this._summarizer) {
+      try {
+        rawSummary = await this._summarizer({
+          messages: this._cloneMessages(messages),
+          currentSummary: this._longTermSummaries.map(message => message.content).join('\n\n'),
+          targetTokens,
+          maxTokens: this.maxTokens,
+          estimateTokens: text => this._countTextTokens(text),
+        });
+      } catch (error) {
+        fallbackUsed = true;
+        this._lastError = error;
+        this._safeEmit('swap:error', {
+          error,
+          source: options.source,
+          messages,
+        });
+      }
+    }
+
+    const summaryContent = this._normalizeSummaryResult(rawSummary)
+      || buildDefaultSummary(messages, { prefix: this.summaryPrefix });
+    const content = this._truncateTextToTokenBudget(summaryContent, targetTokens);
+
+    return {
+      role: 'system',
+      content,
+      metadata: {
+        aiox: {
+          type: 'hierarchical_context_summary',
+          source: options.source,
+          fallbackUsed,
+          messagesSummarized: messages.length,
+          createdAt: new Date().toISOString(),
+          sourceMessages: this._extractSourceMessages(messages),
+        },
+      },
+    };
+  }
+
+  _extractSourceMessages(messages) {
+    const sources = [];
+
+    for (const message of messages) {
+      const nestedSources = message.metadata
+        && message.metadata.aiox
+        && Array.isArray(message.metadata.aiox.sourceMessages)
+        ? message.metadata.aiox.sourceMessages
+        : null;
+
+      if (nestedSources) {
+        sources.push(...cloneValue(nestedSources));
+        continue;
+      }
+
+      sources.push({
+        role: message.role,
+        id: message.id,
+        metadata: cloneValue(message.metadata),
+      });
+    }
+
+    return sources;
+  }
+
+  _normalizeSummaryResult(result) {
+    if (!result) return null;
+    if (typeof result === 'string') return result.trim() || null;
+    if (typeof result.content === 'string') return result.content.trim() || null;
+    if (typeof result.summary === 'string') return result.summary.trim() || null;
+    return null;
+  }
+
+  _truncateSummaryMessage(message) {
+    const cloned = this._cloneMessage(message);
+    cloned.content = this._truncateTextToTokenBudget(cloned.content, this._summaryTargetTokens());
+    cloned.metadata = {
+      ...(cloned.metadata || {}),
+      aiox: {
+        ...(cloned.metadata && cloned.metadata.aiox ? cloned.metadata.aiox : {}),
+        truncatedToFitBudget: true,
+      },
+    };
+    return cloned;
+  }
+
+  _truncateTextToTokenBudget(text, tokenBudget) {
+    const suffix = '\n[summary truncated to fit context budget]';
+    let result = normalizeContent(text);
+    let attempts = 0;
+
+    while (this._countTextTokens(result) > tokenBudget && result.length > suffix.length && attempts < 12) {
+      attempts += 1;
+      const currentTokens = this._countTextTokens(result);
+      const ratio = Math.max(0.1, tokenBudget / currentTokens);
+      const nextLength = Math.max(0, Math.floor(result.length * ratio) - suffix.length - 8);
+      result = `${result.slice(0, nextLength).trimEnd()}${suffix}`;
+    }
+
+    return result;
+  }
+
+  _recordSwap(payload) {
+    this._swapCount += 1;
+    this._lastSwap = {
+      ...payload,
+      swapCount: this._swapCount,
+      completedAt: new Date().toISOString(),
+    };
+    this._safeEmit('swap:complete', this._lastSwap);
+  }
+
+  _safeEmit(eventName, payload) {
+    try {
+      this.emit(eventName, payload);
+    } catch (error) {
+      this._lastError = error;
+    }
+
+    try {
+      if (eventName === 'swap:complete' && this._onSwap) {
+        this._onSwap(payload);
+      }
+      if (eventName === 'swap:error' && this._onSwapError) {
+        this._onSwapError(payload);
+      }
+    } catch (error) {
+      this._lastError = error;
+    }
+  }
+
+  _summaryTargetTokens() {
+    return Math.max(16, Math.floor(this.maxTokens * this.summaryTokenRatio));
+  }
+
+  _getTotalTokens() {
+    return this._countMessagesTokens([...this._longTermSummaries, ...this._shortTermMessages]);
+  }
+
+  _countMessagesTokens(messages) {
+    return messages.reduce((total, message) => total + this._countMessageTokens(message), 0);
+  }
+
+  _countMessageTokens(message) {
+    const roleTokens = this._countTextTokens(message.role || '');
+    const contentTokens = this._countTextTokens(normalizeContent(message.content));
+    return roleTokens + contentTokens;
+  }
+
+  _countTextTokens(text) {
+    const normalizedText = normalizeContent(text);
+
+    if (typeof this._tokenizer === 'function') {
+      const result = normalizeTokenCount(this._tokenizer(normalizedText));
+      if (result !== null) return result;
+    }
+
+    if (this._tokenizer && typeof this._tokenizer.countTokens === 'function') {
+      const result = normalizeTokenCount(this._tokenizer.countTokens(normalizedText));
+      if (result !== null) return result;
+    }
+
+    if (this._tokenizer && typeof this._tokenizer.encode === 'function') {
+      const result = normalizeTokenCount(this._tokenizer.encode(normalizedText));
+      if (result !== null) return result;
+    }
+
+    return estimateTokens(normalizedText);
+  }
+
+  _cloneMessages(messages) {
+    return messages.map(message => this._cloneMessage(message));
+  }
+
+  _cloneMessage(message) {
+    return cloneValue(message);
+  }
+}
+
+module.exports = {
+  HierarchicalContextManager,
+  DEFAULT_MAX_TOKENS,
+  DEFAULT_SUMMARIZATION_THRESHOLD,
+  DEFAULT_MIN_RECENT_MESSAGES,
+  DEFAULT_SUMMARY_TOKEN_RATIO,
+  DEFAULT_SUMMARY_PREFIX,
+  buildDefaultSummary,
+};

--- a/.aiox-core/core/synapse/context/index.js
+++ b/.aiox-core/core/synapse/context/index.js
@@ -1,0 +1,17 @@
+/**
+ * SYNAPSE context runtime exports.
+ *
+ * @module core/synapse/context
+ */
+
+'use strict';
+
+const contextTracker = require('./context-tracker');
+const contextBuilder = require('./context-builder');
+const hierarchicalContext = require('./hierarchical-context-manager');
+
+module.exports = {
+  ...contextTracker,
+  ...contextBuilder,
+  ...hierarchicalContext,
+};

--- a/.aiox-core/data/entity-registry.yaml
+++ b/.aiox-core/data/entity-registry.yaml
@@ -1,6 +1,6 @@
 metadata:
   version: 1.0.0
-  lastUpdated: '2026-05-08T18:29:29.169Z'
+  lastUpdated: '2026-05-08T19:13:43.512Z'
   entityCount: 755
   checksumAlgorithm: sha256
   resolutionRate: 100
@@ -12951,7 +12951,7 @@ entities:
       path: .aiox-core/core/synapse/context/hierarchical-context-manager.js
       layer: L1
       type: module
-      purpose: Maintains bounded LLM-ready context by compacting older messages into summaries
+      purpose: this._longTermSummaries.map(message => message.content).join('\n\n'),
       keywords:
         - hierarchical
         - context
@@ -12967,8 +12967,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:8f10627cf01712aa4e799ca2cb01fcd6c6694e3462cd0be592561c37ff8cbd53
-      lastVerified: '2026-05-08T18:29:29.162Z'
+      checksum: sha256:34f5b9e64c46880138ad684d64e7006f63c16211a219afa81a2c1b6236748af5
+      lastVerified: '2026-05-08T19:13:43.506Z'
     synapse-context-index:
       path: .aiox-core/core/synapse/context/index.js
       layer: L1
@@ -12989,7 +12989,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a67e843cf61e823e0c1b73efdb2d67d268a798fc0c25505a199c1da130d4fe36
-      lastVerified: '2026-05-08T18:29:29.164Z'
+      lastVerified: '2026-05-08T19:10:54.503Z'
   agents:
     aiox-master:
       path: .aiox-core/development/agents/aiox-master.md

--- a/.aiox-core/data/entity-registry.yaml
+++ b/.aiox-core/data/entity-registry.yaml
@@ -1,7 +1,7 @@
 metadata:
   version: 1.0.0
-  lastUpdated: '2026-05-08T14:34:39.794Z'
-  entityCount: 753
+  lastUpdated: '2026-05-08T18:29:29.169Z'
+  entityCount: 755
   checksumAlgorithm: sha256
   resolutionRate: 100
 entities:
@@ -11458,6 +11458,7 @@ entities:
         - builder
       usedBy:
         - synapse-engine
+        - synapse-context-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -11479,6 +11480,7 @@ entities:
       usedBy:
         - pipeline-collector
         - synapse-engine
+        - synapse-context-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -11892,6 +11894,7 @@ entities:
         - memory-bridge
         - synapse-memory-provider
         - formatter
+        - hierarchical-context-manager
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -12944,6 +12947,49 @@ entities:
       externalDeps: []
       plannedDeps: []
       lifecycle: experimental
+    hierarchical-context-manager:
+      path: .aiox-core/core/synapse/context/hierarchical-context-manager.js
+      layer: L1
+      type: module
+      purpose: Maintains bounded LLM-ready context by compacting older messages into summaries
+      keywords:
+        - hierarchical
+        - context
+        - manager
+      usedBy:
+        - synapse-context-index
+      dependencies:
+        - tokens
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:8f10627cf01712aa4e799ca2cb01fcd6c6694e3462cd0be592561c37ff8cbd53
+      lastVerified: '2026-05-08T18:29:29.162Z'
+    synapse-context-index:
+      path: .aiox-core/core/synapse/context/index.js
+      layer: L1
+      type: module
+      purpose: Exports SYNAPSE context runtime helpers and the hierarchical context manager
+      keywords:
+        - index
+      usedBy: []
+      dependencies:
+        - context-tracker
+        - context-builder
+        - hierarchical-context-manager
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: experimental
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:a67e843cf61e823e0c1b73efdb2d67d268a798fc0c25505a199c1da130d4fe36
+      lastVerified: '2026-05-08T18:29:29.164Z'
   agents:
     aiox-master:
       path: .aiox-core/development/agents/aiox-master.md

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.1.15
-generated_at: "2026-05-08T18:32:17.980Z"
+generated_at: "2026-05-08T19:14:10.833Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1120
 files:
@@ -1097,9 +1097,9 @@ files:
     type: core
     size: 9144
   - path: core/synapse/context/hierarchical-context-manager.js
-    hash: sha256:8f10627cf01712aa4e799ca2cb01fcd6c6694e3462cd0be592561c37ff8cbd53
+    hash: sha256:34f5b9e64c46880138ad684d64e7006f63c16211a219afa81a2c1b6236748af5
     type: core
-    size: 15720
+    size: 16313
   - path: core/synapse/context/index.js
     hash: sha256:a67e843cf61e823e0c1b73efdb2d67d268a798fc0c25505a199c1da130d4fe36
     type: core
@@ -1277,9 +1277,9 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:ff8b68dc4924b962e87edb6ca660128caca635f62acf4edd3dd05cc5232331db
+    hash: sha256:c2b4e0dacd2225744a29db180f022519cef80db8ba9156b5d348fb0a2bd65128
     type: data
-    size: 527962
+    size: 527952
   - path: data/learned-patterns.yaml
     hash: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
     type: data

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,9 +8,9 @@
 # - File types for categorization
 #
 version: 5.1.15
-generated_at: "2026-05-08T14:35:03.596Z"
+generated_at: "2026-05-08T18:32:17.980Z"
 generator: scripts/generate-install-manifest.js
-file_count: 1117
+file_count: 1120
 files:
   - path: cli/commands/config/index.js
     hash: sha256:25c4b9bf4e0241abf7754b55153f49f1a214f1fb5fe904a576675634cb7b3da9
@@ -1096,6 +1096,18 @@ files:
     hash: sha256:5a54a15fbbbd4b6095e7e78297cb87e4a123a7c1d714a7c7916272ef6fd680f1
     type: core
     size: 9144
+  - path: core/synapse/context/hierarchical-context-manager.js
+    hash: sha256:8f10627cf01712aa4e799ca2cb01fcd6c6694e3462cd0be592561c37ff8cbd53
+    type: core
+    size: 15720
+  - path: core/synapse/context/index.js
+    hash: sha256:a67e843cf61e823e0c1b73efdb2d67d268a798fc0c25505a199c1da130d4fe36
+    type: core
+    size: 363
+  - path: core/synapse/context/README.md
+    hash: sha256:0376afd13b40d31338ecfdc327f872b2290e2f1736483b527fb1ae469f0c33dc
+    type: core
+    size: 1380
   - path: core/synapse/diagnostics/collectors/consistency-collector.js
     hash: sha256:65f4255f87c9900400649dc8b9aedaac4851b5939d93e127778bd93cee99db12
     type: core
@@ -1265,9 +1277,9 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:9f68c1c624f34243acbd1205cde7989d58aeefc71692f17ea3c92afa9e69877a
+    hash: sha256:ff8b68dc4924b962e87edb6ca660128caca635f62acf4edd3dd05cc5232331db
     type: data
-    size: 526494
+    size: 527962
   - path: data/learned-patterns.yaml
     hash: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
     type: data

--- a/docs/stories/epic-447-hierarchical-context-management/EPIC-447-HIERARCHICAL-CONTEXT-MANAGEMENT.md
+++ b/docs/stories/epic-447-hierarchical-context-management/EPIC-447-HIERARCHICAL-CONTEXT-MANAGEMENT.md
@@ -1,0 +1,65 @@
+# Epic 447: Hierarchical Context Management
+
+## Metadata
+
+| Campo | Valor |
+|-------|-------|
+| Epic ID | 447 |
+| Status | Ready |
+| Source Issue | #447 |
+| Issue URL | https://github.com/SynkraAI/aiox-core/issues/447 |
+| Repository | SynkraAI/aiox-core |
+| Priority | P3 |
+| Area | Core runtime, SYNAPSE context, memory |
+
+## Objetivo
+
+Implementar uma superfície canônica de gerenciamento hierárquico de contexto no `aiox-core`, permitindo que agentes de longa duração comprimam histórico, preservem decisões relevantes e evitem estouro de janela de contexto sem descartar silenciosamente o raciocínio anterior.
+
+## Problema
+
+Execuções longas de agentes acumulam mensagens e eventualmente atingem limites de contexto do modelo. O repositório já possui estimativa de contexto, brackets SYNAPSE e ponte de memória, mas ainda não há uma API dedicada para manter `short_term_memory` e `long_term_memory` com sumarização incremental de conversas de agente.
+
+## Code Reality
+
+- `.aiox-core/core/synapse/context/context-tracker.js` já calcula brackets, orçamento de tokens e status FRESH/MODERATE/DEPLETED/CRITICAL.
+- `.aiox-core/core/synapse/utils/tokens.js` já oferece `estimateTokens()` por heurística `chars / 4`.
+- `.aiox-core/core/synapse/memory/memory-bridge.js` já faz retrieval bracket-aware de memórias, mas é consumer-only e não gerencia histórico ativo.
+- `.aiox-core/core/orchestration/context-manager.js` já persiste estado de workflow, mas não é um gerenciador de janela de contexto de LLM.
+- Não existe hoje uma classe `HierarchicalContextManager` ou API equivalente.
+
+## Escopo
+
+- Criar API de gerenciamento hierárquico de mensagens para loops de agente.
+- Suportar tokenizer e summarizer injetáveis, com fallback para `estimateTokens()`.
+- Mover mensagens antigas para resumo de longo prazo quando um threshold configurável for atingido.
+- Preservar metadata de mensagens e emitir eventos/telemetria básica de swap.
+- Manter compatibilidade total com APIs existentes de SYNAPSE, MemoryBridge e orchestration.
+
+## Fora de Escopo
+
+- Criar banco vetorial novo.
+- Migrar todos os loops de agente existentes em massa.
+- Fazer chamada real para provedor externo nos testes.
+- Substituir `MemoryBridge` ou `SynapseMemoryProvider`.
+- Exigir uma dependência de tokenizer nova sem justificativa e testes de fallback.
+
+## Stories
+
+| Story | Título | Status | Prioridade | Ordem |
+|-------|--------|--------|------------|-------|
+| 447.1 | Hierarchical Context Manager Contract | Ready | P3 | 1 |
+
+## Ordem de Execução
+
+1. Validar `STORY-447.1-HIERARCHICAL-CONTEXT-MANAGER-CONTRACT.md` com `@po *validate-story-draft`.
+2. Implementar a API de contexto hierárquico com testes focados.
+3. Revisar integração com SYNAPSE e memory surfaces existentes antes de qualquer adoção ampla em loops de agente.
+
+## Validation Gates
+
+- `npm test -- --runTestsByPath tests/synapse/context-tracker.test.js tests/synapse/memory-bridge.test.js tests/core/orchestration/context-manager.test.js`
+- Testes novos da story para `HierarchicalContextManager`.
+- `npm run lint`
+- `npm run typecheck`
+- `npm run validate:manifest`, se arquivos de core forem adicionados ao pacote instalável.

--- a/docs/stories/epic-447-hierarchical-context-management/STORY-447.1-HIERARCHICAL-CONTEXT-MANAGER-CONTRACT.md
+++ b/docs/stories/epic-447-hierarchical-context-management/STORY-447.1-HIERARCHICAL-CONTEXT-MANAGER-CONTRACT.md
@@ -1,0 +1,205 @@
+# Story 447.1: Hierarchical Context Manager Contract
+
+## Metadata
+
+| Campo | Valor |
+|-------|-------|
+| Story ID | 447.1 |
+| Epic | [447 - Hierarchical Context Management](./EPIC-447-HIERARCHICAL-CONTEXT-MANAGEMENT.md) |
+| Status | Ready for Review |
+| Executor | @dev |
+| Quality Gate | @architect |
+| quality_gate_tools | npm test focused, npm run lint, npm run typecheck, npm run validate:manifest |
+| Points | 8 |
+| Priority | P3 |
+| Story Order | 1 |
+| Source Issue | #447 |
+| Issue URL | https://github.com/SynkraAI/aiox-core/issues/447 |
+| Implementation Repository | SynkraAI/aiox-core |
+| Start Gate | PO validation must confirm code reality and no duplication with existing SYNAPSE context modules. |
+
+## Status
+
+- [x] Draft
+- [x] PO validated
+- [x] Ready for implementation
+- [x] Ready for Review
+
+## Executor Assignment
+
+```yaml
+executor: "@dev"
+quality_gate: "@architect"
+quality_gate_tools:
+  - npm test focused
+  - npm run lint
+  - npm run typecheck
+  - npm run validate:manifest
+accountable: "pedro-valerio"
+domain: "*"
+deploy_type: "none"
+```
+
+## Community Origin
+
+**Discussion URL**: https://github.com/SynkraAI/aiox-core/issues/447
+**Author**: GitHub issue author
+**Approved Date**: 2026-03-11
+**Approved By**: AIOX triage via `status: confirmed`
+
+## Story
+
+**As a** framework maintainer,
+**I want** a hierarchical context manager that compacts long-running agent history into short-term and long-term context buffers,
+**so that** autonomous agents can keep executing without hitting model context limits or losing the semantic meaning of earlier decisions.
+
+## Contexto
+
+Issue #447 proposes a `HierarchicalContextManager` with `addMessage()` and `getContext()` APIs, threshold-based summarization and memory swapping. The current codebase already has partial context primitives, so this story must extend the existing runtime instead of creating an unrelated subsystem.
+
+Existing surfaces to reuse or preserve:
+
+- `.aiox-core/core/synapse/context/context-tracker.js` for context brackets and token budget behavior.
+- `.aiox-core/core/synapse/utils/tokens.js` for current default token estimation.
+- `.aiox-core/core/synapse/memory/memory-bridge.js` for memory hints retrieval semantics.
+- `.aiox-core/core/orchestration/context-manager.js` for workflow-state persistence only; do not confuse it with LLM context-window management.
+
+## Acceptance Criteria
+
+- [ ] AC1: A new canonical `HierarchicalContextManager` API exists under the SYNAPSE/context runtime and is exported from the appropriate module surface.
+- [ ] AC2: The API supports at minimum `addMessage(message)`, `getContext()`, `getStats()` and `clear()` without requiring a live LLM provider.
+- [ ] AC3: Configuration supports `maxTokens`, `summarizationThreshold`, injected `tokenizer`, injected `summarizer`, and a safe fallback to the existing `estimateTokens()` utility.
+- [ ] AC4: When the active context crosses the configured threshold, older messages are summarized into a long-term buffer while recent messages remain available in short-term context.
+- [ ] AC5: `getContext()` returns a context payload that stays within `maxTokens` under deterministic tests, including cases with repeated long messages.
+- [ ] AC6: Swap events are observable through a minimal event interface or callback hooks, including success and failure paths, without crashing the agent loop on summarization failure.
+- [ ] AC7: The implementation preserves message role/content/metadata shape and never silently drops unsummarized content unless the configured summarizer explicitly returns a summary.
+- [ ] AC8: The story does not alter existing `context-tracker`, `MemoryBridge`, or orchestration behavior except through additive exports or optional integration points.
+- [ ] AC9: Documentation includes a usage example matching the issue intent and explains how to inject tokenizer/summarizer dependencies.
+- [ ] AC10: Focused tests cover threshold behavior, token accounting, summary insertion, failure fallback, metadata preservation and max-token enforcement.
+
+## CodeRabbit Integration
+
+### Story Type Analysis
+
+**Primary Type**: Core runtime feature
+**Secondary Type(s)**: Architecture, memory/context management, resilience
+**Complexity**: High
+
+### Specialized Agent Assignment
+
+**Primary Agents**:
+- @dev
+- @architect
+
+**Supporting Agents**:
+- @qa
+- @po
+
+### Quality Gate Tasks
+
+- [ ] Pre-Commit (@dev): Run focused unit tests and verify no existing SYNAPSE context behavior regressed.
+- [ ] Pre-PR (@devops): Confirm additive API surface and package manifest updates if new files are exported.
+- [ ] Architecture Review (@architect): Confirm the implementation extends existing context/memory primitives instead of duplicating them.
+
+### Self-Healing Configuration
+
+- CRITICAL: report and stop for architecture/API conflicts.
+- HIGH: fix test failures inside the new manager and adjacent exports.
+- MEDIUM: fix docs and examples in the same branch.
+
+## Tasks / Subtasks
+
+- [x] T1: Confirm target module path and export surface for the new manager before implementation.
+- [x] T2: Implement `HierarchicalContextManager` with configurable tokenizer, summarizer, threshold and max-token behavior.
+- [x] T3: Add deterministic unit tests for message addition, threshold crossing, summary compaction, metadata preservation and failure fallback.
+- [x] T4: Add integration-safe tests proving existing `context-tracker` and `MemoryBridge` behavior remains unchanged.
+- [x] T5: Update docs or README with a usage example and dependency-injection guidance.
+- [x] T6: Update manifest/entity registry only if required by existing packaging gates.
+- [x] T7: Run focused tests, lint, typecheck and manifest validation.
+
+## Dev Notes
+
+- Do not introduce `js-tiktoken` as a hard dependency in the first pass unless the implementation includes fallback behavior and dependency rationale. The repo currently has `estimateTokens()` as the safe default.
+- Keep summarization injected. The manager should not import OpenAI, Anthropic, Claude, Gemini, Kimi or OpenRouter directly.
+- Treat `.aiox-core/core/orchestration/context-manager.js` as workflow-state persistence, not as the target class to overload.
+- Prefer additive exports. Existing consumers should continue working without configuration changes.
+- Issue #447 includes an external attachment, but this story should be implemented from repo contracts and issue requirements, not by blindly importing attached code.
+
+## Testing
+
+Required focused validation:
+
+```bash
+npm test -- --runTestsByPath tests/synapse/context-tracker.test.js tests/synapse/memory-bridge.test.js tests/core/orchestration/context-manager.test.js
+npm test -- --runTestsByPath tests/synapse/hierarchical-context-manager.test.js
+npm run lint
+npm run typecheck
+npm run validate:manifest
+```
+
+If `tests/synapse/hierarchical-context-manager.test.js` lands under a different path, update this section and the File List during implementation.
+
+## Dependencies
+
+- **Blocked by:** none.
+- **Blocks:** future long-running agent loop integration stories.
+- **Related:** SYNAPSE context tracker and MemoryBridge surfaces.
+
+## Definition of Ready
+
+- [x] PO validation completed with no unresolved blocker.
+- [x] Target file paths confirmed against current code reality.
+- [x] Acceptance criteria are testable without live LLM calls.
+
+## Definition of Done
+
+- [ ] All ACs complete.
+- [ ] Focused tests pass.
+- [ ] Lint and typecheck pass.
+- [ ] Manifest validation passes if new package files are added.
+- [ ] File List and Dev Agent Record are updated.
+
+## Dev Agent Record
+
+### Debug Log
+
+- Draft created from issue #447 and current repo inspection on 2026-05-08.
+- Fast-forwarded `main` from `origin/main` before implementation to include PRs #704 and #705.
+- Confirmed target implementation surface under `.aiox-core/core/synapse/context/` and additive export path through `context/index.js`.
+- Implemented deterministic `HierarchicalContextManager` without live LLM dependency; summarization and tokenization remain injected with safe fallbacks.
+- Removed full-suite generated `entity-registry.yaml` timestamp churn and kept the scoped registry update for the new SYNAPSE context modules.
+- Validation completed: focused hierarchical test suite passed, adjacent SYNAPSE/orchestration suites passed, manifest validation passed, ESLint scoped check passed, repository lint passed with pre-existing warnings only, typecheck passed and full Jest suite passed.
+- Story DoD self-assessment completed. Build command is N/A because `package.json` does not define `npm run build`. CodeRabbit PR loop is deferred until a PR exists; no local CodeRabbit script is defined in `package.json`.
+
+### Agent Model Used
+
+- GPT-5 Codex
+
+### Completion Notes
+
+- Implemented the canonical hierarchical context manager contract for Story 447.1.
+- Long-running context compaction now maintains short-term messages plus long-term summaries, emits/calls swap observability hooks and falls back safely on summarization failure.
+- Documentation includes dependency-injection usage for tokenizer and summarizer.
+- Story is ready for architecture/QA review.
+
+### File List
+
+| File | Action |
+|------|--------|
+| `docs/stories/epic-447-hierarchical-context-management/EPIC-447-HIERARCHICAL-CONTEXT-MANAGEMENT.md` | Created |
+| `docs/stories/epic-447-hierarchical-context-management/STORY-447.1-HIERARCHICAL-CONTEXT-MANAGER-CONTRACT.md` | Created |
+| `.aiox-core/core/synapse/context/hierarchical-context-manager.js` | Created |
+| `.aiox-core/core/synapse/context/index.js` | Created |
+| `.aiox-core/core/synapse/context/README.md` | Created |
+| `tests/synapse/hierarchical-context-manager.test.js` | Created |
+| `.aiox-core/install-manifest.yaml` | Updated |
+| `.aiox-core/data/entity-registry.yaml` | Updated |
+
+## Change Log
+
+| Data | Agente | Mudança |
+|------|--------|---------|
+| 2026-05-08 | @sm / Codex | Story draft criada a partir do issue #447 e da leitura das superfícies atuais de contexto/memória. |
+| 2026-05-08 | @po (Pax) | Validation auto-fix: seção de status, executor assignment, accountable, deploy_type e headings canônicos adicionados. |
+| 2026-05-08 | @po (Pax) | Validated 9.2/10 [GO with Auto-Fix]. Context: Epic 447, Wave 1. 0 stories anteriores analisadas. D10: 0 divergências, 5 ajustes. Condições: nenhuma. |
+| 2026-05-08 | @dev (Dex) | Implementado `HierarchicalContextManager`, export aditivo, documentação, testes determinísticos, manifest e registry atualizados. |

--- a/docs/stories/epic-447-hierarchical-context-management/STORY-447.1-HIERARCHICAL-CONTEXT-MANAGER-CONTRACT.md
+++ b/docs/stories/epic-447-hierarchical-context-management/STORY-447.1-HIERARCHICAL-CONTEXT-MANAGER-CONTRACT.md
@@ -170,6 +170,7 @@ If `tests/synapse/hierarchical-context-manager.test.js` lands under a different 
 - Removed full-suite generated `entity-registry.yaml` timestamp churn and kept the scoped registry update for the new SYNAPSE context modules.
 - Validation completed: focused hierarchical test suite passed, adjacent SYNAPSE/orchestration suites passed, manifest validation passed, ESLint scoped check passed, repository lint passed with pre-existing warnings only, typecheck passed and full Jest suite passed.
 - Story DoD self-assessment completed. Build command is N/A because `package.json` does not define `npm run build`. CodeRabbit PR loop is deferred until a PR exists; no local CodeRabbit script is defined in `package.json`.
+- CodeRabbit follow-up addressed on PR #706: serialized concurrent `addMessage()` mutations, collapsed long-term summaries before hard-limit truncation, strengthened event/error tests and switched the test import to the configured absolute module alias.
 
 ### Agent Model Used
 
@@ -179,6 +180,8 @@ If `tests/synapse/hierarchical-context-manager.test.js` lands under a different 
 
 - Implemented the canonical hierarchical context manager contract for Story 447.1.
 - Long-running context compaction now maintains short-term messages plus long-term summaries, emits/calls swap observability hooks and falls back safely on summarization failure.
+- Concurrent message additions are serialized through an internal mutation queue so summarization swaps cannot interleave and corrupt context state.
+- Hard-limit truncation now compacts all long-term summaries before truncating the combined result, preserving source-message lineage.
 - Documentation includes dependency-injection usage for tokenizer and summarizer.
 - Story is ready for architecture/QA review.
 
@@ -203,3 +206,4 @@ If `tests/synapse/hierarchical-context-manager.test.js` lands under a different 
 | 2026-05-08 | @po (Pax) | Validation auto-fix: seção de status, executor assignment, accountable, deploy_type e headings canônicos adicionados. |
 | 2026-05-08 | @po (Pax) | Validated 9.2/10 [GO with Auto-Fix]. Context: Epic 447, Wave 1. 0 stories anteriores analisadas. D10: 0 divergências, 5 ajustes. Condições: nenhuma. |
 | 2026-05-08 | @dev (Dex) | Implementado `HierarchicalContextManager`, export aditivo, documentação, testes determinísticos, manifest e registry atualizados. |
+| 2026-05-08 | @dev (Dex) | Ajustados apontamentos do CodeRabbit no PR #706: concorrência, preservação de summaries e assertions de eventos/erros. |

--- a/tests/synapse/hierarchical-context-manager.test.js
+++ b/tests/synapse/hierarchical-context-manager.test.js
@@ -1,7 +1,7 @@
 const {
   HierarchicalContextManager,
   buildDefaultSummary,
-} = require('../../.aiox-core/core/synapse/context');
+} = require('aiox-core/core/synapse/context');
 
 const wordTokenizer = text => String(text || '').trim().split(/\s+/).filter(Boolean).length;
 
@@ -72,8 +72,17 @@ describe('HierarchicalContextManager', () => {
 
     const context = manager.getContext();
     const stats = manager.getStats();
+    const firstCompleteEvent = completeEvents[0];
 
     expect(completeEvents.length).toBeGreaterThan(0);
+    expect(firstCompleteEvent).toMatchObject({
+      source: 'short-term',
+      messagesRemoved: 1,
+      swapCount: 1,
+    });
+    expect(firstCompleteEvent.tokensBefore).toBeGreaterThan(0);
+    expect(firstCompleteEvent.tokensAfter).toBeGreaterThan(0);
+    expect(firstCompleteEvent.summaryTokens).toBeGreaterThan(0);
     expect(stats.longTermSummaries).toBeGreaterThanOrEqual(1);
     expect(stats.totalTokens).toBeLessThanOrEqual(stats.maxTokens);
     expect(context[0].role).toBe('system');
@@ -113,8 +122,86 @@ describe('HierarchicalContextManager', () => {
     expect(contextText).toContain('summary of');
   });
 
+  test('serializes concurrent addMessage calls so swaps cannot corrupt state', async () => {
+    const manager = new HierarchicalContextManager({
+      maxTokens: 32,
+      summarizationThreshold: 0.5,
+      minRecentMessages: 0,
+      tokenizer: wordTokenizer,
+      summarizer: async ({ messages }) => {
+        await new Promise(resolve => setTimeout(resolve, 5));
+        return `summary for ${messages.map(message => message.id).join(',')}`;
+      },
+    });
+
+    await Promise.all(
+      Array.from({ length: 6 }, (_, index) => manager.addMessage({
+        id: `m${index + 1}`,
+        role: index % 2 === 0 ? 'user' : 'assistant',
+        content: 'one two three four five six seven eight',
+      })),
+    );
+
+    const context = manager.getContext();
+    const contextIds = context
+      .flatMap(message => [
+        message.id,
+        ...(message.metadata?.aiox?.sourceMessages || []).map(source => source.id),
+      ])
+      .filter(Boolean);
+
+    expect(new Set(contextIds).size).toBe(contextIds.length);
+    expect(contextIds).toEqual(expect.arrayContaining(['m1', 'm2', 'm3', 'm4', 'm5', 'm6']));
+    expect(manager.getStats().totalTokens).toBeLessThanOrEqual(manager.getStats().maxTokens);
+  });
+
+  test('collapses all long-term summaries before hard-limit truncation', async () => {
+    const manager = new HierarchicalContextManager({
+      maxTokens: 14,
+      summarizationThreshold: 0.75,
+      tokenizer: wordTokenizer,
+      summarizer: async ({ messages }) => `combined ${messages
+        .flatMap(message => message.metadata?.aiox?.sourceMessages || [])
+        .map(source => source.id)
+        .join(' ')}`,
+    });
+
+    manager._longTermSummaries = [
+      {
+        role: 'system',
+        content: 'first summary one two three four five six',
+        metadata: {
+          aiox: {
+            sourceMessages: [{ id: 'm1' }, { id: 'm2' }],
+          },
+        },
+      },
+      {
+        role: 'system',
+        content: 'second summary seven eight nine ten eleven twelve',
+        metadata: {
+          aiox: {
+            sourceMessages: [{ id: 'm3' }, { id: 'm4' }],
+          },
+        },
+      },
+    ];
+
+    await manager._fitLongTermSummariesToBudget();
+
+    expect(manager._longTermSummaries).toHaveLength(1);
+    expect(manager._longTermSummaries[0].metadata.aiox.sourceMessages).toEqual([
+      { id: 'm1' },
+      { id: 'm2' },
+      { id: 'm3' },
+      { id: 'm4' },
+    ]);
+    expect(manager.getStats().totalTokens).toBeLessThanOrEqual(manager.getStats().maxTokens);
+  });
+
   test('emits swap:error and falls back to deterministic summary when summarizer fails', async () => {
-    const errorEvents = [];
+    const callbackEvents = [];
+    const emitterEvents = [];
     const manager = new HierarchicalContextManager({
       maxTokens: 30,
       summarizationThreshold: 0.5,
@@ -122,10 +209,10 @@ describe('HierarchicalContextManager', () => {
       summarizer: async () => {
         throw new Error('summarizer unavailable');
       },
-      onSwapError: event => errorEvents.push(event),
+      onSwapError: event => callbackEvents.push(event),
     });
 
-    manager.on('swap:error', event => errorEvents.push(event));
+    manager.on('swap:error', event => emitterEvents.push(event));
 
     await manager.addMessages([
       { role: 'user', content: 'one two three four five six seven eight nine ten eleven' },
@@ -134,7 +221,10 @@ describe('HierarchicalContextManager', () => {
 
     const context = manager.getContext();
 
-    expect(errorEvents.length).toBeGreaterThan(0);
+    expect(callbackEvents).toHaveLength(1);
+    expect(emitterEvents).toHaveLength(1);
+    expect(callbackEvents[0]).toMatchObject({ source: 'short-term' });
+    expect(emitterEvents[0]).toMatchObject({ source: 'short-term' });
     expect(manager.getStats().lastError).toEqual({ message: 'summarizer unavailable' });
     expect(context[0].content).toContain('Long-term context summary');
     expect(context[0].metadata.aiox.fallbackUsed).toBe(true);

--- a/tests/synapse/hierarchical-context-manager.test.js
+++ b/tests/synapse/hierarchical-context-manager.test.js
@@ -1,0 +1,153 @@
+const {
+  HierarchicalContextManager,
+  buildDefaultSummary,
+} = require('../../.aiox-core/core/synapse/context');
+
+const wordTokenizer = text => String(text || '').trim().split(/\s+/).filter(Boolean).length;
+
+describe('HierarchicalContextManager', () => {
+  test('exports the manager from the SYNAPSE context surface', () => {
+    expect(HierarchicalContextManager).toBeDefined();
+    expect(typeof HierarchicalContextManager).toBe('function');
+  });
+
+  test('supports addMessage, getContext, getStats and clear without a live LLM provider', async () => {
+    const manager = new HierarchicalContextManager({
+      maxTokens: 100,
+      summarizationThreshold: 0.75,
+      tokenizer: wordTokenizer,
+    });
+
+    await manager.addMessage({ role: 'user', content: 'short request', metadata: { traceId: 'm1' } });
+
+    expect(manager.getContext()).toEqual([
+      { role: 'user', content: 'short request', metadata: { traceId: 'm1' } },
+    ]);
+    expect(manager.getStats()).toMatchObject({
+      maxTokens: 100,
+      shortTermMessages: 1,
+      longTermSummaries: 0,
+      swapCount: 0,
+    });
+
+    manager.clear();
+
+    expect(manager.getContext()).toEqual([]);
+    expect(manager.getStats()).toMatchObject({
+      shortTermMessages: 0,
+      longTermSummaries: 0,
+      swapCount: 0,
+    });
+  });
+
+  test('compacts older messages when threshold is crossed and preserves recent metadata', async () => {
+    const completeEvents = [];
+    const manager = new HierarchicalContextManager({
+      maxTokens: 40,
+      summarizationThreshold: 0.5,
+      tokenizer: wordTokenizer,
+    });
+    manager.on('swap:complete', event => completeEvents.push(event));
+
+    await manager.addMessages([
+      {
+        id: 'm1',
+        role: 'user',
+        content: 'alpha beta gamma delta epsilon zeta eta theta iota kappa',
+        metadata: { decision: 'keep rationale' },
+      },
+      {
+        id: 'm2',
+        role: 'assistant',
+        content: 'lambda mu nu xi omicron pi rho sigma tau upsilon',
+        metadata: { result: 'draft' },
+      },
+      {
+        id: 'm3',
+        role: 'user',
+        content: 'phi chi psi omega',
+        metadata: { current: true },
+      },
+    ]);
+
+    const context = manager.getContext();
+    const stats = manager.getStats();
+
+    expect(completeEvents.length).toBeGreaterThan(0);
+    expect(stats.longTermSummaries).toBeGreaterThanOrEqual(1);
+    expect(stats.totalTokens).toBeLessThanOrEqual(stats.maxTokens);
+    expect(context[0].role).toBe('system');
+    expect(context[0].metadata.aiox.type).toBe('hierarchical_context_summary');
+    expect(context[0].metadata.aiox.sourceMessages[0]).toEqual({
+      role: 'user',
+      id: 'm1',
+      metadata: { decision: 'keep rationale' },
+    });
+    expect(context[context.length - 1]).toMatchObject({
+      role: 'user',
+      content: 'phi chi psi omega',
+      metadata: { current: true },
+    });
+  });
+
+  test('uses injected summarizer and keeps context under maxTokens for repeated long messages', async () => {
+    const manager = new HierarchicalContextManager({
+      maxTokens: 24,
+      summarizationThreshold: 0.75,
+      tokenizer: wordTokenizer,
+      summarizer: async ({ messages }) => `summary of ${messages.length} message(s)`,
+    });
+
+    for (let index = 0; index < 8; index += 1) {
+      await manager.addMessage({
+        role: index % 2 === 0 ? 'user' : 'assistant',
+        content: 'one two three four five six seven eight nine ten',
+      });
+    }
+
+    const stats = manager.getStats();
+    const contextText = manager.getContext().map(message => message.content).join('\n');
+
+    expect(stats.totalTokens).toBeLessThanOrEqual(stats.maxTokens);
+    expect(stats.swapCount).toBeGreaterThan(0);
+    expect(contextText).toContain('summary of');
+  });
+
+  test('emits swap:error and falls back to deterministic summary when summarizer fails', async () => {
+    const errorEvents = [];
+    const manager = new HierarchicalContextManager({
+      maxTokens: 30,
+      summarizationThreshold: 0.5,
+      tokenizer: wordTokenizer,
+      summarizer: async () => {
+        throw new Error('summarizer unavailable');
+      },
+      onSwapError: event => errorEvents.push(event),
+    });
+
+    manager.on('swap:error', event => errorEvents.push(event));
+
+    await manager.addMessages([
+      { role: 'user', content: 'one two three four five six seven eight nine ten eleven' },
+      { role: 'assistant', content: 'twelve thirteen fourteen fifteen sixteen seventeen' },
+    ]);
+
+    const context = manager.getContext();
+
+    expect(errorEvents.length).toBeGreaterThan(0);
+    expect(manager.getStats().lastError).toEqual({ message: 'summarizer unavailable' });
+    expect(context[0].content).toContain('Long-term context summary');
+    expect(context[0].metadata.aiox.fallbackUsed).toBe(true);
+  });
+
+  test('default summary includes role and content excerpts', () => {
+    const summary = buildDefaultSummary([
+      { role: 'user', content: 'please remember the first decision' },
+      { role: 'assistant', content: 'the decision was stored' },
+    ]);
+
+    expect(summary).toContain('2 message(s) compacted');
+    expect(summary).toContain('user');
+    expect(summary).toContain('assistant');
+  });
+});


### PR DESCRIPTION
## Summary
- add the hierarchical context manager implementation under `.aiox-core/core/synapse/context/`
- export and document the new context surface, including Story 447 contract and epic artifacts
- update the related manifest and registry surfaces required by the hierarchical context flow
- add focused Jest coverage for hierarchical context manager behavior

## Validation
- focused hierarchical tests pass
- adjacent context/memory/orchestration tests pass
- scoped eslint pass
- lint pass with pre-existing warnings
- typecheck pass
- validate:manifest pass
- full Jest suite pass: 338 suites / 8407 tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced HierarchicalContextManager to maintain LLM-ready context within configurable token budgets by compacting older messages into hierarchical summaries and emitting swap events.

* **Documentation**
  * Added SYNAPSE Context Runtime README and Epic/Story docs describing hierarchical context behavior, configuration, and acceptance criteria.

* **Tests**
  * Added comprehensive tests validating compaction, token-budget enforcement, event/error handling, fallback summarization, and concurrency.

* **Chores**
  * Updated registry and install manifest to include the new context runtime components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->