### PR TITLE
docs: draft Epic 184 Kimi provider plan

### DIFF
--- a/docs/stories/epic-184-kimi-provider/EPIC-184-KIMI-K2-5-PROVIDER.md
+++ b/docs/stories/epic-184-kimi-provider/EPIC-184-KIMI-K2-5-PROVIDER.md
@@ -23,7 +23,7 @@ Adicionar suporte nativo e backward-compatible para Kimi K2.5 da Moonshot AI com
 - `ClaudeProvider` e `GeminiProvider` são wrappers de CLI; Kimi K2.5 deve ser HTTP/OpenAI-compatible, não wrapper de CLI.
 - `docs/guides/llm-routing.md` já cobre roteamento Claude Code para DeepSeek via endpoint Anthropic-compatible, mas isso é diferente de provider nativo no factory de `AIProvider`.
 - Existe uma worktree antiga `feat/kimi-ide-integration-20260507`, porém seu escopo é Kimi como target de IDE sync (`.kimi/skills` e transformer), não o provider LLM solicitado no issue #184.
-- A documentação oficial da Kimi API declara compatibilidade com o formato OpenAI e usa `https://api.moonshot.ai/v1` como `base_url`; o endpoint de chat é `/v1/chat/completions`.
+- A documentação oficial da Kimi API declara compatibilidade com o formato OpenAI e usa `https://api.moonshot.ai/v1` como `base_url`; com esse `base_url`, o endpoint relativo de chat é `/chat/completions`.
 
 ## Escopo
 

