### PR TITLE
fix(release): use AIOX npm token for semantic release

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Verify NPM authentication
         run: npm whoami
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_AIOX_SQUADS }}
 
       - name: Pre-flight Tag Validation
         id: preflight
@@ -138,8 +138,8 @@ jobs:
         if: inputs.dry_run != true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN_AIOX_SQUADS }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_AIOX_SQUADS }}
         run: |
           echo "🔍 Running dry-run to preview release..."
           echo ""
@@ -163,8 +163,8 @@ jobs:
       - name: Run Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN_AIOX_SQUADS }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_AIOX_SQUADS }}
         run: |
           if [ "${{ inputs.dry_run }}" == "true" ]; then
             npx semantic-release --dry-run


### PR DESCRIPTION
## Summary
- use the same NPM_TOKEN_AIOX_SQUADS secret in semantic-release that npm-publish already uses
- unblocks semantic-release dry-run before real publication

## Validation
- git diff --check
- GitHub semantic-release dry-run failed before this change at npm whoami with secrets.NPM_TOKEN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication configuration for the automated release pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->