### PR TITLE
fix: canonicalize Pro docs and Kimi skills [Story PRO-13.4]

### DIFF
--- a/.aiox-core/infrastructure/scripts/ide-sync/transformers/kimi.js
+++ b/.aiox-core/infrastructure/scripts/ide-sync/transformers/kimi.js
@@ -311,7 +311,8 @@ function buildDescription(id, name, title, whenToUse) {
     `@${id}`,
   ];
 
-  return `Activate the AIOX ${title} agent (${name}). ${desc} Trigger when user asks to ${id}, or says '${triggerPhrases.join("', '")}'.`;
+  const brandedTitle = /^AIOX\b/i.test(title) ? title : `AIOX ${title}`;
+  return `Activate the ${brandedTitle} agent (${name}). ${desc} Trigger when user asks to ${id}, or says '${triggerPhrases.join("', '")}'.`;
 }
 
 function buildRawContentSection(rawContent, id) {

--- a/.aiox-core/infrastructure/scripts/ide-sync/transformers/kimi.js
+++ b/.aiox-core/infrastructure/scripts/ide-sync/transformers/kimi.js
@@ -3,7 +3,7 @@
  * @story Kimi IDE Integration
  *
  * Format: SKILL.md with YAML frontmatter + markdown instructions
- * Target: .kimi/skills/aios-{agent-id}/SKILL.md
+ * Target: .kimi/skills/aiox-{agent-id}/SKILL.md
  */
 
 /**
@@ -23,7 +23,7 @@ function transform(agentData) {
   const skillId = getSkillId(agentData);
   const activationId = getPreferredActivationId(agentData);
   const name = rawAgent.name || fallbackAgent.name || id;
-  const title = rawAgent.title || fallbackAgent.title || 'AIOS Agent';
+  const title = rawAgent.title || fallbackAgent.title || 'AIOX Agent';
   const icon = rawAgent.icon || fallbackAgent.icon || '🤖';
   const whenToUse = rawAgent.whenToUse || fallbackAgent.whenToUse || `Use for ${title.toLowerCase()} tasks`;
   const archetype = persona.archetype || rawAgent.archetype || 'Specialist';
@@ -311,7 +311,7 @@ function buildDescription(id, name, title, whenToUse) {
     `@${id}`,
   ];
 
-  return `Activate the AIOS ${title} agent (${name}). ${desc} Trigger when user asks to ${id}, or says '${triggerPhrases.join("', '")}'.`;
+  return `Activate the AIOX ${title} agent (${name}). ${desc} Trigger when user asks to ${id}, or says '${triggerPhrases.join("', '")}'.`;
 }
 
 function buildRawContentSection(rawContent, id) {
@@ -394,8 +394,9 @@ function getPreferredActivationId(agentData) {
 
 function getSkillId(agentData) {
   const id = getPreferredActivationId(agentData);
-  if (id.startsWith('aios-')) return id;
-  return `aios-${id}`;
+  if (id.startsWith('aiox-')) return id;
+  if (id.startsWith('aios-')) return id.replace(/^aios-/, 'aiox-');
+  return `aiox-${id}`;
 }
 
 function getDirname(agentData) {

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.1.17
-generated_at: "2026-05-09T08:01:26.461Z"
+generated_at: "2026-05-09T08:57:54.287Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1128
 files:
@@ -3253,9 +3253,9 @@ files:
     type: script
     size: 5693
   - path: infrastructure/scripts/ide-sync/transformers/kimi.js
-    hash: sha256:269fba3c07fcae905e48a1eebd7e65106480fb7e38e0521e4cd77f529465c1c9
+    hash: sha256:923e6b39d901d1dde2fdc0e98b9393dc6e32fd9d93f8bb484f3974ee62af1613
     type: script
-    size: 13795
+    size: 13863
   - path: infrastructure/scripts/ide-sync/validator.js
     hash: sha256:768eba65a0f8ff937c34f6f43fe1b4dc990f2d406e592bc1cda0f8ab5b4f7e0b
     type: script

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.1.17
-generated_at: "2026-05-09T08:57:54.287Z"
+generated_at: "2026-05-09T09:07:47.281Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1128
 files:
@@ -3253,9 +3253,9 @@ files:
     type: script
     size: 5693
   - path: infrastructure/scripts/ide-sync/transformers/kimi.js
-    hash: sha256:923e6b39d901d1dde2fdc0e98b9393dc6e32fd9d93f8bb484f3974ee62af1613
+    hash: sha256:69a6b34e81ba956242ff38cfce4063d9a0d9e32818a5f36e0246d80e41940def
     type: script
-    size: 13863
+    size: 13938
   - path: infrastructure/scripts/ide-sync/validator.js
     hash: sha256:768eba65a0f8ff937c34f6f43fe1b4dc990f2d406e592bc1cda0f8ab5b4f7e0b
     type: script

--- a/.kimi/skills/aiox-analyst/SKILL.md
+++ b/.kimi/skills/aiox-analyst/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "aios-analyst"
-description: "Activate the AIOS Business Analyst agent (Atlas). Use for market research, competitive analysis, user research, brainstorming session facilitation, structured ideation workshops, feasibility studies, industry trends analysis, project discovery (brownfield documentation), and research report creation. NOT for: PRD creation or product strategy → U... Trigger when user asks to analyst, or says 'activate analyst', 'switch to analyst', '@analyst'."
+name: "aiox-analyst"
+description: "Activate the AIOX Business Analyst agent (Atlas). Use for market research, competitive analysis, user research, brainstorming session facilitation, structured ideation workshops, feasibility studies, industry trends analysis, project discovery (brownfield documentation), and research report creation. NOT for: PRD creation or product strategy → U... Trigger when user asks to analyst, or says 'activate analyst', 'switch to analyst', '@analyst'."
 ---
 
 # 🔍 @analyst — Atlas (Decoder) | Business Analyst

--- a/.kimi/skills/aiox-architect/SKILL.md
+++ b/.kimi/skills/aiox-architect/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "aios-architect"
-description: "Activate the AIOS Architect agent (Aria). Use for system architecture (fullstack, backend, frontend, infrastructure), technology stack selection (technical evaluation), API design (REST/GraphQL/tRPC/WebSocket), security architecture, performance optimization, deployment strategy, and cross-cutting concerns (logging, monitoring, error han... Trigger when user asks to architect, or says 'activate architect', 'switch to architect', '@architect'."
+name: "aiox-architect"
+description: "Activate the AIOX Architect agent (Aria). Use for system architecture (fullstack, backend, frontend, infrastructure), technology stack selection (technical evaluation), API design (REST/GraphQL/tRPC/WebSocket), security architecture, performance optimization, deployment strategy, and cross-cutting concerns (logging, monitoring, error han... Trigger when user asks to architect, or says 'activate architect', 'switch to architect', '@architect'."
 ---
 
 # 🏛️ @architect — Aria (Visionary) | Architect

--- a/.kimi/skills/aiox-data-engineer/SKILL.md
+++ b/.kimi/skills/aiox-data-engineer/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "aios-data-engineer"
-description: "Activate the AIOS Database Architect & Operations Engineer agent (Dara). Use for database design, schema architecture, Supabase configuration, RLS policies, migrations, query optimization, data modeling, operations, and monitoring Trigger when user asks to data-engineer, or says 'activate data-engineer', 'switch to data-engineer', '@data-engineer'."
+name: "aiox-data-engineer"
+description: "Activate the AIOX Database Architect & Operations Engineer agent (Dara). Use for database design, schema architecture, Supabase configuration, RLS policies, migrations, query optimization, data modeling, operations, and monitoring Trigger when user asks to data-engineer, or says 'activate data-engineer', 'switch to data-engineer', '@data-engineer'."
 ---
 
 # 📊 @data-engineer — Dara (Sage) | Database Architect & Operations Engineer

--- a/.kimi/skills/aiox-dev/SKILL.md
+++ b/.kimi/skills/aiox-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "aios-dev"
-description: "Activate the AIOS Full Stack Developer agent (Dex). Use for code implementation, debugging, refactoring, and development best practices Trigger when user asks to dev, or says 'activate dev', 'switch to dev', '@dev'."
+name: "aiox-dev"
+description: "Activate the AIOX Full Stack Developer agent (Dex). Use for code implementation, debugging, refactoring, and development best practices Trigger when user asks to dev, or says 'activate dev', 'switch to dev', '@dev'."
 ---
 
 # 💻 @dev — Dex (Builder) | Full Stack Developer

--- a/.kimi/skills/aiox-devops/SKILL.md
+++ b/.kimi/skills/aiox-devops/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "aios-devops"
-description: "Activate the AIOS GitHub Repository Manager & DevOps Specialist agent (Gage). Use for repository operations, version management, CI/CD, quality gates, and GitHub push operations. ONLY agent authorized to push to remote repository. Trigger when user asks to devops, or says 'activate devops', 'switch to devops', '@devops'."
+name: "aiox-devops"
+description: "Activate the AIOX GitHub Repository Manager & DevOps Specialist agent (Gage). Use for repository operations, version management, CI/CD, quality gates, and GitHub push operations. ONLY agent authorized to push to remote repository. Trigger when user asks to devops, or says 'activate devops', 'switch to devops', '@devops'."
 ---
 
 # ⚡ @devops — Gage (Operator) | GitHub Repository Manager & DevOps Specialist

--- a/.kimi/skills/aiox-master/SKILL.md
+++ b/.kimi/skills/aiox-master/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "aiox-master"
-description: "Activate the AIOX AIOX Master Orchestrator & Framework Developer agent (Orion). Use when you need comprehensive expertise across all domains, framework component creation/modification, workflow orchestration, or running tasks that don't require a specialized persona. Trigger when user asks to aiox-master, or says 'activate aiox-master', 'switch to aiox-master', '@aiox-master'."
+description: "Activate the AIOX Master Orchestrator & Framework Developer agent (Orion). Use when you need comprehensive expertise across all domains, framework component creation/modification, workflow orchestration, or running tasks that don't require a specialized persona. Trigger when user asks to aiox-master, or says 'activate aiox-master', 'switch to aiox-master', '@aiox-master'."
 ---
 
 # 👑 @aiox-master — Orion (Orchestrator) | AIOX Master Orchestrator & Framework Developer

--- a/.kimi/skills/aiox-master/SKILL.md
+++ b/.kimi/skills/aiox-master/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "aios-aiox-master"
-description: "Activate the AIOS AIOX Master Orchestrator & Framework Developer agent (Orion). Use when you need comprehensive expertise across all domains, framework component creation/modification, workflow orchestration, or running tasks that don't require a specialized persona. Trigger when user asks to aiox-master, or says 'activate aiox-master', 'switch to aiox-master', '@aiox-master'."
+name: "aiox-master"
+description: "Activate the AIOX AIOX Master Orchestrator & Framework Developer agent (Orion). Use when you need comprehensive expertise across all domains, framework component creation/modification, workflow orchestration, or running tasks that don't require a specialized persona. Trigger when user asks to aiox-master, or says 'activate aiox-master', 'switch to aiox-master', '@aiox-master'."
 ---
 
 # 👑 @aiox-master — Orion (Orchestrator) | AIOX Master Orchestrator & Framework Developer

--- a/.kimi/skills/aiox-pm/SKILL.md
+++ b/.kimi/skills/aiox-pm/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "aios-pm"
-description: "Activate the AIOS Product Manager agent (Morgan). Use for PRD creation (greenfield and brownfield), epic creation and management, product strategy and vision, feature prioritization (MoSCoW, RICE), roadmap planning, business case development, go/no-go decisions, scope definition, success metrics, and stakeholder communication. Epic/Story Delegat... Trigger when user asks to pm, or says 'activate pm', 'switch to pm', '@pm'."
+name: "aiox-pm"
+description: "Activate the AIOX Product Manager agent (Morgan). Use for PRD creation (greenfield and brownfield), epic creation and management, product strategy and vision, feature prioritization (MoSCoW, RICE), roadmap planning, business case development, go/no-go decisions, scope definition, success metrics, and stakeholder communication. Epic/Story Delegat... Trigger when user asks to pm, or says 'activate pm', 'switch to pm', '@pm'."
 ---
 
 # 📋 @pm — Morgan (Strategist) | Product Manager

--- a/.kimi/skills/aiox-po/SKILL.md
+++ b/.kimi/skills/aiox-po/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "aios-po"
-description: "Activate the AIOS Product Owner agent (Pax). Use for backlog management, story refinement, acceptance criteria, sprint planning, and prioritization decisions Trigger when user asks to po, or says 'activate po', 'switch to po', '@po'."
+name: "aiox-po"
+description: "Activate the AIOX Product Owner agent (Pax). Use for backlog management, story refinement, acceptance criteria, sprint planning, and prioritization decisions Trigger when user asks to po, or says 'activate po', 'switch to po', '@po'."
 ---
 
 # 🎯 @po — Pax (Balancer) | Product Owner

--- a/.kimi/skills/aiox-qa/SKILL.md
+++ b/.kimi/skills/aiox-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "aios-qa"
-description: "Activate the AIOS Test Architect & Quality Advisor agent (Quinn). Use for comprehensive test architecture review, quality gate decisions, and code improvement. Provides thorough analysis including requirements traceability, risk assessment, and test strategy. Advisory only - teams choose their quality bar. Trigger when user asks to qa, or says 'activate qa', 'switch to qa', '@qa'."
+name: "aiox-qa"
+description: "Activate the AIOX Test Architect & Quality Advisor agent (Quinn). Use for comprehensive test architecture review, quality gate decisions, and code improvement. Provides thorough analysis including requirements traceability, risk assessment, and test strategy. Advisory only - teams choose their quality bar. Trigger when user asks to qa, or says 'activate qa', 'switch to qa', '@qa'."
 ---
 
 # ✅ @qa — Quinn (Guardian) | Test Architect & Quality Advisor

--- a/.kimi/skills/aiox-sm/SKILL.md
+++ b/.kimi/skills/aiox-sm/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "aios-sm"
-description: "Activate the AIOS Scrum Master agent (River). Use for user story creation from PRD, story validation and completeness checking, acceptance criteria definition, story refinement, sprint planning, backlog grooming, retrospectives, daily standup facilitation, and local branch management (create/switch/list/delete local branches, local merges). ... Trigger when user asks to sm, or says 'activate sm', 'switch to sm', '@sm'."
+name: "aiox-sm"
+description: "Activate the AIOX Scrum Master agent (River). Use for user story creation from PRD, story validation and completeness checking, acceptance criteria definition, story refinement, sprint planning, backlog grooming, retrospectives, daily standup facilitation, and local branch management (create/switch/list/delete local branches, local merges). ... Trigger when user asks to sm, or says 'activate sm', 'switch to sm', '@sm'."
 ---
 
 # 🌊 @sm — River (Facilitator) | Scrum Master

--- a/.kimi/skills/aiox-squad-creator/SKILL.md
+++ b/.kimi/skills/aiox-squad-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "aios-squad-creator"
-description: "Activate the AIOS Squad Creator agent (Craft). Use to create, validate, publish and manage squads Trigger when user asks to squad-creator, or says 'activate squad-creator', 'switch to squad-creator', '@squad-creator'."
+name: "aiox-squad-creator"
+description: "Activate the AIOX Squad Creator agent (Craft). Use to create, validate, publish and manage squads Trigger when user asks to squad-creator, or says 'activate squad-creator', 'switch to squad-creator', '@squad-creator'."
 ---
 
 # 🏗️ @squad-creator — Craft (Builder) | Squad Creator

--- a/.kimi/skills/aiox-ux-design-expert/SKILL.md
+++ b/.kimi/skills/aiox-ux-design-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: "aios-ux-design-expert"
-description: "Activate the AIOS UX/UI Designer & Design System Architect agent (Uma). Complete design workflow - user research, wireframes, design systems, token extraction, component building, and quality assurance Trigger when user asks to ux-design-expert, or says 'activate ux-design-expert', 'switch to ux-design-expert', '@ux-design-expert'."
+name: "aiox-ux-design-expert"
+description: "Activate the AIOX UX/UI Designer & Design System Architect agent (Uma). Complete design workflow - user research, wireframes, design systems, token extraction, component building, and quality assurance Trigger when user asks to ux-design-expert, or says 'activate ux-design-expert', 'switch to ux-design-expert', '@ux-design-expert'."
 ---
 
 # 🎨 @ux-design-expert — Uma (Empathizer) | UX/UI Designer & Design System Architect

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -170,7 +170,7 @@ aiox-core -> published, currently 5.0.7 in registry
 @aiox-squads/core -> 404
 ```
 
-Important: `@aiox-squads/core@5.1.0` is the continuity publish after the last legacy registry version, `aiox-core@5.0.7`. Confirm the local root `package.json` remains `@aiox-squads/core` at `5.1.0` before publishing.
+Historical note: `@aiox-squads/core@5.1.0` was the continuity publish after the last legacy registry version, `aiox-core@5.0.7`. The current operational release baseline is `@aiox-squads/core@5.1.17`; confirm the local root `package.json` remains `@aiox-squads/core` at `5.1.17` before publishing.
 
 ### Story 124.4 - `@aiox-squads/pro`
 
@@ -180,7 +180,7 @@ Required changes:
 
 ```text
 package name -> @aiox-squads/pro
-peer dependency -> @aiox-squads/core >=5.1.0
+peer dependency -> @aiox-squads/core >=5.1.17
 publish token -> NPM_TOKEN_AIOX_SQUADS in SynkraAI/aiox-pro
 ```
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -20,6 +20,15 @@ Verified on 2026-05-06:
 | `gh secret list --repo SynkraAI/aiox-core`        | `NPM_TOKEN_AIOX_SQUADS` present                                                 |
 | `gh secret list --repo SynkraAI/aiox-pro`         | `NPM_TOKEN_AIOX_SQUADS` present                                                 |
 
+Current release state, verified on 2026-05-09:
+
+```text
+@aiox-squads/core@5.1.17 -> public latest
+@aiox-squads/pro@0.4.2  -> private/restricted release artifact
+```
+
+Customer Pro acquisition does not require direct npm org access. The supported customer path is the authenticated signed-artifact channel served by the historical `aios-license-server` repo.
+
 Maintainer invite status:
 
 ```text
@@ -191,7 +200,7 @@ Expected result:
 
 ```text
 @aiox-squads/core public tarball includes 0 files under pro/
-@aiox-squads/pro remains public until authenticated install/update smoke passes
+@aiox-squads/pro remains private/restricted and is delivered to customers through signed artifact URLs
 ```
 
 DevOps artifact channel checks:
@@ -202,7 +211,7 @@ npm view @aiox-squads/pro version dist-tags --json
 npm access get status @aiox-squads/pro --json
 ```
 
-`@aiox-squads/pro` may be changed to private only after all of these pass:
+`@aiox-squads/pro` is allowed to remain private only while all of these checks pass:
 
 1. Production `aios-license-server` has `PRO_ARTIFACT_BUCKET`, `PRO_ARTIFACT_MANIFEST_JSON`, and `PRO_ARTIFACT_SIGNED_URL_TTL_SECONDS`.
 2. A verified Pro user can request `POST /api/v1/pro/artifact-url`, download the `.tgz`, and match manifest `sha256` and `sizeBytes`.
@@ -210,7 +219,7 @@ npm access get status @aiox-squads/pro --json
 4. A core-only install without npm token does not receive `pro/` content.
 5. Existing Pro update/install does not duplicate slash commands, agent activators, or generated skills.
 
-Privacy transition command, after smoke:
+Privacy transition command, only if the package is ever found public again after smoke:
 
 ```bash
 npm access set status=private @aiox-squads/pro

--- a/docs/guides/pro/install-gate-setup.md
+++ b/docs/guides/pro/install-gate-setup.md
@@ -8,9 +8,9 @@ Guia completo para instalar, ativar e gerenciar o AIOX Pro.
 
 ## Visão Geral
 
-O AIOX Pro é distribuído por um canal autenticado. O instalador valida a **licença ativa**, solicita uma URL assinada de curta duração ao license-server histórico (`aios-license-server`) e instala o artefato premium verificado no projeto.
+O AIOX Pro é distribuído por um canal autenticado. O instalador valida a **licença ativa**, solicita uma URL assinada de curta duração ao serviço/repo histórico `aios-license-server` (mantido sob branding AIOX) e instala o artefato premium verificado no projeto.
 
-```
+```text
 Comprar Licença -> Validar -> Baixar artefato assinado -> Usar Features Pro
 ```
 

--- a/docs/guides/pro/install-gate-setup.md
+++ b/docs/guides/pro/install-gate-setup.md
@@ -43,7 +43,7 @@ npx aiox-pro status
 ### Pré-requisitos
 
 - Node.js >= 18
-- `@aiox-squads/core` >= 5.1.0 instalado no projeto
+- `@aiox-squads/core` >= 5.1.17 instalado no projeto
 
 ### Passo 1: Instalar AIOX Pro
 

--- a/docs/guides/pro/install-gate-setup.md
+++ b/docs/guides/pro/install-gate-setup.md
@@ -6,20 +6,20 @@ Guia completo para instalar, ativar e gerenciar o AIOX Pro.
 
 ---
 
-## Visao Geral
+## Visão Geral
 
-O AIOX Pro e distribuido via npm publico. O pacote e livre para instalar, mas as features premium requerem uma **licenca ativa** para funcionar.
+O AIOX Pro é distribuído por um canal autenticado. O instalador valida a **licença ativa**, solicita uma URL assinada de curta duração ao license-server histórico (`aios-license-server`) e instala o artefato premium verificado no projeto.
 
 ```
-Comprar Licenca → Instalar → Ativar → Usar Features Pro
+Comprar Licença -> Validar -> Baixar artefato assinado -> Usar Features Pro
 ```
 
 ### Pacotes npm
 
-| Pacote | Tipo | Proposito |
+| Pacote | Tipo | Propósito |
 |--------|------|-----------|
-| `aiox-pro` | CLI (1.8 KB) | Comandos de instalacao e gerenciamento |
-| `@aiox-fullstack/pro` | Core (10 MB) | Nome canônico do pacote premium (com fallback legado durante a transição) |
+| `aiox-pro` | CLI (1.8 KB) | Comandos de instalação e gerenciamento |
+| `@aiox-squads/pro` | Artefato premium | Pacote Pro canônico, entregue ao cliente pelo artifact broker autenticado |
 
 ---
 
@@ -40,10 +40,10 @@ npx aiox-pro status
 
 ## Passo a Passo
 
-### Prerequisitos
+### Pré-requisitos
 
 - Node.js >= 18
-- `aiox-core` >= 4.0.0 instalado no projeto
+- `@aiox-squads/core` >= 5.1.0 instalado no projeto
 
 ### Passo 1: Instalar AIOX Pro
 
@@ -51,15 +51,9 @@ npx aiox-pro status
 npx aiox-pro install
 ```
 
-Isso instala o pacote Pro compatível no seu projeto, priorizando o nome canônico e caindo para o legado quando necessário.
+Isso valida sua licença e instala o artefato canônico `@aiox-squads/pro` no projeto. O cliente não precisa de acesso direto ao pacote privado/restrito no npm.
 
-**Alternativa** (instalação manual):
-
-```bash
-npm install @aiox-fullstack/pro@latest
-```
-
-Depois da instalação manual, rode o bootstrap do conteúdo Pro no projeto:
+**Se você já tem o artefato Pro instalado por outro fluxo autorizado**, rode novamente o bootstrap para revalidar e re-scaffoldar o conteúdo Pro:
 
 ```bash
 npx aiox-pro install

--- a/tests/ide-sync/kimi-transformer.test.js
+++ b/tests/ide-sync/kimi-transformer.test.js
@@ -1,7 +1,7 @@
 /**
  * Tests for the Kimi transformer (kimi-skill format).
  * Covers:
- *  - skillId normalization (no double aios- prefix)
+ *  - skillId normalization (no double aiox- prefix)
  *  - preferredActivationAlias support
  *  - YAML object items in array fields render as **KEY:** value (not [object Object])
  *  - Activation Protocol directive is present
@@ -51,9 +51,10 @@ function buildAgentData(overrides = {}) {
 }
 
 describe('kimi transformer', () => {
-  test('normalizes skill id without double aios- prefix', () => {
-    expect(kimi.getSkillId({ id: 'dev', agent: {} })).toBe('aios-dev');
-    expect(kimi.getSkillId({ id: 'aios-master', agent: {} })).toBe('aios-master');
+  test('normalizes skill id without double aiox- prefix', () => {
+    expect(kimi.getSkillId({ id: 'dev', agent: {} })).toBe('aiox-dev');
+    expect(kimi.getSkillId({ id: 'aiox-master', agent: {} })).toBe('aiox-master');
+    expect(kimi.getSkillId({ id: 'aios-master', agent: {} })).toBe('aiox-master');
   });
 
   test('respects preferredActivationAlias', () => {
@@ -61,7 +62,7 @@ describe('kimi transformer', () => {
       id: 'davi-ribas-community-growth-strategist',
       agent: { preferredActivationAlias: 'davi-ribas' },
     });
-    expect(skillId).toBe('aios-davi-ribas');
+    expect(skillId).toBe('aiox-davi-ribas');
   });
 
   test('respects preferred_activation_alias', () => {
@@ -69,7 +70,7 @@ describe('kimi transformer', () => {
       id: 'davi-ribas-community-growth-strategist',
       agent: { preferred_activation_alias: 'davi-ribas' },
     });
-    expect(skillId).toBe('aios-davi-ribas');
+    expect(skillId).toBe('aiox-davi-ribas');
   });
 
   test('sanitizes skill ids used as directories', () => {
@@ -77,9 +78,9 @@ describe('kimi transformer', () => {
       id: 'dev',
       agent: { preferredActivationAlias: '../team\\Danger Agent' },
     });
-    expect(skillId).toBe('aios-team-danger-agent');
+    expect(skillId).toBe('aiox-team-danger-agent');
     expect(kimi.getDirname({ id: '..', agent: { preferredActivationAlias: '../../' } })).toBe(
-      'aios-agent',
+      'aiox-agent',
     );
   });
 
@@ -165,7 +166,7 @@ describe('kimi transformer', () => {
   test('produces nested layout: <skill-id>/SKILL.md', () => {
     const data = buildAgentData({ id: 'dev' });
     expect(kimi.getFilename(data)).toBe('SKILL.md');
-    expect(kimi.getDirname(data)).toBe('aios-dev');
+    expect(kimi.getDirname(data)).toBe('aiox-dev');
     expect(kimi.format).toBe('kimi-skill');
   });
 

--- a/tests/ide-sync/kimi-transformer.test.js
+++ b/tests/ide-sync/kimi-transformer.test.js
@@ -120,6 +120,14 @@ describe('kimi transformer', () => {
     expect(out).toContain('```text\n💻 Dex (Builder) ready');
   });
 
+  test('does not duplicate AIOX in already-branded titles', () => {
+    const out = kimi.transform(buildAgentData({
+      agent: { title: 'AIOX Master Orchestrator' },
+    }));
+    expect(out).toContain('Activate the AIOX Master Orchestrator agent');
+    expect(out).not.toContain('AIOX AIOX');
+  });
+
   test('supports object-shaped command catalogs', () => {
     const out = kimi.transform(buildAgentData({
       commands: {

--- a/tests/ide-sync/validator.test.js
+++ b/tests/ide-sync/validator.test.js
@@ -142,16 +142,16 @@ describe('validator', () => {
     });
 
     it('should detect orphaned files in nested Kimi skill directories', () => {
-      fs.ensureDirSync(path.join(targetDir, 'aios-dev'));
-      fs.ensureDirSync(path.join(targetDir, 'aios-qa'));
-      fs.writeFileSync(path.join(targetDir, 'aios-dev', 'SKILL.md'), 'content');
-      fs.writeFileSync(path.join(targetDir, 'aios-qa', 'SKILL.md'), 'orphan');
+      fs.ensureDirSync(path.join(targetDir, 'aiox-dev'));
+      fs.ensureDirSync(path.join(targetDir, 'aiox-qa'));
+      fs.writeFileSync(path.join(targetDir, 'aiox-dev', 'SKILL.md'), 'content');
+      fs.writeFileSync(path.join(targetDir, 'aiox-qa', 'SKILL.md'), 'orphan');
 
-      const expected = [{ filename: path.join('aios-dev', 'SKILL.md'), content: 'content' }];
+      const expected = [{ filename: path.join('aiox-dev', 'SKILL.md'), content: 'content' }];
       const result = validateIdeSync(expected, targetDir, {}, 'kimi-skill');
 
       expect(result.orphaned).toHaveLength(1);
-      expect(result.orphaned[0].filename).toBe(path.join('aios-qa', 'SKILL.md'));
+      expect(result.orphaned[0].filename).toBe(path.join('aiox-qa', 'SKILL.md'));
     });
 
     it('should not count redirect files as orphaned', () => {


### PR DESCRIPTION
## Summary
- updates active Pro install/publishing docs for @aiox-squads/core@5.1.17, private @aiox-squads/pro@0.4.2, and signed-artifact acquisition
- switches Kimi IDE skill projection from legacy aios-* directories to canonical aiox-* directories without keeping duplicate generated skills
- keeps Claude legacy slash commands as thin shims and Codex skills canonical as aiox-*

## Validation
- npm test -- --runInBand --forceExit tests/ide-sync/kimi-transformer.test.js tests/ide-sync/validator.test.js tests/integration/codex-skills-sync.test.js tests/unit/codex-skills-validate.test.js
- npm run validate:codex-skills
- npm run validate:claude-integration
- npm run sync:ide:check
- npm run validate:publish
- npm run lint
- npm run typecheck
- npm run validate:manifest
- npm registry check: @aiox-squads/core=5.1.17, @aiox-squads/pro=0.4.2, @aiox-squads/pro status=private

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated system branding from AIOS to AIOX across agent identifiers and activation wording.

* **Documentation**
  * Pro installation and publishing docs revised for authenticated distribution, license validation, and canonical package @aiox-squads/pro; clarified installation and release baseline guidance.

* **Tests**
  * Test suites adjusted to expect AIOX naming and to ensure titles aren’t double-prefixed with AIOX.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/719)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->