### PR TITLE
feat: add Kimi OpenAI-compatible provider

### DIFF
--- a/.aiox-core/core/execution/subagent-dispatcher.js
+++ b/.aiox-core/core/execution/subagent-dispatcher.js
@@ -322,6 +322,37 @@ class SubagentDispatcher extends EventEmitter {
   }
 
   /**
+   * Resolve fallback provider from configuration before using the legacy pair.
+   * @param {string} providerName - Current provider name
+   * @returns {string|null} Fallback provider name
+   */
+  getFallbackProviderName(providerName) {
+    if (AIProviderFactory?.getConfig) {
+      const config = AIProviderFactory.getConfig();
+      const configuredFallback = config.ai_providers?.fallback;
+      const configuredPrimary = config.ai_providers?.primary;
+
+      if (configuredFallback && configuredFallback !== providerName) {
+        return configuredFallback;
+      }
+
+      if (configuredPrimary && configuredPrimary !== providerName) {
+        return configuredPrimary;
+      }
+    }
+
+    if (providerName === 'claude') {
+      return 'gemini';
+    }
+
+    if (providerName === 'gemini') {
+      return 'claude';
+    }
+
+    return null;
+  }
+
+  /**
    * Enrich context with memory and gotchas
    * @param {Object} task - Task being dispatched
    * @param {Object} context - Base context
@@ -432,8 +463,6 @@ class SubagentDispatcher extends EventEmitter {
    * @returns {Promise<Object>} - Execution result
    */
   async executeWithProvider(prompt, providerName, task) {
-    const startTime = Date.now();
-
     // Get primary provider
     const provider = this.getAIProvider(providerName);
 
@@ -450,8 +479,8 @@ class SubagentDispatcher extends EventEmitter {
       this.log('provider_not_available', { provider: providerName });
 
       // Try fallback provider
-      const fallbackName = providerName === 'claude' ? 'gemini' : 'claude';
-      const fallback = this.getAIProvider(fallbackName);
+      const fallbackName = this.getFallbackProviderName(providerName);
+      const fallback = fallbackName ? this.getAIProvider(fallbackName) : null;
 
       if (fallback && (await fallback.checkAvailability())) {
         this.log('using_fallback_provider', { original: providerName, fallback: fallbackName });
@@ -563,10 +592,10 @@ class SubagentDispatcher extends EventEmitter {
    * Select result from parallel execution based on mode
    * @param {Object|null} claudeResult - Claude result
    * @param {Object|null} geminiResult - Gemini result
-   * @param {Object} task - Original task
+   * @param {Object} _task - Original task
    * @returns {Object} - Selected result
    */
-  selectParallelResult(claudeResult, geminiResult, task) {
+  selectParallelResult(claudeResult, geminiResult, _task) {
     switch (this.parallelMode) {
       case 'race':
         // Return first successful result
@@ -698,7 +727,11 @@ class SubagentDispatcher extends EventEmitter {
 
       child.on('error', rejectOnce);
 
-      if (!child.stdin || typeof child.stdin.write !== 'function' || typeof child.stdin.end !== 'function') {
+      if (
+        !child.stdin ||
+        typeof child.stdin.write !== 'function' ||
+        typeof child.stdin.end !== 'function'
+      ) {
         rejectOnce(new Error('Claude CLI stdin is not available'));
         return;
       }

--- a/.aiox-core/infrastructure/integrations/ai-providers/README.md
+++ b/.aiox-core/infrastructure/integrations/ai-providers/README.md
@@ -1,6 +1,6 @@
 # AI Providers
 
-Multi-provider AI integration for AIOX. Supports Claude Code and Gemini CLI with automatic fallback and task-based routing.
+Multi-provider AI integration for AIOX. Supports Claude Code, Gemini CLI and OpenAI-compatible HTTP APIs with automatic fallback and task-based routing.
 
 ## Architecture
 
@@ -9,6 +9,7 @@ ai-providers/
 ├── ai-provider.js           # Base abstract class
 ├── claude-provider.js       # Claude Code implementation
 ├── gemini-provider.js       # Gemini CLI implementation
+├── openai-compatible-provider.js # OpenAI-compatible HTTP implementation
 ├── ai-provider-factory.js   # Factory with routing and fallback
 └── index.js                 # Module exports
 ```
@@ -35,13 +36,13 @@ const { getProviderForTask } = require('./ai-providers');
 
 // Get optimal provider for task type
 const provider = getProviderForTask('code_generation'); // Returns Gemini (faster)
-const provider = getProviderForTask('security');        // Returns Claude (deeper reasoning)
+const provider = getProviderForTask('security'); // Returns Claude (deeper reasoning)
 ```
 
 ### Direct Provider Access
 
 ```javascript
-const { ClaudeProvider, GeminiProvider } = require('./ai-providers');
+const { ClaudeProvider, GeminiProvider, OpenAICompatibleProvider } = require('./ai-providers');
 
 // Claude
 const claude = new ClaudeProvider({ model: 'claude-3-5-sonnet' });
@@ -50,6 +51,15 @@ const response = await claude.execute('Explain this function');
 // Gemini with JSON output
 const gemini = new GeminiProvider({ jsonOutput: true });
 const response = await gemini.executeJson('List 5 best practices');
+
+// Kimi/Moonshot through the OpenAI-compatible contract
+const kimi = new OpenAICompatibleProvider({
+  name: 'kimi',
+  baseURL: 'https://api.moonshot.ai/v1',
+  apiKeyEnv: 'MOONSHOT_API_KEY',
+  model: 'kimi-k2.5',
+});
+const response = await kimi.execute('Explain this function');
 ```
 
 ### Check Provider Status
@@ -84,16 +94,23 @@ claude:
 gemini:
   model: gemini-2.0-flash
   previewFeatures: true
+
+kimi:
+  provider: openai-compatible
+  baseURL: https://api.moonshot.ai/v1
+  endpoint: /chat/completions
+  apiKeyEnv: MOONSHOT_API_KEY
+  model: kimi-k2.5
 ```
 
 ## Provider Comparison
 
-| Feature | Claude | Gemini |
-|---------|--------|--------|
-| Best for | Complex reasoning, security | Speed, cost efficiency |
-| JSON output | Manual parsing | Native `--output-format json` |
-| Cost | Higher | ~4x cheaper (Flash) |
-| SWE-bench | ~70% | 78% (Flash) |
+| Feature     | Claude                      | Gemini                        |
+| ----------- | --------------------------- | ----------------------------- |
+| Best for    | Complex reasoning, security | Speed, cost efficiency        |
+| JSON output | Manual parsing              | Native `--output-format json` |
+| Cost        | Higher                      | ~4x cheaper (Flash)           |
+| SWE-bench   | ~70%                        | 78% (Flash)                   |
 
 ## Epic Reference
 

--- a/.aiox-core/infrastructure/integrations/ai-providers/ai-provider-factory.js
+++ b/.aiox-core/infrastructure/integrations/ai-providers/ai-provider-factory.js
@@ -1,7 +1,7 @@
 /**
  * @fileoverview AI Provider Factory
  *
- * Central factory for creating and managing AI providers (Claude, Gemini).
+ * Central factory for creating and managing AI providers (Claude, Gemini, OpenAI-compatible).
  * Automatically selects the correct provider based on .aiox-ai-config.yaml.
  * Supports fallback between providers for reliability.
  *
@@ -14,6 +14,16 @@ const yaml = require('js-yaml');
 
 const { ClaudeProvider } = require('./claude-provider');
 const { GeminiProvider } = require('./gemini-provider');
+const { OpenAICompatibleProvider } = require('./openai-compatible-provider');
+
+const NON_PROVIDER_CONFIG_KEYS = new Set(['ai_providers', 'model_switching', 'parallel_execution']);
+
+const PROVIDER_ALIASES = {
+  openai: 'openai-compatible',
+  openai_compatible: 'openai-compatible',
+  openaiCompatible: 'openai-compatible',
+  moonshot: 'kimi',
+};
 
 /**
  * Cached provider instances (singleton pattern)
@@ -50,6 +60,22 @@ const DEFAULT_CONFIG = {
     previewFeatures: true,
     jsonOutput: false,
   },
+  'openai-compatible': {
+    provider: 'openai-compatible',
+    baseURL: 'https://api.openai.com/v1',
+    endpoint: '/chat/completions',
+    apiKeyEnv: 'OPENAI_API_KEY',
+    model: 'gpt-4o-mini',
+    timeout: 300000,
+  },
+  kimi: {
+    provider: 'openai-compatible',
+    baseURL: 'https://api.moonshot.ai/v1',
+    endpoint: '/chat/completions',
+    apiKeyEnv: 'MOONSHOT_API_KEY',
+    model: 'kimi-k2.5',
+    timeout: 300000,
+  },
 };
 
 /**
@@ -74,12 +100,34 @@ function loadConfig(projectRoot = process.cwd()) {
     const configContent = fs.readFileSync(configPath, 'utf8');
     const userConfig = yaml.load(configContent);
 
-    // Merge with defaults
+    // Merge with defaults while preserving custom provider config blocks.
     cachedConfig = {
+      ...DEFAULT_CONFIG,
+      ...userConfig,
       ai_providers: { ...DEFAULT_CONFIG.ai_providers, ...userConfig?.ai_providers },
       claude: { ...DEFAULT_CONFIG.claude, ...userConfig?.claude },
       gemini: { ...DEFAULT_CONFIG.gemini, ...userConfig?.gemini },
+      'openai-compatible': {
+        ...DEFAULT_CONFIG['openai-compatible'],
+        ...userConfig?.['openai-compatible'],
+        ...userConfig?.openai_compatible,
+        ...userConfig?.openaiCompatible,
+      },
+      kimi: { ...DEFAULT_CONFIG.kimi, ...userConfig?.kimi },
     };
+
+    cachedConfig.ai_providers.routing = {
+      ...DEFAULT_CONFIG.ai_providers.routing,
+      ...userConfig?.ai_providers?.routing,
+    };
+
+    Object.defineProperty(cachedConfig, '__configuredProviderKeys', {
+      value: Object.keys(userConfig || {}).filter((key) =>
+        isProviderConfigKey(key, userConfig[key]),
+      ),
+      enumerable: false,
+      configurable: true,
+    });
 
     return cachedConfig;
   } catch (error) {
@@ -91,29 +139,39 @@ function loadConfig(projectRoot = process.cwd()) {
 
 /**
  * Get or create a provider instance
- * @param {string} providerName - Provider name ('claude' or 'gemini')
+ * @param {string} providerName - Provider name or alias
  * @param {Object} [config] - Override configuration
  * @returns {AIProvider} Provider instance
  */
 function getProvider(providerName, config = null) {
-  const cacheKey = `${providerName}:${JSON.stringify(config || {})}`;
+  const normalizedName = normalizeProviderName(providerName);
+  const cacheKey = `${normalizedName}:${JSON.stringify(config || {})}`;
 
   if (providerCache.has(cacheKey)) {
     return providerCache.get(cacheKey);
   }
 
   const fullConfig = loadConfig();
-  const providerConfig = config || fullConfig[providerName] || {};
+  const providerConfig = config || getProviderConfig(fullConfig, providerName);
+  const providerType = normalizeProviderName(providerConfig.provider || normalizedName);
 
   let provider;
 
-  switch (providerName.toLowerCase()) {
+  switch (providerType) {
     case 'claude':
       provider = new ClaudeProvider(providerConfig);
       break;
 
     case 'gemini':
       provider = new GeminiProvider(providerConfig);
+      break;
+
+    case 'kimi':
+    case 'openai-compatible':
+      provider = new OpenAICompatibleProvider({
+        ...providerConfig,
+        name: normalizedName,
+      });
       break;
 
     default:
@@ -213,7 +271,7 @@ async function executeWithFallback(prompt, options = {}) {
  * @returns {Promise<AIProvider[]>} Array of available providers
  */
 async function getAvailableProviders() {
-  const providers = [getProvider('claude'), getProvider('gemini')];
+  const providers = getConfiguredProviderNames().map((name) => getProvider(name));
 
   const available = [];
   for (const provider of providers) {
@@ -232,7 +290,7 @@ async function getAvailableProviders() {
 async function getProvidersStatus() {
   const status = {};
 
-  for (const name of ['claude', 'gemini']) {
+  for (const name of getConfiguredProviderNames()) {
     const provider = getProvider(name);
     const isAvailable = await provider.checkAvailability();
 
@@ -263,6 +321,99 @@ function getConfig() {
   return loadConfig();
 }
 
+/**
+ * Normalize provider aliases to canonical names.
+ *
+ * @param {string} providerName - Provider name or alias
+ * @returns {string} Normalized provider name
+ */
+function normalizeProviderName(providerName) {
+  const rawName = String(providerName || '').trim();
+  const lowerName = rawName.toLowerCase();
+  return PROVIDER_ALIASES[rawName] || PROVIDER_ALIASES[lowerName] || lowerName;
+}
+
+/**
+ * Get merged configuration for a provider.
+ *
+ * @param {Object} fullConfig - Loaded configuration
+ * @param {string} providerName - Requested provider name
+ * @returns {Object} Provider configuration
+ */
+function getProviderConfig(fullConfig, providerName) {
+  const normalizedName = normalizeProviderName(providerName);
+  const candidateKeys = getProviderConfigKeys(providerName, normalizedName);
+  const merged = { ...(DEFAULT_CONFIG[normalizedName] || {}) };
+
+  for (const key of candidateKeys) {
+    if (fullConfig[key] && typeof fullConfig[key] === 'object') {
+      Object.assign(merged, fullConfig[key]);
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Get known config key variants for a provider.
+ *
+ * @param {string} providerName - Requested provider name
+ * @param {string} normalizedName - Normalized provider name
+ * @returns {string[]} Candidate config keys
+ */
+function getProviderConfigKeys(providerName, normalizedName) {
+  const keys = new Set([providerName, normalizedName]);
+
+  if (normalizedName === 'openai-compatible') {
+    keys.add('openai_compatible');
+    keys.add('openaiCompatible');
+  }
+
+  return Array.from(keys).filter(Boolean);
+}
+
+/**
+ * List providers explicitly selected or configured by the project.
+ *
+ * @returns {string[]} Provider names
+ */
+function getConfiguredProviderNames() {
+  const config = loadConfig();
+  const names = new Set();
+  const providerConfig = config.ai_providers || {};
+
+  addProviderName(names, providerConfig.primary || 'claude');
+  addProviderName(names, providerConfig.fallback || 'gemini');
+
+  for (const name of Object.values(providerConfig.routing || {})) {
+    addProviderName(names, name);
+  }
+
+  for (const key of config.__configuredProviderKeys || []) {
+    addProviderName(names, key);
+  }
+
+  return Array.from(names);
+}
+
+function addProviderName(names, providerName) {
+  if (providerName) {
+    names.add(normalizeProviderName(providerName));
+  }
+}
+
+function isProviderConfigKey(key, value) {
+  if (NON_PROVIDER_CONFIG_KEYS.has(key) || !value || typeof value !== 'object') {
+    return false;
+  }
+
+  const normalizedKey = normalizeProviderName(key);
+  return (
+    ['claude', 'gemini', 'kimi', 'openai-compatible'].includes(normalizedKey) ||
+    Boolean(value.provider || value.baseURL || value.baseUrl || value.apiKey || value.apiKeyEnv)
+  );
+}
+
 module.exports = {
   // Provider access
   getProvider,
@@ -282,4 +433,5 @@ module.exports = {
   // Classes for direct use
   ClaudeProvider,
   GeminiProvider,
+  OpenAICompatibleProvider,
 };

--- a/.aiox-core/infrastructure/integrations/ai-providers/ai-provider-factory.js
+++ b/.aiox-core/infrastructure/integrations/ai-providers/ai-provider-factory.js
@@ -10,6 +10,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 const yaml = require('js-yaml');
 
 const { ClaudeProvider } = require('./claude-provider');
@@ -145,7 +146,7 @@ function loadConfig(projectRoot = process.cwd()) {
  */
 function getProvider(providerName, config = null) {
   const normalizedName = normalizeProviderName(providerName);
-  const cacheKey = `${normalizedName}:${JSON.stringify(config || {})}`;
+  const cacheKey = createProviderCacheKey(normalizedName, config);
 
   if (providerCache.has(cacheKey)) {
     return providerCache.get(cacheKey);
@@ -331,6 +332,44 @@ function normalizeProviderName(providerName) {
   const rawName = String(providerName || '').trim();
   const lowerName = rawName.toLowerCase();
   return PROVIDER_ALIASES[rawName] || PROVIDER_ALIASES[lowerName] || lowerName;
+}
+
+function createProviderCacheKey(normalizedName, config) {
+  return `${normalizedName}:${JSON.stringify(sanitizeCacheConfig(config || {}))}`;
+}
+
+function sanitizeCacheConfig(config) {
+  const { apiKey, fetch: _fetch, headers, ...safeConfig } = config;
+  const sanitized = { ...safeConfig };
+
+  if (apiKey) {
+    sanitized.apiKeyHash = hashSecret(apiKey);
+  }
+
+  if (headers) {
+    sanitized.headers = sanitizeHeaders(headers);
+  }
+
+  return sanitized;
+}
+
+function sanitizeHeaders(headers) {
+  const sanitized = {};
+
+  for (const [key, value] of Object.entries(headers)) {
+    const lowerKey = key.toLowerCase();
+    if (lowerKey === 'authorization' || lowerKey.includes('api-key')) {
+      sanitized[key] = value ? `[sha256:${hashSecret(value)}]` : value;
+    } else {
+      sanitized[key] = value;
+    }
+  }
+
+  return sanitized;
+}
+
+function hashSecret(value) {
+  return crypto.createHash('sha256').update(String(value)).digest('hex').slice(0, 16);
 }
 
 /**

--- a/.aiox-core/infrastructure/integrations/ai-providers/ai-provider.js
+++ b/.aiox-core/infrastructure/integrations/ai-providers/ai-provider.js
@@ -1,7 +1,7 @@
 /**
  * @fileoverview Base AI Provider Class
  *
- * Abstract base class for AI CLI providers (Claude Code, Gemini CLI, etc.).
+ * Abstract base class for AI providers (Claude Code, Gemini CLI, HTTP APIs, etc.).
  * Defines the common interface for executing prompts and managing AI interactions.
  *
  * @see Epic GEMINI-INT - Story 2: AI Provider Factory Pattern
@@ -18,7 +18,7 @@ class AIProvider {
    * Create an AI provider
    * @param {Object} config - Provider configuration
    * @param {string} config.name - Provider name
-   * @param {string} config.command - CLI command to execute
+   * @param {string} config.command - CLI command or transport identifier
    * @param {number} [config.timeout=300000] - Execution timeout in ms (default: 5 min)
    * @param {number} [config.maxRetries=3] - Maximum retry attempts
    * @param {Object} [config.options={}] - Additional provider-specific options
@@ -91,7 +91,9 @@ class AIProvider {
       }
     }
 
-    throw new Error(`[${this.name}] All ${maxRetries} attempts failed. Last error: ${lastError.message}`);
+    throw new Error(
+      `[${this.name}] All ${maxRetries} attempts failed. Last error: ${lastError.message}`,
+    );
   }
 
   /**

--- a/.aiox-core/infrastructure/integrations/ai-providers/index.js
+++ b/.aiox-core/infrastructure/integrations/ai-providers/index.js
@@ -10,6 +10,7 @@
 const { AIProvider } = require('./ai-provider');
 const { ClaudeProvider } = require('./claude-provider');
 const { GeminiProvider } = require('./gemini-provider');
+const { OpenAICompatibleProvider } = require('./openai-compatible-provider');
 const {
   getProvider,
   getPrimaryProvider,
@@ -29,6 +30,7 @@ module.exports = {
   // Provider implementations
   ClaudeProvider,
   GeminiProvider,
+  OpenAICompatibleProvider,
 
   // Factory functions
   getProvider,

--- a/.aiox-core/infrastructure/integrations/ai-providers/openai-compatible-provider.js
+++ b/.aiox-core/infrastructure/integrations/ai-providers/openai-compatible-provider.js
@@ -32,22 +32,14 @@ class OpenAICompatibleProvider extends AIProvider {
    */
   constructor(config = {}) {
     const providerName = config.name || 'openai-compatible';
+    const safeOptions = buildProviderOptions(config);
 
     super({
       name: providerName,
       command: 'http',
       timeout: config.timeout || DEFAULT_TIMEOUT,
       maxRetries: config.maxRetries || 3,
-      options: {
-        endpoint: config.endpoint || DEFAULT_ENDPOINT,
-        baseURL: config.baseURL || config.baseUrl,
-        apiKeyEnv: config.apiKeyEnv || 'OPENAI_API_KEY',
-        model: config.model,
-        headers: config.headers || {},
-        requestOptions: config.requestOptions || {},
-        extraBody: config.extraBody || {},
-        ...config,
-      },
+      options: safeOptions,
     });
 
     this.baseURL = this._normalizeBaseURL(config.baseURL || config.baseUrl);
@@ -257,7 +249,7 @@ class OpenAICompatibleProvider extends AIProvider {
     const contentType = response.headers?.get?.('content-type') || '';
 
     if (contentType.includes('application/json')) {
-      return response.json();
+      return await response.json();
     }
 
     const text = await response.text();
@@ -339,6 +331,21 @@ class OpenAICompatibleProvider extends AIProvider {
 
     return new AbortController();
   }
+}
+
+function buildProviderOptions(config) {
+  const { apiKey: _apiKey, fetch: _fetch, name: _name, ...safeConfig } = config;
+
+  return {
+    ...safeConfig,
+    endpoint: safeConfig.endpoint || DEFAULT_ENDPOINT,
+    baseURL: safeConfig.baseURL || safeConfig.baseUrl,
+    apiKeyEnv: safeConfig.apiKeyEnv || 'OPENAI_API_KEY',
+    model: safeConfig.model,
+    headers: safeConfig.headers || {},
+    requestOptions: safeConfig.requestOptions || {},
+    extraBody: safeConfig.extraBody || {},
+  };
 }
 
 module.exports = { OpenAICompatibleProvider };

--- a/.aiox-core/infrastructure/integrations/ai-providers/openai-compatible-provider.js
+++ b/.aiox-core/infrastructure/integrations/ai-providers/openai-compatible-provider.js
@@ -1,0 +1,344 @@
+/**
+ * @fileoverview OpenAI-compatible HTTP Provider
+ *
+ * Generic provider for APIs that implement the OpenAI Chat Completions
+ * contract, including Moonshot/Kimi and other compatible gateways.
+ */
+
+const { AIProvider } = require('./ai-provider');
+
+const DEFAULT_ENDPOINT = '/chat/completions';
+const DEFAULT_TIMEOUT = 300000;
+
+/**
+ * OpenAI-compatible HTTP provider implementation.
+ *
+ * @class OpenAICompatibleProvider
+ * @extends AIProvider
+ */
+class OpenAICompatibleProvider extends AIProvider {
+  /**
+   * Create an OpenAI-compatible provider.
+   *
+   * @param {Object} [config={}] - Provider configuration
+   * @param {string} [config.name='openai-compatible'] - Provider display name
+   * @param {string} [config.baseURL] - API base URL
+   * @param {string} [config.baseUrl] - Alias for baseURL
+   * @param {string} [config.endpoint='/chat/completions'] - Chat completions endpoint relative to baseURL
+   * @param {string} [config.apiKey] - Direct API key value
+   * @param {string} [config.apiKeyEnv='OPENAI_API_KEY'] - Environment variable containing the API key
+   * @param {string} [config.model] - Default model identifier
+   * @param {Function} [config.fetch] - Fetch implementation for tests or custom runtimes
+   */
+  constructor(config = {}) {
+    const providerName = config.name || 'openai-compatible';
+
+    super({
+      name: providerName,
+      command: 'http',
+      timeout: config.timeout || DEFAULT_TIMEOUT,
+      maxRetries: config.maxRetries || 3,
+      options: {
+        endpoint: config.endpoint || DEFAULT_ENDPOINT,
+        baseURL: config.baseURL || config.baseUrl,
+        apiKeyEnv: config.apiKeyEnv || 'OPENAI_API_KEY',
+        model: config.model,
+        headers: config.headers || {},
+        requestOptions: config.requestOptions || {},
+        extraBody: config.extraBody || {},
+        ...config,
+      },
+    });
+
+    this.baseURL = this._normalizeBaseURL(config.baseURL || config.baseUrl);
+    this.endpoint = this._normalizeEndpoint(config.endpoint || DEFAULT_ENDPOINT);
+    this.apiKey = config.apiKey;
+    this.apiKeyEnv = config.apiKeyEnv || 'OPENAI_API_KEY';
+    this.model = config.model;
+    this.fetchFn = config.fetch || globalThis.fetch;
+  }
+
+  /**
+   * Check local provider readiness without performing an external API call.
+   *
+   * @returns {Promise<boolean>} True if fetch and API key are available
+   */
+  async checkAvailability(options = {}) {
+    if (typeof this.fetchFn !== 'function') {
+      this.isAvailable = false;
+      this.lastError = new Error('fetch API is not available in this runtime');
+      return false;
+    }
+
+    if (!this._resolveApiKey(options)) {
+      this.isAvailable = false;
+      this.lastError = new Error(`${this.name} API key is not configured`);
+      return false;
+    }
+
+    this.isAvailable = true;
+    this.version = this.model || null;
+    this.lastError = null;
+    return true;
+  }
+
+  /**
+   * Execute a prompt using an OpenAI-compatible Chat Completions API.
+   *
+   * @param {string} prompt - Prompt to send
+   * @param {Object} [options={}] - Execution options
+   * @returns {Promise<AIResponse>} The AI response
+   */
+  async execute(prompt, options = {}) {
+    const startTime = Date.now();
+    const apiKey = this._resolveApiKey(options);
+    const model = options.model || this.model || this.options.model;
+
+    if (typeof this.fetchFn !== 'function') {
+      throw new Error(`[${this.name}] fetch API is not available in this runtime`);
+    }
+
+    if (!apiKey) {
+      throw new Error(
+        `[${this.name}] API key is not configured. Set ${this.apiKeyEnv} or provide apiKey.`,
+      );
+    }
+
+    if (!model) {
+      throw new Error(`[${this.name}] model is required for OpenAI-compatible execution`);
+    }
+
+    const timeout = options.timeout || this.timeout;
+    const controller = this._createAbortController();
+    const timeoutId = controller ? setTimeout(() => controller.abort(), timeout) : null;
+
+    try {
+      const response = await this.fetchFn(this._buildURL(options), {
+        method: 'POST',
+        headers: this._buildHeaders(apiKey, options),
+        body: JSON.stringify(this._buildPayload(prompt, model, options)),
+        signal: controller?.signal,
+      });
+
+      const duration = Date.now() - startTime;
+      const responseBody = await this._readResponseBody(response);
+
+      if (!response.ok) {
+        throw new Error(
+          `[${this.name}] request failed with status ${response.status}: ${this._sanitizeError(
+            this._stringifyBody(responseBody),
+            apiKey,
+          )}`,
+        );
+      }
+
+      const output = this._extractOutput(responseBody);
+
+      return {
+        success: true,
+        output,
+        data: responseBody,
+        metadata: {
+          duration,
+          provider: this.name,
+          model,
+          usage: responseBody?.usage,
+          id: responseBody?.id,
+        },
+      };
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        throw new Error(`[${this.name}] request timed out after ${timeout}ms`);
+      }
+
+      throw new Error(this._sanitizeError(error.message, apiKey));
+    } finally {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    }
+  }
+
+  /**
+   * Get provider information without exposing secrets.
+   *
+   * @returns {Object} Provider info
+   */
+  getInfo() {
+    return {
+      ...super.getInfo(),
+      baseURL: this.baseURL,
+      endpoint: this.endpoint,
+      model: this.model,
+      apiKeyEnv: this.apiKeyEnv,
+      hasApiKey: Boolean(this._resolveApiKey()),
+    };
+  }
+
+  _buildURL(options = {}) {
+    const baseURL = this._normalizeBaseURL(options.baseURL || options.baseUrl || this.baseURL);
+    const endpoint = this._normalizeEndpoint(options.endpoint || this.endpoint);
+    return `${baseURL}${endpoint}`;
+  }
+
+  _buildHeaders(apiKey, options = {}) {
+    return {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+      ...(this.options.headers || {}),
+      ...(options.headers || {}),
+    };
+  }
+
+  _buildPayload(prompt, model, options = {}) {
+    const messages = options.messages ||
+      this.options.messages || [{ role: 'user', content: prompt }];
+    const payload = {
+      model,
+      messages,
+      ...(this.options.requestOptions || {}),
+      ...(this.options.extraBody || {}),
+      ...(options.requestOptions || {}),
+      ...(options.extraBody || {}),
+      ...(options.body || {}),
+    };
+
+    this._copyDefined(payload, 'temperature', options.temperature ?? this.options.temperature);
+    this._copyDefined(
+      payload,
+      'top_p',
+      options.top_p ?? options.topP ?? this.options.top_p ?? this.options.topP,
+    );
+    this._copyDefined(
+      payload,
+      'max_tokens',
+      options.max_tokens ?? options.maxTokens ?? this.options.max_tokens ?? this.options.maxTokens,
+    );
+    this._copyDefined(payload, 'n', options.n ?? this.options.n);
+    this._copyDefined(
+      payload,
+      'presence_penalty',
+      options.presence_penalty ??
+        options.presencePenalty ??
+        this.options.presence_penalty ??
+        this.options.presencePenalty,
+    );
+    this._copyDefined(
+      payload,
+      'frequency_penalty',
+      options.frequency_penalty ??
+        options.frequencyPenalty ??
+        this.options.frequency_penalty ??
+        this.options.frequencyPenalty,
+    );
+    this._copyDefined(payload, 'tools', options.tools ?? this.options.tools);
+    this._copyDefined(
+      payload,
+      'tool_choice',
+      options.tool_choice ??
+        options.toolChoice ??
+        this.options.tool_choice ??
+        this.options.toolChoice,
+    );
+    this._copyDefined(payload, 'thinking', options.thinking ?? this.options.thinking);
+    this._copyDefined(
+      payload,
+      'response_format',
+      options.response_format ??
+        options.responseFormat ??
+        this.options.response_format ??
+        this.options.responseFormat,
+    );
+
+    return payload;
+  }
+
+  async _readResponseBody(response) {
+    const contentType = response.headers?.get?.('content-type') || '';
+
+    if (contentType.includes('application/json')) {
+      return response.json();
+    }
+
+    const text = await response.text();
+    try {
+      return JSON.parse(text);
+    } catch {
+      return { text };
+    }
+  }
+
+  _extractOutput(responseBody) {
+    const choice = responseBody?.choices?.[0];
+    const content = choice?.message?.content ?? choice?.text ?? responseBody?.text ?? '';
+
+    if (Array.isArray(content)) {
+      return content
+        .map((part) => {
+          if (typeof part === 'string') return part;
+          return part?.text || part?.content || '';
+        })
+        .filter(Boolean)
+        .join('\n')
+        .trim();
+    }
+
+    if (typeof content === 'string') {
+      return content.trim();
+    }
+
+    if (content == null) {
+      return '';
+    }
+
+    return JSON.stringify(content);
+  }
+
+  _resolveApiKey(options = {}) {
+    return options.apiKey || this.apiKey || process.env[this.apiKeyEnv];
+  }
+
+  _sanitizeError(message, apiKey) {
+    if (!message) return message;
+
+    let sanitized = String(message);
+    if (apiKey) {
+      sanitized = sanitized.split(apiKey).join('[REDACTED]');
+    }
+
+    return sanitized.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/g, 'Bearer [REDACTED]');
+  }
+
+  _stringifyBody(body) {
+    if (typeof body === 'string') return body;
+    return JSON.stringify(body);
+  }
+
+  _normalizeBaseURL(baseURL) {
+    if (!baseURL) {
+      throw new Error(`[${this.name}] baseURL is required`);
+    }
+    return String(baseURL).replace(/\/+$/, '');
+  }
+
+  _normalizeEndpoint(endpoint) {
+    const normalized = String(endpoint || DEFAULT_ENDPOINT);
+    return normalized.startsWith('/') ? normalized : `/${normalized}`;
+  }
+
+  _copyDefined(target, key, value) {
+    if (value !== undefined) {
+      target[key] = value;
+    }
+  }
+
+  _createAbortController() {
+    if (typeof AbortController === 'undefined') {
+      return null;
+    }
+
+    return new AbortController();
+  }
+}
+
+module.exports = { OpenAICompatibleProvider };

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,9 +8,9 @@
 # - File types for categorization
 #
 version: 5.1.15
-generated_at: "2026-05-08T19:14:10.833Z"
+generated_at: "2026-05-08T20:56:13.546Z"
 generator: scripts/generate-install-manifest.js
-file_count: 1120
+file_count: 1121
 files:
   - path: cli/commands/config/index.js
     hash: sha256:25c4b9bf4e0241abf7754b55153f49f1a214f1fb5fe904a576675634cb7b3da9
@@ -461,9 +461,9 @@ files:
     type: core
     size: 51556
   - path: core/execution/subagent-dispatcher.js
-    hash: sha256:26e2bbc4b30142186e8ad450aced18284f8333677af0fb506e0b19a8324e94f2
+    hash: sha256:fa8ce6aa5fdd85f7a06c3c560a85d904222658076158c35031ddae19bb63efe1
     type: core
-    size: 28002
+    size: 28869
   - path: core/execution/wave-executor.js
     hash: sha256:4e2324edb37ae0729062b5ac029f2891e050e7efd3a48d0f4a1dc4f227a6716b
     type: core
@@ -2921,13 +2921,13 @@ files:
     type: infrastructure
     size: 6882
   - path: infrastructure/integrations/ai-providers/ai-provider-factory.js
-    hash: sha256:b558c971363fb5b1a8bb4f3caf7683a4a72f3feb6f67e1810ad6679860373e12
+    hash: sha256:8a19d40cd4f9ccf8b457b12fb3318ef4d1ac81ecbc0823c5b9149bff0ee02bff
     type: infrastructure
-    size: 6990
+    size: 11616
   - path: infrastructure/integrations/ai-providers/ai-provider.js
-    hash: sha256:78a9d55c187de61af315e3bc9ac74356cf2788d39f5c04682f5f4697fc38bca3
+    hash: sha256:6818a612190788be35664d39c053bdcf597230bf38dc4e7f2d4744ee996449a1
     type: infrastructure
-    size: 4507
+    size: 4540
   - path: infrastructure/integrations/ai-providers/claude-provider.js
     hash: sha256:ae3c88afda09e599d15911be353efc0e68c1b1ec7797d8859711d9538a606637
     type: infrastructure
@@ -2937,13 +2937,17 @@ files:
     type: infrastructure
     size: 10494
   - path: infrastructure/integrations/ai-providers/index.js
-    hash: sha256:7e72904e827f143bb3d1a74004a2c2c52ba44b696d9709544511cc180d8d641a
+    hash: sha256:67906c50c6d233d5da8f05b3c0c0891fa58ee609d84410d043c81c9966dcc3b3
     type: infrastructure
-    size: 962
+    size: 1068
+  - path: infrastructure/integrations/ai-providers/openai-compatible-provider.js
+    hash: sha256:cdcfd0f2e2c85fe545333d04a10254b09dec552d6525cdd8cf08d03b4152b8f9
+    type: infrastructure
+    size: 9992
   - path: infrastructure/integrations/ai-providers/README.md
-    hash: sha256:a9f492467a613990049e37cc1702a67e284390b98de1b2ecea3cb71050a3dff6
+    hash: sha256:41945acf8b602add3cc4502025ed49a38bcb0f0644636368945b094db50bd3e4
     type: infrastructure
-    size: 2599
+    size: 3360
   - path: infrastructure/integrations/gemini-extensions/cloudrun-adapter.js
     hash: sha256:e4134d7f150c6fe010d2820363f78896e2b6c13b4a2352b38b4d8b2d9f12b478
     type: infrastructure
@@ -3821,9 +3825,9 @@ files:
     type: template
     size: 3210
   - path: product/templates/aiox-ai-config.yaml
-    hash: sha256:58023a5108ee66b16f93c82ee8a7c0414852f7c887257a8ff9040f060b140746
+    hash: sha256:0fe45ebef52ec371be568e82b119678d1ce407bfb51452dee12778eddacc7629
     type: template
-    size: 3167
+    size: 3692
   - path: product/templates/architecture-tmpl.yaml
     hash: sha256:9483f38486932842e1bc1a73c35b3f90fa2cd9c703c7d5effabea7dc8f76350a
     type: template

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.1.15
-generated_at: "2026-05-08T21:09:35.695Z"
+generated_at: "2026-05-08T21:14:02.282Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1122
 files:
@@ -2921,9 +2921,9 @@ files:
     type: infrastructure
     size: 6882
   - path: infrastructure/integrations/ai-providers/ai-provider-factory.js
-    hash: sha256:8a19d40cd4f9ccf8b457b12fb3318ef4d1ac81ecbc0823c5b9149bff0ee02bff
+    hash: sha256:6c5d55300997a40b7ea49b1a3dca49ae017b3a3b2366e4ced3453c056bb1d460
     type: infrastructure
-    size: 11616
+    size: 12596
   - path: infrastructure/integrations/ai-providers/ai-provider.js
     hash: sha256:6818a612190788be35664d39c053bdcf597230bf38dc4e7f2d4744ee996449a1
     type: infrastructure
@@ -2941,9 +2941,9 @@ files:
     type: infrastructure
     size: 1068
   - path: infrastructure/integrations/ai-providers/openai-compatible-provider.js
-    hash: sha256:cdcfd0f2e2c85fe545333d04a10254b09dec552d6525cdd8cf08d03b4152b8f9
+    hash: sha256:6fec5be513b71b5d99b87f26ff101fba5c32d3d67e2f2687dac23d2f27a8c8a3
     type: infrastructure
-    size: 9992
+    size: 10199
   - path: infrastructure/integrations/ai-providers/README.md
     hash: sha256:41945acf8b602add3cc4502025ed49a38bcb0f0644636368945b094db50bd3e4
     type: infrastructure
@@ -3825,9 +3825,9 @@ files:
     type: template
     size: 3210
   - path: product/templates/aiox-ai-config.yaml
-    hash: sha256:0fe45ebef52ec371be568e82b119678d1ce407bfb51452dee12778eddacc7629
+    hash: sha256:14efe89e4be87326f621b1ff2a03c928806566ec134e74b191ff24156d5a0140
     type: template
-    size: 3692
+    size: 3729
   - path: product/templates/architecture-tmpl.yaml
     hash: sha256:9483f38486932842e1bc1a73c35b3f90fa2cd9c703c7d5effabea7dc8f76350a
     type: template

--- a/.aiox-core/product/templates/aiox-ai-config.yaml
+++ b/.aiox-core/product/templates/aiox-ai-config.yaml
@@ -80,13 +80,13 @@ kimi:
   maxRetries: 3
 
 # Generic OpenAI-Compatible Configuration
-# Override these values for OpenRouter or another compatible gateway.
+# REQUIRED: Override all values below for your specific gateway.
 openai_compatible:
   provider: openai-compatible
-  baseURL: https://api.openai.com/v1
+  baseURL: https://your-openai-compatible-gateway.example/v1
   endpoint: /chat/completions
-  apiKeyEnv: OPENAI_API_KEY
-  model: gpt-4o-mini
+  apiKeyEnv: YOUR_OPENAI_COMPATIBLE_API_KEY
+  model: your-model-id
   timeout: 300000
   maxRetries: 3
 

--- a/.aiox-core/product/templates/aiox-ai-config.yaml
+++ b/.aiox-core/product/templates/aiox-ai-config.yaml
@@ -1,6 +1,6 @@
 # AIOX AI Provider Configuration
 #
-# Configure AI providers (Claude Code, Gemini CLI) for AIOX operations.
+# Configure AI providers (Claude Code, Gemini CLI, OpenAI-compatible APIs) for AIOX operations.
 # This file controls which provider is used for different task types.
 #
 # @see Epic GEMINI-INT - Story 2: AI Provider Factory Pattern
@@ -8,19 +8,19 @@
 # Provider Configuration
 ai_providers:
   # Primary provider - used by default
-  primary: claude        # Options: claude, gemini
+  primary: claude # Options: claude, gemini, kimi, openai-compatible
 
   # Fallback provider - used when primary fails
-  fallback: gemini       # Options: claude, gemini, null (no fallback)
+  fallback: gemini # Options: claude, gemini, kimi, openai-compatible, null (no fallback)
 
   # Task-based routing
   # Route specific task types to preferred providers
   routing:
     # Simple tasks - use cheaper/faster provider
-    simple_tasks: gemini       # Code formatting, simple refactors
+    simple_tasks: gemini # Code formatting, simple refactors
 
     # Complex tasks - use more capable provider
-    complex_tasks: claude      # Architecture, security reviews
+    complex_tasks: claude # Architecture, security reviews
 
     # Documentation - high volume, speed matters
     documentation: gemini
@@ -40,10 +40,10 @@ ai_providers:
 # Claude Code Configuration
 claude:
   # Model to use
-  model: claude-3-5-sonnet    # Options: claude-3-5-sonnet, claude-3-opus, etc.
+  model: claude-3-5-sonnet # Options: claude-3-5-sonnet, claude-3-opus, etc.
 
   # Execution timeout (ms)
-  timeout: 300000             # 5 minutes
+  timeout: 300000 # 5 minutes
 
   # Maximum retry attempts
   maxRetries: 3
@@ -54,10 +54,10 @@ claude:
 # Gemini CLI Configuration
 gemini:
   # Model to use
-  model: gemini-2.0-flash     # Options: gemini-2.0-flash, gemini-2.0-pro
+  model: gemini-2.0-flash # Options: gemini-2.0-flash, gemini-2.0-pro
 
   # Execution timeout (ms)
-  timeout: 300000             # 5 minutes
+  timeout: 300000 # 5 minutes
 
   # Maximum retry attempts
   maxRetries: 3
@@ -68,37 +68,59 @@ gemini:
   # Use JSON output format by default
   jsonOutput: false
 
+# Kimi / Moonshot Configuration
+# Uses the OpenAI-compatible Chat Completions API. Keep MOONSHOT_API_KEY in .env.
+kimi:
+  provider: openai-compatible
+  baseURL: https://api.moonshot.ai/v1
+  endpoint: /chat/completions
+  apiKeyEnv: MOONSHOT_API_KEY
+  model: kimi-k2.5
+  timeout: 300000
+  maxRetries: 3
+
+# Generic OpenAI-Compatible Configuration
+# Override these values for OpenRouter or another compatible gateway.
+openai_compatible:
+  provider: openai-compatible
+  baseURL: https://api.openai.com/v1
+  endpoint: /chat/completions
+  apiKeyEnv: OPENAI_API_KEY
+  model: gpt-4o-mini
+  timeout: 300000
+  maxRetries: 3
+
 # Model Switching (Story 16)
 # Automatic selection between Flash and Pro based on task complexity
 model_switching:
-  enabled: false              # Enable when Story 16 is complete
+  enabled: false # Enable when Story 16 is complete
   default_model: gemini-2.0-flash
   complexity_threshold:
-    simple: 0.3               # < 0.3 = Flash
-    medium: 0.7               # 0.3-0.7 = Flash
-    complex: 1.0              # > 0.7 = Pro
+    simple: 0.3 # < 0.3 = Flash
+    medium: 0.7 # 0.3-0.7 = Flash
+    complex: 1.0 # > 0.7 = Pro
   quality_fallback:
     enabled: true
-    min_score: 0.6            # If quality < 0.6, retry with Pro
+    min_score: 0.6 # If quality < 0.6, retry with Pro
 
 # Parallel Execution (Story 17)
 # Run Claude + Gemini simultaneously for better quality
 parallel_execution:
-  enabled: false              # Enable when Story 17 is complete
-  default_mode: fallback      # Options: race, consensus, best-of, merge, fallback
+  enabled: false # Enable when Story 17 is complete
+  default_mode: fallback # Options: race, consensus, best-of, merge, fallback
 
   # Task-specific modes
   task_modes:
-    architecture: consensus   # Both must agree on architecture
-    security: consensus       # Critical - need agreement
-    code_generation: best-of  # Pick best code
-    documentation: race       # Speed matters
-    refactoring: merge        # Combine insights
+    architecture: consensus # Both must agree on architecture
+    security: consensus # Critical - need agreement
+    code_generation: best-of # Pick best code
+    documentation: race # Speed matters
+    refactoring: merge # Combine insights
 
   # Cost control
   cost_control:
-    max_parallel_cost: 1.00   # Max cost for parallel run (USD)
-    fallback_on_budget: true  # Disable parallel if over budget
+    max_parallel_cost: 1.00 # Max cost for parallel run (USD)
+    fallback_on_budget: true # Disable parallel if over budget
 
   # Quality thresholds
   quality_thresholds:

--- a/docs/stories/epic-184-kimi-provider/EPIC-184-KIMI-K2-5-PROVIDER.md
+++ b/docs/stories/epic-184-kimi-provider/EPIC-184-KIMI-K2-5-PROVIDER.md
@@ -5,7 +5,7 @@
 | Campo | Valor |
 |-------|-------|
 | Epic ID | 184 |
-| Status | Ready |
+| Status | In Review |
 | Source Issue | #184 |
 | Issue URL | https://github.com/SynkraAI/aiox-core/issues/184 |
 | Repository | SynkraAI/aiox-core |
@@ -45,7 +45,7 @@ Adicionar suporte nativo e backward-compatible para Kimi K2.5 da Moonshot AI com
 
 | Story | Título | Status | Prioridade | Ordem |
 |-------|--------|--------|------------|-------|
-| 184.1 | OpenAI-Compatible Kimi Provider Contract | Ready | P4 | 1 |
+| 184.1 | OpenAI-Compatible Kimi Provider Contract | Ready for Review | P4 | 1 |
 
 ## Ordem de Execução
 

--- a/docs/stories/epic-184-kimi-provider/STORY-184.1-OPENAI-COMPATIBLE-KIMI-PROVIDER.md
+++ b/docs/stories/epic-184-kimi-provider/STORY-184.1-OPENAI-COMPATIBLE-KIMI-PROVIDER.md
@@ -207,6 +207,7 @@ If the provider test lands under a different path, update this section and the F
 - Added factory aliases/presets for `openai-compatible`, `openai_compatible`, `openai`, `kimi` and `moonshot`, preserving `claude` primary and `gemini` fallback defaults.
 - Generalized provider status discovery and `subagent-dispatcher` fallback behavior for configured non-CLI providers.
 - Regenerated `.aiox-core/install-manifest.yaml` after adding the new provider file.
+- Addressed CodeRabbit review feedback for secret-safe provider options/cache keys, async JSON parsing, generic OpenAI-compatible template placeholders and configured fallback test coverage.
 
 ### Agent Model Used
 
@@ -221,7 +222,7 @@ If the provider test lands under a different path, update this section and the F
 
 ### Validation Evidence
 
-- `npm test -- --runTestsByPath tests/infrastructure/ai-providers/openai-compatible-provider.test.js tests/infrastructure/ai-providers/ai-provider-factory.test.js tests/core/subagent-dispatcher.test.js --runInBand` passed: 3 suites, 56 tests.
+- `npm test -- --runTestsByPath tests/infrastructure/ai-providers/openai-compatible-provider.test.js tests/infrastructure/ai-providers/ai-provider-factory.test.js tests/core/subagent-dispatcher.test.js --runInBand` passed: 3 suites, 58 tests.
 - `npm run test:ci` passed: 338 suites passed, 12 skipped; 8399 tests passed, 170 skipped.
 - `npm run validate:manifest` passed.
 - `npm run lint` passed with 0 errors and existing repo-wide warnings.

--- a/docs/stories/epic-184-kimi-provider/STORY-184.1-OPENAI-COMPATIBLE-KIMI-PROVIDER.md
+++ b/docs/stories/epic-184-kimi-provider/STORY-184.1-OPENAI-COMPATIBLE-KIMI-PROVIDER.md
@@ -6,7 +6,7 @@
 |-------|-------|
 | Story ID | 184.1 |
 | Epic | [184 - Kimi K2.5 Provider Support](./EPIC-184-KIMI-K2-5-PROVIDER.md) |
-| Status | Ready |
+| Status | Ready for Review |
 | Executor | @dev |
 | Quality Gate | @architect |
 | quality_gate_tools | npm test focused, npm run lint, npm run typecheck, npm run validate:manifest |
@@ -23,7 +23,7 @@
 - [x] Draft
 - [x] PO validated
 - [x] Ready for implementation
-- [ ] Ready for Review
+- [x] Ready for Review
 - [ ] Done
 
 ## Executor Assignment
@@ -67,18 +67,18 @@ The correct implementation path is a reusable `OpenAICompatibleProvider` plus a 
 
 ## Acceptance Criteria
 
-- [ ] AC1: A new `OpenAICompatibleProvider` exists under `.aiox-core/infrastructure/integrations/ai-providers/` and extends the existing `AIProvider` contract.
-- [ ] AC2: The provider supports `baseURL`/`baseUrl`, `apiKey`, `apiKeyEnv`, `model`, `timeout`, optional default headers and Chat Completions-compatible request payloads.
-- [ ] AC3: The provider never logs raw API keys and returns the existing `AIResponse` shape with provider/model/duration metadata.
-- [ ] AC4: `ai-provider-factory.js` registers `openai-compatible` and `kimi` aliases without changing the default `claude` primary and `gemini` fallback.
-- [ ] AC5: Kimi default config uses Moonshot's OpenAI-compatible base URL and a Kimi K2.5 model identifier only as a configurable preset, not as a hard dependency.
-- [ ] AC6: `getAvailableProviders()` and `getProvidersStatus()` include configured providers without hardcoding only `claude` and `gemini`.
-- [ ] AC7: Tests mock HTTP/fetch and cover success, API error, missing key, timeout or network failure, JSON response parsing and factory alias registration.
-- [ ] AC8: Documentation shows `.aiox-ai-config.yaml` examples for Moonshot/Kimi and OpenRouter-style overrides without committing secrets.
-- [ ] AC9: Existing Claude/Gemini provider tests continue to pass unchanged in behavior.
-- [ ] AC10: The story does not merge or depend on the stale Kimi IDE sync worktree; IDE sync can become a separate future story if still desired.
-- [ ] AC11: `.aiox-core/infrastructure/integrations/ai-providers/index.js`, provider README and `.aiox-core/product/templates/aiox-ai-config.yaml` expose the new provider without changing current Claude/Gemini defaults.
-- [ ] AC12: `subagent-dispatcher.js` continues to work when the selected provider is `kimi` or `openai-compatible`, including fallback selection from configuration rather than hardcoding only Claude/Gemini.
+- [x] AC1: A new `OpenAICompatibleProvider` exists under `.aiox-core/infrastructure/integrations/ai-providers/` and extends the existing `AIProvider` contract.
+- [x] AC2: The provider supports `baseURL`/`baseUrl`, `apiKey`, `apiKeyEnv`, `model`, `timeout`, optional default headers and Chat Completions-compatible request payloads.
+- [x] AC3: The provider never logs raw API keys and returns the existing `AIResponse` shape with provider/model/duration metadata.
+- [x] AC4: `ai-provider-factory.js` registers `openai-compatible` and `kimi` aliases without changing the default `claude` primary and `gemini` fallback.
+- [x] AC5: Kimi default config uses Moonshot's OpenAI-compatible base URL and a Kimi K2.5 model identifier only as a configurable preset, not as a hard dependency.
+- [x] AC6: `getAvailableProviders()` and `getProvidersStatus()` include configured providers without hardcoding only `claude` and `gemini`.
+- [x] AC7: Tests mock HTTP/fetch and cover success, API error, missing key, timeout or network failure, JSON response parsing and factory alias registration.
+- [x] AC8: Documentation shows `.aiox-ai-config.yaml` examples for Moonshot/Kimi and OpenRouter-style overrides without committing secrets.
+- [x] AC9: Existing Claude/Gemini provider tests continue to pass unchanged in behavior.
+- [x] AC10: The story does not merge or depend on the stale Kimi IDE sync worktree; IDE sync can become a separate future story if still desired.
+- [x] AC11: `.aiox-core/infrastructure/integrations/ai-providers/index.js`, provider README and `.aiox-core/product/templates/aiox-ai-config.yaml` expose the new provider without changing current Claude/Gemini defaults.
+- [x] AC12: `subagent-dispatcher.js` continues to work when the selected provider is `kimi` or `openai-compatible`, including fallback selection from configuration rather than hardcoding only Claude/Gemini.
 
 ## CodeRabbit Integration
 
@@ -101,21 +101,21 @@ The correct implementation path is a reusable `OpenAICompatibleProvider` plus a 
 
 ### Quality Gate Tasks
 
-- [ ] Pre-Commit (@dev): Run provider factory tests and the new OpenAI-compatible provider tests.
+- [x] Pre-Commit (@dev): Run provider factory tests and the new OpenAI-compatible provider tests.
 - [ ] Pre-PR (@devops): Confirm no secrets are committed and manifest updates match package files.
 - [ ] Architecture Review (@architect): Confirm the design is generic OpenAI-compatible provider plus Kimi preset, not a one-off Kimi-only fork.
 
 ## Tasks / Subtasks
 
-- [ ] T1: Confirm exact provider file paths and exports from current `ai-providers` module.
-- [ ] T2: Implement `OpenAICompatibleProvider` using native fetch or an existing local HTTP primitive, with graceful fallback for unsupported runtimes if needed.
-- [ ] T3: Add `kimi` and `openai-compatible` factory registration, config merging and provider status discovery.
-- [ ] T4: Add deterministic tests with mocked HTTP responses and no external network calls.
-- [ ] T5: Update docs with Kimi/Moonshot and OpenRouter configuration examples.
-- [ ] T6: Update manifest/entity registry only if required by existing packaging gates.
-- [ ] T7: Run focused tests, lint, typecheck and manifest validation.
-- [ ] T8: Export `OpenAICompatibleProvider` from the provider module index and factory exports.
-- [ ] T9: Update `subagent-dispatcher.js` fallback logic so configured non-CLI providers do not fall back through a hardcoded Claude/Gemini toggle.
+- [x] T1: Confirm exact provider file paths and exports from current `ai-providers` module.
+- [x] T2: Implement `OpenAICompatibleProvider` using native fetch or an existing local HTTP primitive, with graceful fallback for unsupported runtimes if needed.
+- [x] T3: Add `kimi` and `openai-compatible` factory registration, config merging and provider status discovery.
+- [x] T4: Add deterministic tests with mocked HTTP responses and no external network calls.
+- [x] T5: Update docs with Kimi/Moonshot and OpenRouter configuration examples.
+- [x] T6: Update manifest/entity registry only if required by existing packaging gates.
+- [x] T7: Run focused tests, lint, typecheck and manifest validation.
+- [x] T8: Export `OpenAICompatibleProvider` from the provider module index and factory exports.
+- [x] T9: Update `subagent-dispatcher.js` fallback logic so configured non-CLI providers do not fall back through a hardcoded Claude/Gemini toggle.
 
 ## Dev Notes
 
@@ -135,8 +135,7 @@ The correct implementation path is a reusable `OpenAICompatibleProvider` plus a 
 Required focused validation:
 
 ```bash
-npm test -- --runTestsByPath tests/infrastructure/ai-providers/ai-provider-factory.test.js
-npm test -- --runTestsByPath tests/infrastructure/ai-providers/openai-compatible-provider.test.js
+npm test -- --runTestsByPath tests/infrastructure/ai-providers/openai-compatible-provider.test.js tests/infrastructure/ai-providers/ai-provider-factory.test.js tests/core/subagent-dispatcher.test.js --runInBand
 npm run lint
 npm run typecheck
 npm run validate:manifest
@@ -187,11 +186,11 @@ If the provider test lands under a different path, update this section and the F
 
 ## Definition of Done
 
-- [ ] All ACs complete.
-- [ ] Focused tests pass.
-- [ ] Lint and typecheck pass.
-- [ ] Manifest validation passes if package files are added.
-- [ ] File List and Dev Agent Record are updated.
+- [x] All ACs complete.
+- [x] Focused tests pass.
+- [x] Lint and typecheck pass.
+- [x] Manifest validation passes if package files are added.
+- [x] File List and Dev Agent Record are updated.
 - [ ] Issue #184 has implementation evidence and can be closed or explicitly moved to follow-up scope.
 
 ## Dev Agent Record
@@ -204,6 +203,10 @@ If the provider test lands under a different path, update this section and the F
 - Confirmed current provider factory registers `claude` and `gemini` only.
 - Verified current Kimi API docs: OpenAI-compatible base URL is `https://api.moonshot.ai/v1`, and the chat completions endpoint relative to that base URL is `/chat/completions`.
 - PO validation completed on 2026-05-08 after PR #710 was merged to `main`; #184 was reopened because planning alone does not close implementation.
+- Implemented `OpenAICompatibleProvider` with fetch injection, no-network availability checks, secret redaction, timeout handling and OpenAI Chat Completions response parsing.
+- Added factory aliases/presets for `openai-compatible`, `openai_compatible`, `openai`, `kimi` and `moonshot`, preserving `claude` primary and `gemini` fallback defaults.
+- Generalized provider status discovery and `subagent-dispatcher` fallback behavior for configured non-CLI providers.
+- Regenerated `.aiox-core/install-manifest.yaml` after adding the new provider file.
 
 ### Agent Model Used
 
@@ -211,14 +214,39 @@ If the provider test lands under a different path, update this section and the F
 
 ### Completion Notes
 
-- Draft only. No runtime implementation has been made in this story yet.
+- Runtime implementation is complete and ready for review.
+- Kimi uses the official Moonshot base URL `https://api.moonshot.ai/v1`, endpoint `/chat/completions`, API key env `MOONSHOT_API_KEY` and model `kimi-k2.5`.
+- No live Moonshot/OpenRouter calls were added to tests.
+- Local `npm run lint` passed with existing repo-wide warnings; touched JS files were also linted directly with no warnings after `eslint --fix`.
+
+### Validation Evidence
+
+- `npm test -- --runTestsByPath tests/infrastructure/ai-providers/openai-compatible-provider.test.js tests/infrastructure/ai-providers/ai-provider-factory.test.js tests/core/subagent-dispatcher.test.js --runInBand` passed: 3 suites, 56 tests.
+- `npm run test:ci` passed: 338 suites passed, 12 skipped; 8399 tests passed, 170 skipped.
+- `npm run validate:manifest` passed.
+- `npm run lint` passed with 0 errors and existing repo-wide warnings.
+- `npm run typecheck` passed.
+- `node .aiox-core/utils/aiox-validator.js stories` passed.
+- `node scripts/semantic-lint.js docs/stories/epic-184-kimi-provider/EPIC-184-KIMI-K2-5-PROVIDER.md docs/stories/epic-184-kimi-provider/STORY-184.1-OPENAI-COMPATIBLE-KIMI-PROVIDER.md` passed.
+- `git diff --check` passed.
 
 ### File List
 
 | File | Action |
 |------|--------|
-| `docs/stories/epic-184-kimi-provider/EPIC-184-KIMI-K2-5-PROVIDER.md` | Created |
-| `docs/stories/epic-184-kimi-provider/STORY-184.1-OPENAI-COMPATIBLE-KIMI-PROVIDER.md` | Created |
+| `.aiox-core/infrastructure/integrations/ai-providers/openai-compatible-provider.js` | Created |
+| `.aiox-core/infrastructure/integrations/ai-providers/ai-provider-factory.js` | Modified |
+| `.aiox-core/infrastructure/integrations/ai-providers/ai-provider.js` | Modified |
+| `.aiox-core/infrastructure/integrations/ai-providers/index.js` | Modified |
+| `.aiox-core/infrastructure/integrations/ai-providers/README.md` | Modified |
+| `.aiox-core/core/execution/subagent-dispatcher.js` | Modified |
+| `.aiox-core/product/templates/aiox-ai-config.yaml` | Modified |
+| `.aiox-core/install-manifest.yaml` | Modified |
+| `tests/infrastructure/ai-providers/openai-compatible-provider.test.js` | Created |
+| `tests/infrastructure/ai-providers/ai-provider-factory.test.js` | Modified |
+| `tests/core/subagent-dispatcher.test.js` | Modified |
+| `docs/stories/epic-184-kimi-provider/EPIC-184-KIMI-K2-5-PROVIDER.md` | Created earlier |
+| `docs/stories/epic-184-kimi-provider/STORY-184.1-OPENAI-COMPATIBLE-KIMI-PROVIDER.md` | Updated |
 
 ## Change Log
 
@@ -226,3 +254,4 @@ If the provider test lands under a different path, update this section and the F
 |------|--------|---------|
 | 2026-05-08 | @sm / Codex | Epic/story draft criados a partir do issue #184, leitura do provider factory atual e documentação oficial Kimi API. |
 | 2026-05-08 | @po / Codex | Story validada contra `origin/main`, ajustes técnicos adicionados e status movido para Ready. |
+| 2026-05-08 | @dev / Codex | Provider OpenAI-compatible/Kimi implementado, testes adicionados, docs/config atualizados e manifest regenerado. |

--- a/tests/core/subagent-dispatcher.test.js
+++ b/tests/core/subagent-dispatcher.test.js
@@ -14,7 +14,9 @@ const {
 } = require('./execution-test-helpers');
 
 // Mock gotchas-memory (exists but exports object, not constructor directly)
-jest.mock('../../.aiox-core/core/memory/gotchas-memory', () => { throw new Error('mocked'); });
+jest.mock('../../.aiox-core/core/memory/gotchas-memory', () => {
+  throw new Error('mocked');
+});
 
 const { SubagentDispatcher } = require('../../.aiox-core/core/execution/subagent-dispatcher');
 
@@ -200,12 +202,16 @@ describe('SubagentDispatcher', () => {
   describe('buildPrompt', () => {
     test('includes agent and task info', () => {
       const sd = new SubagentDispatcher();
-      const prompt = sd.buildPrompt('@dev', {
-        id: 't1',
-        description: 'Build feature X',
-        acceptanceCriteria: ['AC1', 'AC2'],
-        files: ['src/app.js'],
-      }, {});
+      const prompt = sd.buildPrompt(
+        '@dev',
+        {
+          id: 't1',
+          description: 'Build feature X',
+          acceptanceCriteria: ['AC1', 'AC2'],
+          files: ['src/app.js'],
+        },
+        {},
+      );
 
       expect(prompt).toContain('@dev');
       expect(prompt).toContain('Build feature X');
@@ -215,10 +221,14 @@ describe('SubagentDispatcher', () => {
 
     test('includes gotchas and patterns from context', () => {
       const sd = new SubagentDispatcher();
-      const prompt = sd.buildPrompt('@dev', { id: 't1', description: 'test' }, {
-        gotchas: [{ pattern: 'avoid X', workaround: 'use Y' }],
-        patterns: [{ name: 'Pattern A', description: 'Desc' }],
-      });
+      const prompt = sd.buildPrompt(
+        '@dev',
+        { id: 't1', description: 'test' },
+        {
+          gotchas: [{ pattern: 'avoid X', workaround: 'use Y' }],
+          patterns: [{ name: 'Pattern A', description: 'Desc' }],
+        },
+      );
 
       expect(prompt).toContain('avoid X');
       expect(prompt).toContain('Pattern A');
@@ -238,6 +248,18 @@ describe('SubagentDispatcher', () => {
     test('returns empty for empty output', () => {
       const sd = new SubagentDispatcher();
       expect(sd.extractModifiedFiles('')).toEqual([]);
+    });
+  });
+
+  // ── Provider fallback ────────────────────────────────────────────────
+
+  describe('provider fallback', () => {
+    test('uses configured fallback before legacy Claude/Gemini pair', () => {
+      const sd = new SubagentDispatcher();
+
+      expect(sd.getFallbackProviderName('kimi')).toBe('gemini');
+      expect(sd.getFallbackProviderName('gemini')).toBe('claude');
+      expect(sd.getFallbackProviderName('claude')).toBe('gemini');
     });
   });
 

--- a/tests/core/subagent-dispatcher.test.js
+++ b/tests/core/subagent-dispatcher.test.js
@@ -12,6 +12,7 @@ const {
   createMockGotchasMemory,
   collectEvents,
 } = require('./execution-test-helpers');
+const AIProviderFactory = require('../../.aiox-core/infrastructure/integrations/ai-providers');
 
 // Mock gotchas-memory (exists but exports object, not constructor directly)
 jest.mock('../../.aiox-core/core/memory/gotchas-memory', () => {
@@ -254,12 +255,29 @@ describe('SubagentDispatcher', () => {
   // ── Provider fallback ────────────────────────────────────────────────
 
   describe('provider fallback', () => {
-    test('uses configured fallback before legacy Claude/Gemini pair', () => {
+    test('uses default provider configuration before the legacy Claude/Gemini pair', () => {
       const sd = new SubagentDispatcher();
 
       expect(sd.getFallbackProviderName('kimi')).toBe('gemini');
       expect(sd.getFallbackProviderName('gemini')).toBe('claude');
       expect(sd.getFallbackProviderName('claude')).toBe('gemini');
+    });
+
+    test('honors configured fallback before legacy provider pairing', () => {
+      const getConfigSpy = jest.spyOn(AIProviderFactory, 'getConfig').mockReturnValue({
+        ai_providers: {
+          primary: 'kimi',
+          fallback: 'openai-compatible',
+        },
+      });
+
+      try {
+        const sd = new SubagentDispatcher();
+        expect(sd.getFallbackProviderName('claude')).toBe('openai-compatible');
+        expect(sd.getFallbackProviderName('openai-compatible')).toBe('kimi');
+      } finally {
+        getConfigSpy.mockRestore();
+      }
     });
   });
 

--- a/tests/infrastructure/ai-providers/ai-provider-factory.test.js
+++ b/tests/infrastructure/ai-providers/ai-provider-factory.test.js
@@ -100,6 +100,27 @@ describe('AI Provider Factory', () => {
       expect(provider.baseURL).toBe('https://gateway.example/v1');
     });
 
+    it('should not reuse custom providers with different inline API keys', () => {
+      const first = getProvider('custom-gateway', {
+        provider: 'openai-compatible',
+        baseURL: 'https://gateway.example/v1',
+        apiKey: 'first-test-key',
+        model: 'gateway-model',
+        fetch: jest.fn(),
+      });
+      const second = getProvider('custom-gateway', {
+        provider: 'openai-compatible',
+        baseURL: 'https://gateway.example/v1',
+        apiKey: 'second-test-key',
+        model: 'gateway-model',
+        fetch: jest.fn(),
+      });
+
+      expect(first).toBeInstanceOf(OpenAICompatibleProvider);
+      expect(second).toBeInstanceOf(OpenAICompatibleProvider);
+      expect(first).not.toBe(second);
+    });
+
     it('should throw error for unknown provider', () => {
       expect(() => getProvider('unknown')).toThrow('Unknown AI provider');
     });

--- a/tests/infrastructure/ai-providers/ai-provider-factory.test.js
+++ b/tests/infrastructure/ai-providers/ai-provider-factory.test.js
@@ -11,11 +11,29 @@ const {
   executeWithFallback,
   getAvailableProviders,
   getProvidersStatus,
+  clearProviderCache,
   ClaudeProvider,
   GeminiProvider,
+  OpenAICompatibleProvider,
 } = require('../../../.aiox-core/infrastructure/integrations/ai-providers/ai-provider-factory');
 
 describe('AI Provider Factory', () => {
+  const originalMoonshotKey = process.env.MOONSHOT_API_KEY;
+
+  beforeEach(() => {
+    clearProviderCache();
+    delete process.env.MOONSHOT_API_KEY;
+  });
+
+  afterEach(() => {
+    clearProviderCache();
+    if (originalMoonshotKey === undefined) {
+      delete process.env.MOONSHOT_API_KEY;
+    } else {
+      process.env.MOONSHOT_API_KEY = originalMoonshotKey;
+    }
+  });
+
   describe('Provider Classes', () => {
     it('should export ClaudeProvider class', () => {
       expect(ClaudeProvider).toBeDefined();
@@ -27,6 +45,15 @@ describe('AI Provider Factory', () => {
       expect(GeminiProvider).toBeDefined();
       const provider = new GeminiProvider();
       expect(provider.name).toBe('gemini');
+    });
+
+    it('should export OpenAICompatibleProvider class', () => {
+      expect(OpenAICompatibleProvider).toBeDefined();
+      const provider = new OpenAICompatibleProvider({
+        baseURL: 'https://api.example.com/v1',
+        model: 'example-model',
+      });
+      expect(provider.name).toBe('openai-compatible');
     });
   });
 
@@ -41,6 +68,36 @@ describe('AI Provider Factory', () => {
       const provider = getProvider('gemini');
       expect(provider).toBeDefined();
       expect(provider.name).toBe('gemini');
+    });
+
+    it('should return kimi provider through the OpenAI-compatible contract', () => {
+      const provider = getProvider('kimi');
+      expect(provider).toBeDefined();
+      expect(provider).toBeInstanceOf(OpenAICompatibleProvider);
+      expect(provider.name).toBe('kimi');
+      expect(provider.model).toBe('kimi-k2.5');
+      expect(provider.baseURL).toBe('https://api.moonshot.ai/v1');
+    });
+
+    it('should return openai-compatible provider aliases', () => {
+      const provider = getProvider('openai_compatible');
+      expect(provider).toBeDefined();
+      expect(provider).toBeInstanceOf(OpenAICompatibleProvider);
+      expect(provider.name).toBe('openai-compatible');
+    });
+
+    it('should support custom providers declared as openai-compatible', () => {
+      const provider = getProvider('custom-gateway', {
+        provider: 'openai-compatible',
+        baseURL: 'https://gateway.example/v1',
+        apiKey: 'test-key',
+        model: 'gateway-model',
+        fetch: jest.fn(),
+      });
+
+      expect(provider).toBeInstanceOf(OpenAICompatibleProvider);
+      expect(provider.name).toBe('custom-gateway');
+      expect(provider.baseURL).toBe('https://gateway.example/v1');
     });
 
     it('should throw error for unknown provider', () => {
@@ -79,16 +136,19 @@ describe('AI Provider Factory', () => {
   });
 
   describe('getAvailableProviders', () => {
-    it('should return an object or array', () => {
-      const providers = getAvailableProviders();
+    it('should return an object or array', async () => {
+      const providers = await getAvailableProviders();
       expect(providers).toBeDefined();
+      expect(Array.isArray(providers)).toBe(true);
     });
   });
 
   describe('getProvidersStatus', () => {
-    it('should return an object', () => {
-      const status = getProvidersStatus();
+    it('should return an object', async () => {
+      const status = await getProvidersStatus();
       expect(typeof status).toBe('object');
+      expect(status).toHaveProperty('claude');
+      expect(status).toHaveProperty('gemini');
     });
   });
 

--- a/tests/infrastructure/ai-providers/openai-compatible-provider.test.js
+++ b/tests/infrastructure/ai-providers/openai-compatible-provider.test.js
@@ -1,0 +1,213 @@
+/**
+ * OpenAI-Compatible Provider Tests
+ * Story 184.1
+ */
+
+const {
+  AIProvider,
+} = require('../../../.aiox-core/infrastructure/integrations/ai-providers/ai-provider');
+const {
+  OpenAICompatibleProvider,
+} = require('../../../.aiox-core/infrastructure/integrations/ai-providers/openai-compatible-provider');
+
+function jsonResponse(body, overrides = {}) {
+  return {
+    ok: true,
+    status: 200,
+    headers: {
+      get: () => 'application/json',
+    },
+    json: jest.fn().mockResolvedValue(body),
+    ...overrides,
+  };
+}
+
+describe('OpenAICompatibleProvider', () => {
+  const originalMoonshotKey = process.env.MOONSHOT_API_KEY;
+  let fetchMock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    delete process.env.MOONSHOT_API_KEY;
+  });
+
+  afterEach(() => {
+    if (originalMoonshotKey === undefined) {
+      delete process.env.MOONSHOT_API_KEY;
+    } else {
+      process.env.MOONSHOT_API_KEY = originalMoonshotKey;
+    }
+  });
+
+  it('extends AIProvider and keeps HTTP transport metadata', () => {
+    const provider = new OpenAICompatibleProvider({
+      name: 'kimi',
+      baseURL: 'https://api.moonshot.ai/v1',
+      apiKeyEnv: 'MOONSHOT_API_KEY',
+      model: 'kimi-k2.5',
+      fetch: fetchMock,
+    });
+
+    expect(provider).toBeInstanceOf(AIProvider);
+    expect(provider.name).toBe('kimi');
+    expect(provider.command).toBe('http');
+    expect(provider.getInfo()).toMatchObject({
+      name: 'kimi',
+      baseURL: 'https://api.moonshot.ai/v1',
+      endpoint: '/chat/completions',
+      model: 'kimi-k2.5',
+      apiKeyEnv: 'MOONSHOT_API_KEY',
+      hasApiKey: false,
+    });
+  });
+
+  it('checks local availability without external network calls', async () => {
+    const provider = new OpenAICompatibleProvider({
+      baseURL: 'https://api.moonshot.ai/v1',
+      apiKeyEnv: 'MOONSHOT_API_KEY',
+      model: 'kimi-k2.5',
+      fetch: fetchMock,
+    });
+
+    await expect(provider.checkAvailability()).resolves.toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    process.env.MOONSHOT_API_KEY = 'moonshot-test-key';
+
+    await expect(provider.checkAvailability()).resolves.toBe(true);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('executes a chat completion request and returns AIResponse metadata', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        id: 'chatcmpl-test',
+        choices: [{ message: { content: 'Hello from Kimi' } }],
+        usage: { total_tokens: 12 },
+      }),
+    );
+
+    const provider = new OpenAICompatibleProvider({
+      name: 'kimi',
+      baseUrl: 'https://api.moonshot.ai/v1/',
+      apiKey: 'direct-secret',
+      model: 'kimi-k2.5',
+      fetch: fetchMock,
+    });
+
+    const response = await provider.execute('Say hello');
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.moonshot.ai/v1/chat/completions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer direct-secret',
+          'Content-Type': 'application/json',
+        }),
+      }),
+    );
+
+    const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(requestBody).toMatchObject({
+      model: 'kimi-k2.5',
+      messages: [{ role: 'user', content: 'Say hello' }],
+    });
+    expect(response).toMatchObject({
+      success: true,
+      output: 'Hello from Kimi',
+      metadata: {
+        provider: 'kimi',
+        model: 'kimi-k2.5',
+        usage: { total_tokens: 12 },
+        id: 'chatcmpl-test',
+      },
+    });
+  });
+
+  it('supports custom messages and OpenAI-style generation options', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({
+        choices: [{ message: { content: [{ type: 'text', text: 'structured response' }] } }],
+      }),
+    );
+
+    const provider = new OpenAICompatibleProvider({
+      baseURL: 'https://gateway.example/v1',
+      apiKey: 'gateway-key',
+      model: 'gateway-model',
+      fetch: fetchMock,
+    });
+
+    const response = await provider.execute('ignored when messages exist', {
+      messages: [
+        { role: 'system', content: 'Be concise' },
+        { role: 'user', content: 'Hi' },
+      ],
+      temperature: 0.2,
+      maxTokens: 128,
+      extraBody: { thinking: { type: 'disabled' } },
+    });
+
+    const requestBody = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(requestBody).toMatchObject({
+      model: 'gateway-model',
+      messages: [
+        { role: 'system', content: 'Be concise' },
+        { role: 'user', content: 'Hi' },
+      ],
+      temperature: 0.2,
+      max_tokens: 128,
+      thinking: { type: 'disabled' },
+    });
+    expect(response.output).toBe('structured response');
+  });
+
+  it('fails safely when the API key is missing', async () => {
+    const provider = new OpenAICompatibleProvider({
+      baseURL: 'https://api.moonshot.ai/v1',
+      apiKeyEnv: 'MOONSHOT_API_KEY',
+      model: 'kimi-k2.5',
+      fetch: fetchMock,
+    });
+
+    await expect(provider.execute('hello')).rejects.toThrow('API key is not configured');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('redacts secrets from API error messages', async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse(
+        { error: { message: 'Invalid key direct-secret in Authorization: Bearer direct-secret' } },
+        { ok: false, status: 401 },
+      ),
+    );
+
+    const provider = new OpenAICompatibleProvider({
+      baseURL: 'https://api.moonshot.ai/v1',
+      apiKey: 'direct-secret',
+      model: 'kimi-k2.5',
+      fetch: fetchMock,
+    });
+
+    await expect(provider.execute('hello')).rejects.toThrow('REDACTED');
+    await expect(provider.execute('hello')).rejects.not.toThrow('direct-secret');
+  });
+
+  it('reports timeout errors from aborted requests', async () => {
+    const abortError = new Error('aborted');
+    abortError.name = 'AbortError';
+    fetchMock.mockRejectedValue(abortError);
+
+    const provider = new OpenAICompatibleProvider({
+      baseURL: 'https://api.moonshot.ai/v1',
+      apiKey: 'direct-secret',
+      model: 'kimi-k2.5',
+      timeout: 10,
+      fetch: fetchMock,
+    });
+
+    await expect(provider.execute('hello')).rejects.toThrow('request timed out after 10ms');
+  });
+});

--- a/tests/infrastructure/ai-providers/openai-compatible-provider.test.js
+++ b/tests/infrastructure/ai-providers/openai-compatible-provider.test.js
@@ -51,6 +51,8 @@ describe('OpenAICompatibleProvider', () => {
     expect(provider).toBeInstanceOf(AIProvider);
     expect(provider.name).toBe('kimi');
     expect(provider.command).toBe('http');
+    expect(provider.options.apiKey).toBeUndefined();
+    expect(provider.options.fetch).toBeUndefined();
     expect(provider.getInfo()).toMatchObject({
       name: 'kimi',
       baseURL: 'https://api.moonshot.ai/v1',


### PR DESCRIPTION
## Summary
- adds a generic OpenAI-compatible HTTP provider with Kimi/Moonshot presets and aliases
- updates provider factory discovery/status, exports, docs, config template and dispatcher fallback behavior
- adds mocked HTTP tests for provider execution and factory registration

## Validation
- npm run test:ci
- npm test -- --runTestsByPath tests/infrastructure/ai-providers/openai-compatible-provider.test.js tests/infrastructure/ai-providers/ai-provider-factory.test.js tests/core/subagent-dispatcher.test.js --runInBand
- npm run validate:manifest
- npm run lint
- npm run typecheck
- git diff --check
- node .aiox-core/utils/aiox-validator.js stories
- node scripts/semantic-lint.js docs/stories/epic-184-kimi-provider/EPIC-184-KIMI-K2-5-PROVIDER.md docs/stories/epic-184-kimi-provider/STORY-184.1-OPENAI-COMPATIBLE-KIMI-PROVIDER.md

Closes #184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenAI‑compatible provider support (including Moonshot "kimi").
  * Improved provider fallback resolution to honor configured primary/fallback settings.

* **Documentation**
  * Updated provider README and configuration templates with OpenAI‑compatible examples and usage.

* **Tests**
  * Added and expanded tests for the OpenAI‑compatible provider, provider factory, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->