--- a/docs/stories/epic-184-kimi-provider/EPIC-184-KIMI-K2-5-PROVIDER.md
+++ b/docs/stories/epic-184-kimi-provider/EPIC-184-KIMI-K2-5-PROVIDER.md
@@ -1,0 +1,78 @@
+# Epic 184: Kimi K2.5 Provider Support
+
+## Metadata
+
+| Campo | Valor |
+|-------|-------|
+| Epic ID | 184 |
+| Status | Draft |
+| Source Issue | #184 |
+| Issue URL | https://github.com/SynkraAI/aiox-core/issues/184 |
+| Repository | SynkraAI/aiox-core |
+| Priority | P4 |
+| Area | Core runtime, AI providers, LLM routing |
+
+## Objetivo
+
+Adicionar suporte nativo e backward-compatible para Kimi K2.5 da Moonshot AI como provider OpenAI-compatible no `aiox-core`, permitindo uso via Moonshot API ou endpoints compatíveis sem quebrar os providers existentes `claude` e `gemini`.
+
+## Code Reality
+
+- `.aiox-core/infrastructure/integrations/ai-providers/ai-provider.js` define a interface base `AIProvider` para execução, retry, status e metadata.
+- `.aiox-core/infrastructure/integrations/ai-providers/ai-provider-factory.js` registra apenas `claude` e `gemini`, carrega `.aiox-ai-config.yaml`, mantém cache de providers e possui listas hardcoded em `getAvailableProviders()` e `getProvidersStatus()`.
+- `ClaudeProvider` e `GeminiProvider` são wrappers de CLI; Kimi K2.5 deve ser HTTP/OpenAI-compatible, não wrapper de CLI.
+- `docs/guides/llm-routing.md` já cobre roteamento Claude Code para DeepSeek via endpoint Anthropic-compatible, mas isso é diferente de provider nativo no factory de `AIProvider`.
+- Existe uma worktree antiga `feat/kimi-ide-integration-20260507`, porém seu escopo é Kimi como target de IDE sync (`.kimi/skills` e transformer), não o provider LLM solicitado no issue #184.
+- A documentação oficial da Kimi API declara compatibilidade com o formato OpenAI e usa `https://api.moonshot.ai/v1` como `base_url`; o endpoint de chat é `/v1/chat/completions`.
+
+## Escopo
+
+- Criar um provider HTTP genérico `OpenAICompatibleProvider` reaproveitável para Kimi e outros endpoints compatíveis.
+- Registrar aliases `openai-compatible` e `kimi` no factory, com preset seguro para Moonshot/Kimi.
+- Permitir configuração por `.aiox-ai-config.yaml` e variáveis de ambiente, sem registrar segredos em logs ou docs.
+- Garantir que `claude` e `gemini` continuem sendo o default e o fallback atuais.
+- Documentar uso de Kimi K2.5 e OpenRouter/Moonshot como configuração, não como dependência obrigatória.
+
+## Fora de Escopo
+
+- Fazer chamadas reais para Moonshot, OpenRouter ou qualquer provider externo nos testes.
+- Migrar toda a estratégia de LLM routing do Claude Code.
+- Incorporar ou mergear a branch de Kimi IDE sync nesta story.
+- Prometer tool calling perfeito para todos os endpoints OpenAI-compatible sem testes de contrato por provider.
+- Armazenar API keys no repositório.
+
+## Stories
+
+| Story | Título | Status | Prioridade | Ordem |
+|-------|--------|--------|------------|-------|
+| 184.1 | OpenAI-Compatible Kimi Provider Contract | Draft | P4 | 1 |
+
+## Ordem de Execução
+
+### Sequencial
+
+1. Validar `STORY-184.1-OPENAI-COMPATIBLE-KIMI-PROVIDER.md` com PO/architect para confirmar que o escopo é provider LLM, não IDE sync.
+2. Implementar `OpenAICompatibleProvider` com testes unitários sem rede.
+3. Registrar aliases `openai-compatible` e `kimi` no provider factory e remover hardcodes de listas onde necessário.
+4. Atualizar docs e exemplos de `.aiox-ai-config.yaml`.
+5. Rodar validações focadas e publicar PR.
+
+### Paralelizável
+
+- Documentação de uso pode ser preparada em paralelo aos testes depois que o contrato de configuração estiver definido.
+- Expansão futura para a branch de Kimi IDE sync deve rodar em outro ciclo, depois do provider LLM estar validado.
+
+## Validation Gates
+
+- `npm test -- --runTestsByPath tests/infrastructure/ai-providers/ai-provider-factory.test.js`
+- Novo teste focado para `OpenAICompatibleProvider`, com `fetch` mockado e sem chamadas de rede.
+- `npm run lint`
+- `npm run typecheck`
+- `npm run validate:manifest`, se novos arquivos entrarem no pacote instalável.
+
+## Referências
+
+- Issue #184: https://github.com/SynkraAI/aiox-core/issues/184
+- Kimi API overview: https://platform.kimi.ai/docs/api/overview
+- Kimi chat completions endpoint: https://platform.kimi.ai/docs/api/chat
+- Kimi K2.5 quickstart: https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart

--- a/docs/stories/epic-184-kimi-provider/STORY-184.1-OPENAI-COMPATIBLE-KIMI-PROVIDER.md
+++ b/docs/stories/epic-184-kimi-provider/STORY-184.1-OPENAI-COMPATIBLE-KIMI-PROVIDER.md
@@ -61,7 +61,7 @@ Issue #184 asks for native Kimi K2.5 support as an alternative to OpenAI or Clau
 Official Kimi documentation confirms the API is OpenAI-compatible and uses:
 
 - `base_url`: `https://api.moonshot.ai/v1`
-- chat completions endpoint: `/v1/chat/completions`
+- chat completions endpoint relative to that base URL: `/chat/completions`
 
 The correct implementation path is a reusable `OpenAICompatibleProvider` plus a Kimi preset/alias. A Kimi-specific hardcoded provider would solve less and create avoidable duplication.
 
@@ -120,7 +120,7 @@ The correct implementation path is a reusable `OpenAICompatibleProvider` plus a 
 - Prefer `apiKeyEnv` defaults such as `MOONSHOT_API_KEY` for Kimi and allow explicit override.
 - Treat `baseURL` and `baseUrl` as equivalent input names for compatibility with common OpenAI-style config.
 - Preserve current default provider behavior: `primary: claude`, `fallback: gemini`.
-- The stale branch `/private/tmp/aiox-core-kimi` is scoped to IDE sync and should not be replayed into this story without a separate decision.
+- The stale `aiox-core-kimi` branch/worktree is scoped to IDE sync and should not be replayed into this story without a separate decision.
 
 ## Testing
 
@@ -163,9 +163,9 @@ If the provider test lands under a different path, update this section and the F
 
 - Draft created from issue #184 and current repo inspection on 2026-05-08.
 - Confirmed no open PR currently targets Kimi/Moonshot/provider support.
-- Identified stale worktree `/private/tmp/aiox-core-kimi` as IDE sync scope, not provider LLM scope.
+- Identified stale `aiox-core-kimi` branch/worktree as IDE sync scope, not provider LLM scope.
 - Confirmed current provider factory registers `claude` and `gemini` only.
-- Verified current Kimi API docs: OpenAI-compatible base URL is `https://api.moonshot.ai/v1`, chat completions endpoint is `/v1/chat/completions`.
+- Verified current Kimi API docs: OpenAI-compatible base URL is `https://api.moonshot.ai/v1`, and the chat completions endpoint relative to that base URL is `/chat/completions`.
 
 ### Agent Model Used
 

--- a/docs/stories/epic-184-kimi-provider/STORY-184.1-OPENAI-COMPATIBLE-KIMI-PROVIDER.md
+++ b/docs/stories/epic-184-kimi-provider/STORY-184.1-OPENAI-COMPATIBLE-KIMI-PROVIDER.md
@@ -1,0 +1,189 @@
+# Story 184.1: OpenAI-Compatible Kimi Provider Contract
+
+## Metadata
+
+| Campo | Valor |
+|-------|-------|
+| Story ID | 184.1 |
+| Epic | [184 - Kimi K2.5 Provider Support](./EPIC-184-KIMI-K2-5-PROVIDER.md) |
+| Status | Draft |
+| Executor | @dev |
+| Quality Gate | @architect |
+| quality_gate_tools | npm test focused, npm run lint, npm run typecheck, npm run validate:manifest |
+| Points | 8 |
+| Priority | P4 |
+| Story Order | 1 |
+| Source Issue | #184 |
+| Issue URL | https://github.com/SynkraAI/aiox-core/issues/184 |
+| Implementation Repository | SynkraAI/aiox-core |
+| Start Gate | PO/architect validation must confirm provider scope and no overlap with Kimi IDE sync work. |
+
+## Status
+
+- [x] Draft
+- [ ] PO validated
+- [ ] Ready for implementation
+- [ ] Ready for Review
+- [ ] Done
+
+## Executor Assignment
+
+```yaml
+executor: "@dev"
+quality_gate: "@architect"
+quality_gate_tools:
+  - npm test focused
+  - npm run lint
+  - npm run typecheck
+  - npm run validate:manifest
+accountable: "pedro-valerio"
+domain: "*"
+deploy_type: "none"
+```
+
+## Community Origin
+
+**Discussion URL**: https://github.com/SynkraAI/aiox-core/issues/184
+**Author**: GitHub issue author
+**Approved Date**: 2026-03-11
+**Approved By**: AIOX triage via `status: confirmed`
+
+## Story
+
+**As a** framework maintainer,
+**I want** Kimi K2.5 to be available through a generic OpenAI-compatible provider in the AIOX provider factory,
+**so that** agents can use Moonshot/OpenRouter-compatible model endpoints without replacing the existing Claude/Gemini provider contract.
+
+## Contexto
+
+Issue #184 asks for native Kimi K2.5 support as an alternative to OpenAI or Claude. The current implementation already has an `AIProvider` base class, `ClaudeProvider`, `GeminiProvider` and a factory that loads `.aiox-ai-config.yaml`, but the factory only knows `claude` and `gemini`.
+
+Official Kimi documentation confirms the API is OpenAI-compatible and uses:
+
+- `base_url`: `https://api.moonshot.ai/v1`
+- chat completions endpoint: `/v1/chat/completions`
+
+The correct implementation path is a reusable `OpenAICompatibleProvider` plus a Kimi preset/alias. A Kimi-specific hardcoded provider would solve less and create avoidable duplication.
+
+## Acceptance Criteria
+
+- [ ] AC1: A new `OpenAICompatibleProvider` exists under `.aiox-core/infrastructure/integrations/ai-providers/` and extends the existing `AIProvider` contract.
+- [ ] AC2: The provider supports `baseURL`/`baseUrl`, `apiKey`, `apiKeyEnv`, `model`, `timeout`, optional default headers and Chat Completions-compatible request payloads.
+- [ ] AC3: The provider never logs raw API keys and returns the existing `AIResponse` shape with provider/model/duration metadata.
+- [ ] AC4: `ai-provider-factory.js` registers `openai-compatible` and `kimi` aliases without changing the default `claude` primary and `gemini` fallback.
+- [ ] AC5: Kimi default config uses Moonshot's OpenAI-compatible base URL and a Kimi K2.5 model identifier only as a configurable preset, not as a hard dependency.
+- [ ] AC6: `getAvailableProviders()` and `getProvidersStatus()` include configured providers without hardcoding only `claude` and `gemini`.
+- [ ] AC7: Tests mock HTTP/fetch and cover success, API error, missing key, timeout or network failure, JSON response parsing and factory alias registration.
+- [ ] AC8: Documentation shows `.aiox-ai-config.yaml` examples for Moonshot/Kimi and OpenRouter-style overrides without committing secrets.
+- [ ] AC9: Existing Claude/Gemini provider tests continue to pass unchanged in behavior.
+- [ ] AC10: The story does not merge or depend on the stale Kimi IDE sync worktree; IDE sync can become a separate future story if still desired.
+
+## CodeRabbit Integration
+
+### Story Type Analysis
+
+**Primary Type**: Core runtime feature
+**Secondary Type(s)**: Provider abstraction, configuration, documentation
+**Complexity**: Medium-high
+
+### Specialized Agent Assignment
+
+**Primary Agents**:
+- @dev
+- @architect
+
+**Supporting Agents**:
+- @qa
+- @po
+- @devops
+
+### Quality Gate Tasks
+
+- [ ] Pre-Commit (@dev): Run provider factory tests and the new OpenAI-compatible provider tests.
+- [ ] Pre-PR (@devops): Confirm no secrets are committed and manifest updates match package files.
+- [ ] Architecture Review (@architect): Confirm the design is generic OpenAI-compatible provider plus Kimi preset, not a one-off Kimi-only fork.
+
+## Tasks / Subtasks
+
+- [ ] T1: Confirm exact provider file paths and exports from current `ai-providers` module.
+- [ ] T2: Implement `OpenAICompatibleProvider` using native fetch or an existing local HTTP primitive, with graceful fallback for unsupported runtimes if needed.
+- [ ] T3: Add `kimi` and `openai-compatible` factory registration, config merging and provider status discovery.
+- [ ] T4: Add deterministic tests with mocked HTTP responses and no external network calls.
+- [ ] T5: Update docs with Kimi/Moonshot and OpenRouter configuration examples.
+- [ ] T6: Update manifest/entity registry only if required by existing packaging gates.
+- [ ] T7: Run focused tests, lint, typecheck and manifest validation.
+
+## Dev Notes
+
+- Do not add a live Moonshot/OpenRouter integration test in CI.
+- Do not introduce a new SDK dependency unless native fetch is insufficient and the dependency is justified in the PR.
+- Prefer `apiKeyEnv` defaults such as `MOONSHOT_API_KEY` for Kimi and allow explicit override.
+- Treat `baseURL` and `baseUrl` as equivalent input names for compatibility with common OpenAI-style config.
+- Preserve current default provider behavior: `primary: claude`, `fallback: gemini`.
+- The stale branch `/private/tmp/aiox-core-kimi` is scoped to IDE sync and should not be replayed into this story without a separate decision.
+
+## Testing
+
+Required focused validation:
+
+```bash
+npm test -- --runTestsByPath tests/infrastructure/ai-providers/ai-provider-factory.test.js
+npm test -- --runTestsByPath tests/infrastructure/ai-providers/openai-compatible-provider.test.js
+npm run lint
+npm run typecheck
+npm run validate:manifest
+```
+
+If the provider test lands under a different path, update this section and the File List during implementation.
+
+## Dependencies
+
+- **Blocked by:** PO/architect validation of this draft.
+- **Blocks:** issue #184 closure.
+- **Related:** issue #137; existing LLM routing docs; Kimi IDE sync branch is adjacent but not in scope.
+
+## Definition of Ready
+
+- [ ] PO validation completed with no unresolved blocker.
+- [x] Target provider surfaces confirmed against current code reality.
+- [x] Acceptance criteria are testable without live API calls.
+
+## Definition of Done
+
+- [ ] All ACs complete.
+- [ ] Focused tests pass.
+- [ ] Lint and typecheck pass.
+- [ ] Manifest validation passes if package files are added.
+- [ ] File List and Dev Agent Record are updated.
+- [ ] Issue #184 has implementation evidence and can be closed or explicitly moved to follow-up scope.
+
+## Dev Agent Record
+
+### Debug Log
+
+- Draft created from issue #184 and current repo inspection on 2026-05-08.
+- Confirmed no open PR currently targets Kimi/Moonshot/provider support.
+- Identified stale worktree `/private/tmp/aiox-core-kimi` as IDE sync scope, not provider LLM scope.
+- Confirmed current provider factory registers `claude` and `gemini` only.
+- Verified current Kimi API docs: OpenAI-compatible base URL is `https://api.moonshot.ai/v1`, chat completions endpoint is `/v1/chat/completions`.
+
+### Agent Model Used
+
+- GPT-5 Codex
+
+### Completion Notes
+
+- Draft only. No runtime implementation has been made in this story yet.
+
+### File List
+
+| File | Action |
+|------|--------|
+| `docs/stories/epic-184-kimi-provider/EPIC-184-KIMI-K2-5-PROVIDER.md` | Created |
+| `docs/stories/epic-184-kimi-provider/STORY-184.1-OPENAI-COMPATIBLE-KIMI-PROVIDER.md` | Created |
+
+## Change Log
+
+| Data | Agente | Mudança |
+|------|--------|---------|
+| 2026-05-08 | @sm / Codex | Epic/story draft criados a partir do issue #184, leitura do provider factory atual e documentação oficial Kimi API. |


### PR DESCRIPTION
## Summary\n- adds Epic 184 planning artifact for Kimi K2.5 provider support\n- adds Story 184.1 draft for a generic OpenAI-compatible provider plus Kimi preset\n- records current code reality: provider factory supports Claude/Gemini only, stale Kimi worktree is IDE sync scope\n\n## Validation\n- NODE_PATH=/Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules node scripts/validate-manifest.js\n- NODE_PATH=/Users/rafaelcosta/Projects/AIOX/aiox-core/node_modules node .aiox-core/utils/aiox-validator.js stories\n- git diff --check\n\nDoes not close #184. This PR only publishes the draft plan/story for validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive epic-level docs for planned Moonshot Kimi K2.5 provider as an OpenAI-compatible LLM option.
  * Added a story outlining acceptance criteria, configuration expectations, discovery/status behavior, testing guidance (mocked HTTP tests), and developer tasks/validation gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->