### PR TITLE
fix: repair Pro installer npx commands

### DIFF
--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -88,11 +88,9 @@ jobs:
           PRO_SUBMODULE_TOKEN: ${{ secrets.PRO_SUBMODULE_TOKEN }}
         run: |
           echo "::add-mask::$PRO_SUBMODULE_TOKEN"
-          cleanup_pro_submodule_token() {
-            git config --local --unset-all url."https://x-access-token:${PRO_SUBMODULE_TOKEN}@github.com/SynkraAI/".insteadOf || true
-          }
-          trap cleanup_pro_submodule_token EXIT
-          git config --local url."https://x-access-token:${PRO_SUBMODULE_TOKEN}@github.com/SynkraAI/".insteadOf "https://github.com/SynkraAI/"
+          export GIT_CONFIG_COUNT=1
+          export GIT_CONFIG_KEY_0="url.https://x-access-token:${PRO_SUBMODULE_TOKEN}@github.com/SynkraAI/.insteadOf"
+          export GIT_CONFIG_VALUE_0="https://github.com/SynkraAI/"
           git submodule sync --recursive
           git submodule update --init --recursive
 

--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -88,10 +88,13 @@ jobs:
           PRO_SUBMODULE_TOKEN: ${{ secrets.PRO_SUBMODULE_TOKEN }}
         run: |
           echo "::add-mask::$PRO_SUBMODULE_TOKEN"
-          git config --global url."https://x-access-token:${PRO_SUBMODULE_TOKEN}@github.com/SynkraAI/".insteadOf "https://github.com/SynkraAI/"
+          cleanup_pro_submodule_token() {
+            git config --local --unset-all url."https://x-access-token:${PRO_SUBMODULE_TOKEN}@github.com/SynkraAI/".insteadOf || true
+          }
+          trap cleanup_pro_submodule_token EXIT
+          git config --local url."https://x-access-token:${PRO_SUBMODULE_TOKEN}@github.com/SynkraAI/".insteadOf "https://github.com/SynkraAI/"
           git submodule sync --recursive
           git submodule update --init --recursive
-          git config --global --unset-all url."https://x-access-token:${PRO_SUBMODULE_TOKEN}@github.com/SynkraAI/".insteadOf || true
 
       - name: Setup Node.js
         if: steps.token-check.outputs.skip != 'true'

--- a/.github/workflows/pro-integration.yml
+++ b/.github/workflows/pro-integration.yml
@@ -79,8 +79,19 @@ jobs:
         if: steps.token-check.outputs.skip != 'true'
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.PRO_SUBMODULE_TOKEN }}
-          submodules: 'recursive'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          submodules: false
+
+      - name: Initialize Pro submodule
+        if: steps.token-check.outputs.skip != 'true'
+        env:
+          PRO_SUBMODULE_TOKEN: ${{ secrets.PRO_SUBMODULE_TOKEN }}
+        run: |
+          echo "::add-mask::$PRO_SUBMODULE_TOKEN"
+          git config --global url."https://x-access-token:${PRO_SUBMODULE_TOKEN}@github.com/SynkraAI/".insteadOf "https://github.com/SynkraAI/"
+          git submodule sync --recursive
+          git submodule update --init --recursive
+          git config --global --unset-all url."https://x-access-token:${PRO_SUBMODULE_TOKEN}@github.com/SynkraAI/".insteadOf || true
 
       - name: Setup Node.js
         if: steps.token-check.outputs.skip != 'true'

--- a/README.md
+++ b/README.md
@@ -618,8 +618,7 @@ Para saber como acessar, ativar, recuperar conta e validar as squads Pro, consul
 ### Instalação
 
 ```bash
-npx aiox-pro install
-npx aiox-pro setup
+npx -y -p @aiox-squads/core@latest aiox pro setup
 ```
 
 ### Identificação Estável de Máquina (>= 5.0.8)

--- a/docs/guides/aiox-pro-access.md
+++ b/docs/guides/aiox-pro-access.md
@@ -15,8 +15,7 @@ Se o instalador responder que não encontrou acesso para o email, o problema é 
 No projeto onde você quer usar o Pro:
 
 ```bash
-npx aiox-pro install
-npx aiox-pro setup
+npx -y -p @aiox-squads/core@latest aiox pro setup
 ```
 
 O setup guiado oferece dois caminhos:
@@ -29,14 +28,14 @@ Em automação/CI, use variáveis de ambiente:
 ```bash
 export AIOX_PRO_EMAIL="seu-email@exemplo.com"
 export AIOX_PRO_PASSWORD="sua-senha"
-npx aiox-pro setup
+npx -y -p @aiox-squads/core@latest aiox pro setup
 ```
 
 Ou, para chave legada:
 
 ```bash
 export AIOX_PRO_KEY="PRO-XXXX-XXXX-XXXX-XXXX"
-npx aiox-pro setup
+npx -y -p @aiox-squads/core@latest aiox pro setup
 ```
 
 ## Verificar o acesso
@@ -44,9 +43,9 @@ npx aiox-pro setup
 Depois de instalar:
 
 ```bash
-npx aiox-pro status
-npx aiox-pro features
-npx aiox-pro validate
+npx -y -p @aiox-squads/core@latest aiox pro status
+npx -y -p @aiox-squads/core@latest aiox pro features
+npx -y -p @aiox-squads/core@latest aiox pro validate
 ```
 
 Esses comandos verificam a licença, listam recursos Pro disponíveis e forçam uma revalidação online quando necessário.
@@ -58,7 +57,7 @@ As squads Pro são entregues pelo pacote Pro privado e sincronizadas pelo instal
 Se as squads não aparecerem depois de uma instalação bem-sucedida, rode:
 
 ```bash
-npx aiox-pro update
+npx -y -p @aiox-squads/core@latest aiox pro update
 npm run sync:ide
 ```
 
@@ -67,7 +66,7 @@ npm run sync:ide
 Para recuperar senha ou licença:
 
 ```bash
-npx aiox-pro recover
+npx -y @aiox-squads/aiox-pro-cli@latest recover
 ```
 
 Se o email comprado não for reconhecido, ou se a conta existir mas a ativação falhar, o fluxo operacional correto é acionar `@devops` com um destes comandos:
@@ -80,7 +79,7 @@ Se o email comprado não for reconhecido, ou se a conta existir mas a ativação
 ## Erros comuns
 
 - `No AIOX Pro access found for this email.`: o email ainda não tem entitlement Pro ou foi digitado diferente do cadastro.
-- `AIOX Pro is not installed.`: rode `npx aiox-pro install` antes de status/validate.
+- `AIOX Pro is not installed.`: rode `npx -y -p @aiox-squads/core@latest aiox pro setup` antes de status/validate.
 - `Invalid key format`: a chave legada precisa seguir o formato `PRO-XXXX-XXXX-XXXX-XXXX`.
 - Falha em CI sem prompt interativo: defina `AIOX_PRO_EMAIL` + `AIOX_PRO_PASSWORD` ou `AIOX_PRO_KEY`.
 

--- a/docs/guides/pro/install-gate-setup.md
+++ b/docs/guides/pro/install-gate-setup.md
@@ -18,7 +18,7 @@ Comprar Licença -> Validar -> Baixar artefato assinado -> Usar Features Pro
 
 | Pacote | Tipo | Propósito |
 |--------|------|-----------|
-| `aiox-pro` | CLI (1.8 KB) | Comandos de instalação e gerenciamento |
+| `@aiox-squads/aiox-pro-cli` | CLI | Comandos de recuperação e compatibilidade |
 | `@aiox-squads/pro` | Artefato premium | Pacote Pro canônico, entregue ao cliente pelo artifact broker autenticado |
 
 ---
@@ -27,13 +27,13 @@ Comprar Licença -> Validar -> Baixar artefato assinado -> Usar Features Pro
 
 ```bash
 # Instalar AIOX Pro (instala o pacote Pro compatível automaticamente)
-npx aiox-pro install
+npx -y -p @aiox-squads/core@latest aiox pro setup
 
-# Ativar sua licenca
-npx aiox-pro activate --key PRO-XXXX-XXXX-XXXX-XXXX
+# Ativar sua licença por chave legada
+npx -y -p @aiox-squads/core@latest aiox pro activate --key PRO-XXXX-XXXX-XXXX-XXXX
 
-# Verificar ativacao
-npx aiox-pro status
+# Verificar ativação
+npx -y -p @aiox-squads/core@latest aiox pro status
 ```
 
 ---
@@ -48,7 +48,7 @@ npx aiox-pro status
 ### Passo 1: Instalar AIOX Pro
 
 ```bash
-npx aiox-pro install
+npx -y -p @aiox-squads/core@latest aiox pro setup
 ```
 
 Isso valida sua licença e instala o artefato canônico `@aiox-squads/pro` no projeto. O cliente não precisa de acesso direto ao pacote privado/restrito no npm.
@@ -56,7 +56,7 @@ Isso valida sua licença e instala o artefato canônico `@aiox-squads/pro` no pr
 **Se você já tem o artefato Pro instalado por outro fluxo autorizado**, rode novamente o bootstrap para revalidar e re-scaffoldar o conteúdo Pro:
 
 ```bash
-npx aiox-pro install
+npx -y -p @aiox-squads/core@latest aiox pro setup
 ```
 
 ### Passo 2: Ativar Licenca
@@ -64,7 +64,7 @@ npx aiox-pro install
 Apos a compra, voce recebera uma chave no formato `PRO-XXXX-XXXX-XXXX-XXXX`.
 
 ```bash
-npx aiox-pro activate --key PRO-XXXX-XXXX-XXXX-XXXX
+npx -y -p @aiox-squads/core@latest aiox pro activate --key PRO-XXXX-XXXX-XXXX-XXXX
 ```
 
 Esse comando:
@@ -76,10 +76,10 @@ Esse comando:
 
 ```bash
 # Status da licenca
-npx aiox-pro status
+npx -y -p @aiox-squads/core@latest aiox pro status
 
 # Listar features disponiveis
-npx aiox-pro features
+npx -y -p @aiox-squads/core@latest aiox pro features
 ```
 
 ---
@@ -88,13 +88,13 @@ npx aiox-pro features
 
 | Comando | Descricao |
 |---------|-----------|
-| `npx aiox-pro install` | Instala o pacote AIOX Pro compatível no projeto |
-| `npx aiox-pro activate --key KEY` | Ativa uma chave de licenca |
-| `npx aiox-pro status` | Mostra status da licenca atual |
-| `npx aiox-pro features` | Lista todas as features pro e disponibilidade |
-| `npx aiox-pro validate` | Forca revalidacao online da licenca |
-| `npx aiox-pro deactivate` | Desativa a licenca nesta maquina |
-| `npx aiox-pro help` | Mostra todos os comandos |
+| `npx -y -p @aiox-squads/core@latest aiox pro setup` | Instala o pacote AIOX Pro compatível no projeto |
+| `npx -y -p @aiox-squads/core@latest aiox pro activate --key KEY` | Ativa uma chave de licença |
+| `npx -y -p @aiox-squads/core@latest aiox pro status` | Mostra status da licença atual |
+| `npx -y -p @aiox-squads/core@latest aiox pro features` | Lista todas as features Pro e disponibilidade |
+| `npx -y -p @aiox-squads/core@latest aiox pro validate` | Força revalidação online da licença |
+| `npx -y -p @aiox-squads/core@latest aiox pro deactivate` | Desativa a licença nesta máquina |
+| `npx -y -p @aiox-squads/core@latest aiox pro help` | Mostra todos os comandos |
 
 ---
 
@@ -107,9 +107,9 @@ Apos a instalacao e ativacao, o AIOX Pro funciona offline:
 - Verificacao de features 100% local no dia a dia
 
 A internet so e necessaria para:
-1. Ativacao inicial (`npx aiox-pro activate`)
+1. Ativação inicial (`npx -y -p @aiox-squads/core@latest aiox pro activate`)
 2. Revalidacao periodica (automatica a cada 30 dias)
-3. Desativacao (`npx aiox-pro deactivate`)
+3. Desativação (`npx -y -p @aiox-squads/core@latest aiox pro deactivate`)
 
 ---
 
@@ -120,17 +120,17 @@ Para pipelines, instale e ative usando secrets de ambiente:
 **GitHub Actions:**
 ```yaml
 - name: Install AIOX Pro
-  run: npx aiox-pro install
+  run: npx -y -p @aiox-squads/core@latest aiox pro setup
 
 - name: Activate License
-  run: npx aiox-pro activate --key ${{ secrets.AIOX_PRO_LICENSE_KEY }}
+  run: npx -y -p @aiox-squads/core@latest aiox pro activate --key ${{ secrets.AIOX_PRO_LICENSE_KEY }}
 ```
 
 **GitLab CI:**
 ```yaml
 before_script:
-  - npx aiox-pro install
-  - npx aiox-pro activate --key ${AIOX_PRO_LICENSE_KEY}
+  - npx -y -p @aiox-squads/core@latest aiox pro setup
+  - npx -y -p @aiox-squads/core@latest aiox pro activate --key ${AIOX_PRO_LICENSE_KEY}
 ```
 
 ---
@@ -153,7 +153,7 @@ License activation failed: Invalid key format
 License activation failed: Maximum seats exceeded
 ```
 
-- Desative a licenca na outra maquina: `npx aiox-pro deactivate`
+- Desative a licença na outra máquina: `npx -y -p @aiox-squads/core@latest aiox pro deactivate`
 - Ou contate support para aumentar o limite de seats
 
 ### Erro de rede na ativacao
@@ -173,7 +173,7 @@ License activation failed: ECONNREFUSED
 ```
 ┌─────────────────┐     ┌─────────────────────────────────┐     ┌──────────┐
 │  Cliente (CLI)   │────>│  License Server (Vercel)        │────>│ Supabase │
-│  npx aiox-pro    │<────│  aiox-license-server.vercel.app │<────│ Database │
+│  aiox pro        │<────│  aiox-license-server.vercel.app │<────│ Database │
 └─────────────────┘     └─────────────────────────────────┘     └──────────┘
                                                                       │
                                                                       │

--- a/docs/guides/workflows/pro-developer-workflow.md
+++ b/docs/guides/workflows/pro-developer-workflow.md
@@ -119,14 +119,14 @@ ls pro/package.json
 ### Customer Pro Setup
 
 ```bash
-npx aiox-pro setup
+npx -y -p @aiox-squads/core@latest aiox pro setup
 ```
 
 The setup flow uses email/password authentication. Normal customers do not need npm org access or `NPM_TOKEN`.
 
 Troubleshooting:
 
-- `Pro content source not found`: rerun `npx aiox-pro setup` and choose the email login/create-account flow.
+- `Pro content source not found`: rerun `npx -y -p @aiox-squads/core@latest aiox pro setup` and choose the email login/create-account flow.
 - `Pro artifact download failed`: retry after a few minutes; the signed URL is short-lived.
 - `Pro artifact sha256 mismatch`: stop and contact support. Do not scaffold from the downloaded artifact.
 - `No active Pro subscription`: confirm the email used for login matches the Pro purchase.

--- a/docs/stories/epic-pro-13/STORY-PRO-13.5-PRIVATE-PRO-DISTRIBUTION-HARDENING.md
+++ b/docs/stories/epic-pro-13/STORY-PRO-13.5-PRIVATE-PRO-DISTRIBUTION-HARDENING.md
@@ -357,12 +357,18 @@ Implementation should preserve the open-core boundary:
 Expected implementation touchpoints:
 
 - `package.json`
+- `package-lock.json`
 - `bin/utils/validate-publish.js`
 - `packages/installer/src/wizard/pro-setup.js`
 - `packages/installer/src/pro/pro-scaffolder.js`
 - `packages/aiox-pro-cli/bin/aiox-pro.js`
+- `packages/aiox-pro-cli/package.json`
+- `packages/installer/package.json`
 - `packages/installer/src/wizard/i18n.js`
 - `docs/PUBLISHING.md`
+- `README.md`
+- `docs/guides/aiox-pro-access.md`
+- `docs/guides/pro/install-gate-setup.md`
 - `docs/guides/workflows/pro-developer-workflow.md`
 - `tests/pro-wizard.test.js`
 - `tests/installer/pro-setup-auth.test.js`
@@ -456,6 +462,8 @@ Expected implementation touchpoints:
 - 2026-05-09: Published `@aiox-squads/core@5.1.17`; npm `latest` resolves to `5.1.17`; clean install smoke confirms `aiox --version` returns `5.1.17`, the installed public package has zero `pro/` paths, and the installer default points to Pro artifact `0.4.2`.
 - 2026-05-08: GitHub CI follow-up fixed: `tests/pro-wizard.test.js` interactive license-key retry test now stubs the license client instead of reaching the real inline HTTP fallback, removing the Node 18 timeout while preserving prompt/retry assertions.
 - 2026-05-08: Merged `origin/main` and addressed CodeRabbit actionable comments: legacy `npm notice` size-prefixed pack output is normalized before `pro/` checks, `aiox-pro install/setup/wizard -k` is accepted, artifact download has an abort timeout, and artifact-installed Pro package cleanup runs on scaffold failures.
+- 2026-05-12: Student install incident triage confirmed the unscoped `npx aiox-pro recover/install/setup` path is invalid for fresh machines; installer and docs now point recovery to `npx -y @aiox-squads/aiox-pro-cli@latest recover` and setup to `npx -y -p @aiox-squads/core@latest aiox pro setup`.
+- 2026-05-12: `@aiox-squads/installer` bumped to `3.3.2` and `@aiox-squads/aiox-pro-cli` bumped to `0.2.1` so @devops can publish the signed-artifact installer and scoped CLI command fix.
 - Validation evidence:
   - `node -c packages/installer/src/wizard/pro-setup.js && node -c packages/aiox-pro-cli/bin/aiox-pro.js && node -c bin/utils/validate-publish.js`
   - `node -c packages/installer/src/pro/pro-scaffolder.js && node -c pro/license/license-api.js && node -c .aiox-core/cli/commands/pro/index.js`
@@ -463,6 +471,11 @@ Expected implementation touchpoints:
   - `npm run validate:publish`
   - `npm run typecheck`
   - `npm test -- --runInBand tests/pro-wizard.test.js tests/installer/pro-setup-auth.test.js tests/installer/pro-scaffolder.test.js tests/cli/validate-publish.test.js tests/pro/pro-updater.test.js tests/pro-recover.test.js`
+  - `node -c packages/installer/src/wizard/i18n.js && node -c packages/installer/src/wizard/pro-setup.js && node -c packages/installer/src/pro/pro-scaffolder.js && node -c packages/aiox-pro-cli/bin/aiox-pro.js`
+  - `npm test -- --runInBand tests/pro-wizard.test.js tests/installer/pro-setup-auth.test.js tests/pro-recover.test.js tests/installer/pro-scaffolder.test.js`
+  - `npm pack --workspace @aiox-squads/aiox-pro-cli --dry-run --json`
+  - `npm pack --workspace @aiox-squads/installer --dry-run --json`
+  - `npm run validate:publish`
   - `npx jest --runInBand tests/license/license-api.test.js --testPathIgnorePatterns='node_modules'`
   - full smoke matrix saved in `outputs/qa/2026-05-pro-13-5-smoke.json`
   - Pro artifact upload evidence saved in `outputs/qa/2026-05-pro-13-5-pro-artifact-0.4.1.json`

--- a/docs/stories/epic-pro-13/STORY-PRO-13.5-PRIVATE-PRO-DISTRIBUTION-HARDENING.md
+++ b/docs/stories/epic-pro-13/STORY-PRO-13.5-PRIVATE-PRO-DISTRIBUTION-HARDENING.md
@@ -365,6 +365,7 @@ Expected implementation touchpoints:
 - `packages/aiox-pro-cli/package.json`
 - `packages/installer/package.json`
 - `packages/installer/src/wizard/i18n.js`
+- `.github/workflows/pro-integration.yml`
 - `docs/PUBLISHING.md`
 - `README.md`
 - `docs/guides/aiox-pro-access.md`
@@ -464,6 +465,7 @@ Expected implementation touchpoints:
 - 2026-05-08: Merged `origin/main` and addressed CodeRabbit actionable comments: legacy `npm notice` size-prefixed pack output is normalized before `pro/` checks, `aiox-pro install/setup/wizard -k` is accepted, artifact download has an abort timeout, and artifact-installed Pro package cleanup runs on scaffold failures.
 - 2026-05-12: Student install incident triage confirmed the unscoped `npx aiox-pro recover/install/setup` path is invalid for fresh machines; installer and docs now point recovery to `npx -y @aiox-squads/aiox-pro-cli@latest recover` and setup to `npx -y -p @aiox-squads/core@latest aiox pro setup`.
 - 2026-05-12: `@aiox-squads/installer` bumped to `3.3.2` and `@aiox-squads/aiox-pro-cli` bumped to `0.2.1` so @devops can publish the signed-artifact installer and scoped CLI command fix.
+- 2026-05-12: GitHub Pro Integration checkout fixed to use `GITHUB_TOKEN` for the `aiox-core` PR merge ref and reserve `PRO_SUBMODULE_TOKEN` for private Pro submodule initialization only.
 - Validation evidence:
   - `node -c packages/installer/src/wizard/pro-setup.js && node -c packages/aiox-pro-cli/bin/aiox-pro.js && node -c bin/utils/validate-publish.js`
   - `node -c packages/installer/src/pro/pro-scaffolder.js && node -c pro/license/license-api.js && node -c .aiox-core/cli/commands/pro/index.js`
@@ -476,6 +478,7 @@ Expected implementation touchpoints:
   - `npm pack --workspace @aiox-squads/aiox-pro-cli --dry-run --json`
   - `npm pack --workspace @aiox-squads/installer --dry-run --json`
   - `npm run validate:publish`
+  - `npx yaml-lint .github/workflows/pro-integration.yml`
   - `npx jest --runInBand tests/license/license-api.test.js --testPathIgnorePatterns='node_modules'`
   - full smoke matrix saved in `outputs/qa/2026-05-pro-13-5-smoke.json`
   - Pro artifact upload evidence saved in `outputs/qa/2026-05-pro-13-5-pro-artifact-0.4.1.json`

--- a/docs/stories/epic-pro-13/STORY-PRO-13.5-PRIVATE-PRO-DISTRIBUTION-HARDENING.md
+++ b/docs/stories/epic-pro-13/STORY-PRO-13.5-PRIVATE-PRO-DISTRIBUTION-HARDENING.md
@@ -466,6 +466,7 @@ Expected implementation touchpoints:
 - 2026-05-12: Student install incident triage confirmed the unscoped `npx aiox-pro recover/install/setup` path is invalid for fresh machines; installer and docs now point recovery to `npx -y @aiox-squads/aiox-pro-cli@latest recover` and setup to `npx -y -p @aiox-squads/core@latest aiox pro setup`.
 - 2026-05-12: `@aiox-squads/installer` bumped to `3.3.2` and `@aiox-squads/aiox-pro-cli` bumped to `0.2.1` so @devops can publish the signed-artifact installer and scoped CLI command fix.
 - 2026-05-12: GitHub Pro Integration checkout fixed to use `GITHUB_TOKEN` for the `aiox-core` PR merge ref and reserve `PRO_SUBMODULE_TOKEN` for private Pro submodule initialization only.
+- 2026-05-12: CodeRabbit PR follow-up applied: Pro Integration now stores the credentialized submodule URL in repo-local git config with `trap` cleanup, and Pro wizard tests use repository-absolute package imports.
 - Validation evidence:
   - `node -c packages/installer/src/wizard/pro-setup.js && node -c packages/aiox-pro-cli/bin/aiox-pro.js && node -c bin/utils/validate-publish.js`
   - `node -c packages/installer/src/pro/pro-scaffolder.js && node -c pro/license/license-api.js && node -c .aiox-core/cli/commands/pro/index.js`
@@ -479,6 +480,8 @@ Expected implementation touchpoints:
   - `npm pack --workspace @aiox-squads/installer --dry-run --json`
   - `npm run validate:publish`
   - `npx yaml-lint .github/workflows/pro-integration.yml`
+  - `npm test -- --runInBand tests/pro-wizard.test.js`
+  - `npx eslint tests/pro-wizard.test.js`
   - `npx jest --runInBand tests/license/license-api.test.js --testPathIgnorePatterns='node_modules'`
   - full smoke matrix saved in `outputs/qa/2026-05-pro-13-5-smoke.json`
   - Pro artifact upload evidence saved in `outputs/qa/2026-05-pro-13-5-pro-artifact-0.4.1.json`

--- a/docs/stories/epic-pro-13/STORY-PRO-13.5-PRIVATE-PRO-DISTRIBUTION-HARDENING.md
+++ b/docs/stories/epic-pro-13/STORY-PRO-13.5-PRIVATE-PRO-DISTRIBUTION-HARDENING.md
@@ -466,7 +466,7 @@ Expected implementation touchpoints:
 - 2026-05-12: Student install incident triage confirmed the unscoped `npx aiox-pro recover/install/setup` path is invalid for fresh machines; installer and docs now point recovery to `npx -y @aiox-squads/aiox-pro-cli@latest recover` and setup to `npx -y -p @aiox-squads/core@latest aiox pro setup`.
 - 2026-05-12: `@aiox-squads/installer` bumped to `3.3.2` and `@aiox-squads/aiox-pro-cli` bumped to `0.2.1` so @devops can publish the signed-artifact installer and scoped CLI command fix.
 - 2026-05-12: GitHub Pro Integration checkout fixed to use `GITHUB_TOKEN` for the `aiox-core` PR merge ref and reserve `PRO_SUBMODULE_TOKEN` for private Pro submodule initialization only.
-- 2026-05-12: CodeRabbit PR follow-up applied: Pro Integration now stores the credentialized submodule URL in repo-local git config with `trap` cleanup, and Pro wizard tests use repository-absolute package imports.
+- 2026-05-12: CodeRabbit PR follow-up applied: Pro Integration now injects the credentialized submodule URL through process-scoped `GIT_CONFIG_*` environment variables, and Pro wizard tests use repository-absolute package imports.
 - Validation evidence:
   - `node -c packages/installer/src/wizard/pro-setup.js && node -c packages/aiox-pro-cli/bin/aiox-pro.js && node -c bin/utils/validate-publish.js`
   - `node -c packages/installer/src/pro/pro-scaffolder.js && node -c pro/license/license-api.js && node -c .aiox-core/cli/commands/pro/index.js`

--- a/package-lock.json
+++ b/package-lock.json
@@ -14527,10 +14527,10 @@
     },
     "packages/aiox-pro-cli": {
       "name": "@aiox-squads/aiox-pro-cli",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@aiox-squads/installer": "^3.3.0",
+        "@aiox-squads/installer": "^3.3.2",
         "open": "^10.0.0"
       },
       "bin": {
@@ -14542,7 +14542,7 @@
     },
     "packages/installer": {
       "name": "@aiox-squads/installer",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "MIT",
       "dependencies": {
         "@aiox-squads/core": "^5.1.0",

--- a/packages/aiox-pro-cli/bin/aiox-pro.js
+++ b/packages/aiox-pro-cli/bin/aiox-pro.js
@@ -4,7 +4,7 @@
  * aiox-pro CLI
  *
  * Thin CLI wrapper for AIOX Pro setup and delegated commands.
- * Provides a clean npx interface: npx aiox-pro install
+ * Provides a clean npx interface: npx @aiox-squads/aiox-pro-cli install
  *
  * Commands:
  *   install             Run authenticated Pro setup in the current project
@@ -121,7 +121,7 @@ function showHelp() {
 aiox-pro v${VERSION} — AIOX Pro CLI
 
 Usage:
-  npx aiox-pro <command> [options]
+  npx -y @aiox-squads/aiox-pro-cli@latest <command> [options]
 
 Commands:
   install              Run authenticated Pro setup in the current project
@@ -137,14 +137,14 @@ Commands:
   help                 Show this help message
 
 Examples:
-  npx aiox-pro install
-  npx aiox-pro update
-  npx aiox-pro setup
-  npx aiox-pro wizard --key PRO-XXXX-XXXX-XXXX-XXXX
-  npx aiox-pro install -k PRO-XXXX-XXXX-XXXX-XXXX
-  npx aiox-pro activate --key PRO-XXXX-XXXX-XXXX-XXXX
-  npx aiox-pro status
-  npx aiox-pro recover
+  npx -y @aiox-squads/aiox-pro-cli@latest install
+  npx -y @aiox-squads/aiox-pro-cli@latest update
+  npx -y @aiox-squads/aiox-pro-cli@latest setup
+  npx -y @aiox-squads/aiox-pro-cli@latest wizard --key PRO-XXXX-XXXX-XXXX-XXXX
+  npx -y @aiox-squads/aiox-pro-cli@latest install -k PRO-XXXX-XXXX-XXXX-XXXX
+  npx -y @aiox-squads/aiox-pro-cli@latest activate --key PRO-XXXX-XXXX-XXXX-XXXX
+  npx -y @aiox-squads/aiox-pro-cli@latest status
+  npx -y @aiox-squads/aiox-pro-cli@latest recover
 
 Documentation: https://synkra.ai/pro/docs
 `);

--- a/packages/aiox-pro-cli/package.json
+++ b/packages/aiox-pro-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/aiox-pro-cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "CLI for AIOX Pro — install, activate and manage your license",
   "bin": {
     "aiox-pro": "bin/aiox-pro.js"
@@ -10,7 +10,7 @@
     "src/"
   ],
   "dependencies": {
-    "@aiox-squads/installer": "^3.3.0",
+    "@aiox-squads/installer": "^3.3.2",
     "open": "^10.0.0"
   },
   "keywords": [

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/installer",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "AIOX Installer - Automated setup wizard for AIOX projects (greenfield & brownfield)",
   "main": "src/index.js",
   "bin": {

--- a/packages/installer/src/pro/pro-scaffolder.js
+++ b/packages/installer/src/pro/pro-scaffolder.js
@@ -80,7 +80,7 @@ async function scaffoldProContent(targetDir, proSourceDir, options = {}) {
   // Validate pro source exists
   if (!(await fs.pathExists(proSourceDir))) {
     result.errors.push(
-      `Pro package not found at ${proSourceDir}. Run "npx aiox-pro install" or "aiox pro setup" first.`,
+      `Pro package not found at ${proSourceDir}. Run "npx -y -p @aiox-squads/core@latest aiox pro setup" or "aiox pro setup" first.`,
     );
     return result;
   }

--- a/packages/installer/src/wizard/i18n.js
+++ b/packages/installer/src/wizard/i18n.js
@@ -122,7 +122,8 @@ const TRANSLATIONS = {
     proKeyRequired: 'License key is required',
     proKeyInvalid: 'Invalid format. Expected: PRO-XXXX-XXXX-XXXX-XXXX',
     proKeyValidated: 'License validated: {key}',
-    proModuleNotAvailable: 'Pro license module not available. Install AIOX Pro with `npx aiox-pro install`.',
+    proModuleNotAvailable:
+      'Pro license module not available. Run: npx -y -p @aiox-squads/core@latest aiox pro setup',
     proModuleBootstrap: 'Pro license module not found locally. Installing AIOX Pro to bootstrap...',
     proServerUnreachable: 'License server is unreachable. Check your internet connection and try again.',
     proVerifyingAccessShort: 'Verifying access...',
@@ -150,19 +151,21 @@ const TRANSLATIONS = {
     proInstallingPackage: 'Installing AIOX Pro package...',
     proPackageInstalled: 'Pro package installed',
     proPackageInstallFailed: 'Failed to install Pro package',
-    proScaffolderNotAvailable: 'Pro scaffolder not available. Install AIOX Pro with `npx aiox-pro install`.',
+    proScaffolderNotAvailable:
+      'Pro scaffolder not available. Run: npx -y -p @aiox-squads/core@latest aiox pro setup',
     proFilesInstalled: 'Files installed: {count}',
     proSquads: 'Squads: {names}',
     proConfigs: 'Configs: {count} files',
     proFeaturesUnlocked: 'Features unlocked: {count}',
     proInstallComplete: 'AIOX Pro installation complete!',
-    proNeedHelp: 'Need help? Run: npx aiox-pro recover',
+    proNeedHelp: 'Need help? Run: npx -y @aiox-squads/aiox-pro-cli@latest recover',
     proCISetEnv: 'CI mode: Set AIOX_PRO_EMAIL + AIOX_PRO_PASSWORD or AIOX_PRO_KEY environment variables.',
     proVerificationFailed: 'Verification failed: {message}',
     proPackageNotFound: 'Pro content source not found. Re-run Pro setup with email login or contact support.',
     proScaffolderNotFound: 'Pro scaffolder module not found.',
     proNpmInitFailed: 'npm init failed: {message}',
-    proNpmInstallFailed: 'AIOX Pro package install failed: {message}. Try manually: npx aiox-pro install',
+    proNpmInstallFailed:
+      'AIOX Pro package install failed: {message}. Try manually: npx -y -p @aiox-squads/core@latest aiox pro setup',
   },
 
   pt: {
@@ -281,7 +284,8 @@ const TRANSLATIONS = {
     proKeyRequired: 'Chave de licença é obrigatória',
     proKeyInvalid: 'Formato inválido. Esperado: PRO-XXXX-XXXX-XXXX-XXXX',
     proKeyValidated: 'Licença validada: {key}',
-    proModuleNotAvailable: 'Módulo de licença Pro não disponível. Instale o AIOX Pro com `npx aiox-pro install`.',
+    proModuleNotAvailable:
+      'Módulo de licença Pro não disponível. Execute: npx -y -p @aiox-squads/core@latest aiox pro setup',
     proModuleBootstrap: 'Módulo de licença Pro não encontrado localmente. Instalando o AIOX Pro...',
     proServerUnreachable: 'Servidor de licenças inacessível. Verifique sua conexão com a internet e tente novamente.',
     proVerifyingAccessShort: 'Verificando acesso...',
@@ -309,19 +313,21 @@ const TRANSLATIONS = {
     proInstallingPackage: 'Instalando pacote AIOX Pro...',
     proPackageInstalled: 'Pacote Pro instalado',
     proPackageInstallFailed: 'Falha ao instalar pacote Pro',
-    proScaffolderNotAvailable: 'Scaffolder Pro não disponível. Instale o AIOX Pro com `npx aiox-pro install`.',
+    proScaffolderNotAvailable:
+      'Scaffolder Pro não disponível. Execute: npx -y -p @aiox-squads/core@latest aiox pro setup',
     proFilesInstalled: 'Arquivos instalados: {count}',
     proSquads: 'Squads: {names}',
     proConfigs: 'Configs: {count} arquivos',
     proFeaturesUnlocked: 'Recursos desbloqueados: {count}',
     proInstallComplete: 'Instalação do AIOX Pro completa!',
-    proNeedHelp: 'Precisa de ajuda? Execute: npx aiox-pro recover',
+    proNeedHelp: 'Precisa de ajuda? Execute: npx -y @aiox-squads/aiox-pro-cli@latest recover',
     proCISetEnv: 'Modo CI: Defina as variáveis AIOX_PRO_EMAIL + AIOX_PRO_PASSWORD ou AIOX_PRO_KEY.',
     proVerificationFailed: 'Verificação falhou: {message}',
     proPackageNotFound: 'Fonte de conteúdo Pro não encontrada. Rode o setup Pro novamente com login por email ou contate o suporte.',
     proScaffolderNotFound: 'Módulo scaffolder Pro não encontrado.',
     proNpmInitFailed: 'npm init falhou: {message}',
-    proNpmInstallFailed: 'A instalação do pacote AIOX Pro falhou: {message}. Tente manualmente: npx aiox-pro install',
+    proNpmInstallFailed:
+      'A instalação do pacote AIOX Pro falhou: {message}. Tente manualmente: npx -y -p @aiox-squads/core@latest aiox pro setup',
   },
 
   es: {
@@ -439,7 +445,8 @@ const TRANSLATIONS = {
     proKeyRequired: 'Clave de licencia es obligatoria',
     proKeyInvalid: 'Formato inválido. Esperado: PRO-XXXX-XXXX-XXXX-XXXX',
     proKeyValidated: 'Licencia validada: {key}',
-    proModuleNotAvailable: 'Módulo de licencia Pro no disponible. Instale AIOX Pro con `npx aiox-pro install`.',
+    proModuleNotAvailable:
+      'Módulo de licencia Pro no disponible. Ejecute: npx -y -p @aiox-squads/core@latest aiox pro setup',
     proModuleBootstrap: 'Módulo de licencia Pro no encontrado localmente. Instalando AIOX Pro...',
     proServerUnreachable: 'Servidor de licencias inaccesible. Verifique su conexión a internet e intente nuevamente.',
     proVerifyingAccessShort: 'Verificando acceso...',
@@ -467,19 +474,21 @@ const TRANSLATIONS = {
     proInstallingPackage: 'Instalando paquete AIOX Pro...',
     proPackageInstalled: 'Paquete Pro instalado',
     proPackageInstallFailed: 'Error al instalar paquete Pro',
-    proScaffolderNotAvailable: 'Scaffolder Pro no disponible. Instale AIOX Pro con `npx aiox-pro install`.',
+    proScaffolderNotAvailable:
+      'Scaffolder Pro no disponible. Ejecute: npx -y -p @aiox-squads/core@latest aiox pro setup',
     proFilesInstalled: 'Archivos instalados: {count}',
     proSquads: 'Squads: {names}',
     proConfigs: 'Configs: {count} archivos',
     proFeaturesUnlocked: 'Funciones desbloqueadas: {count}',
     proInstallComplete: '¡Instalación de AIOX Pro completa!',
-    proNeedHelp: '¿Necesita ayuda? Ejecute: npx aiox-pro recover',
+    proNeedHelp: '¿Necesita ayuda? Ejecute: npx -y @aiox-squads/aiox-pro-cli@latest recover',
     proCISetEnv: 'Modo CI: Configure las variables AIOX_PRO_EMAIL + AIOX_PRO_PASSWORD o AIOX_PRO_KEY.',
     proVerificationFailed: 'Verificación fallida: {message}',
     proPackageNotFound: 'Fuente de contenido Pro no encontrada. Ejecuta el setup Pro nuevamente con login por email o contacta soporte.',
     proScaffolderNotFound: 'Módulo scaffolder Pro no encontrado.',
     proNpmInitFailed: 'npm init falló: {message}',
-    proNpmInstallFailed: 'La instalación del paquete AIOX Pro falló: {message}. Intente manualmente: npx aiox-pro install',
+    proNpmInstallFailed:
+      'La instalación del paquete AIOX Pro falló: {message}. Intente manualmente: npx -y -p @aiox-squads/core@latest aiox pro setup',
   },
 };
 

--- a/packages/installer/src/wizard/pro-setup.js
+++ b/packages/installer/src/wizard/pro-setup.js
@@ -815,7 +815,7 @@ async function acquireProArtifactSourceDir(targetDir, licenseResult, options = {
     return {
       success: false,
       error:
-        'Authenticated Pro artifact download requires email/password login. Run `npx aiox-pro setup` and choose the login/create-account flow.',
+        'Authenticated Pro artifact download requires email/password login. Run `npx -y -p @aiox-squads/core@latest aiox pro setup` and choose the login/create-account flow.',
     };
   }
 

--- a/tests/pro-recover.test.js
+++ b/tests/pro-recover.test.js
@@ -219,6 +219,8 @@ describe('CLI alias reset-password', () => {
       'utf-8',
     );
     expect(cliSource).toMatch(/reset-password\s+.*alias/i);
+    expect(cliSource).toContain('npx -y @aiox-squads/aiox-pro-cli@latest recover');
+    expect(cliSource).not.toContain('npx aiox-pro recover');
   });
 
   test('install and wizard accept short -k key flag', () => {

--- a/tests/pro-wizard.test.js
+++ b/tests/pro-wizard.test.js
@@ -53,8 +53,8 @@ afterEach(() => {
 
 // ─── Helper to get module ───────────────────────────────────────────────────
 
-const proSetup = require('../packages/installer/src/wizard/pro-setup');
-const wizardI18n = require('../packages/installer/src/wizard/i18n');
+const proSetup = require('packages/installer/src/wizard/pro-setup');
+const wizardI18n = require('packages/installer/src/wizard/i18n');
 
 const CORE_PRO_SETUP_COMMAND = 'npx -y -p @aiox-squads/core@latest aiox pro setup';
 const SCOPED_PRO_RECOVER_COMMAND = 'npx -y @aiox-squads/aiox-pro-cli@latest recover';

--- a/tests/pro-wizard.test.js
+++ b/tests/pro-wizard.test.js
@@ -54,6 +54,10 @@ afterEach(() => {
 // ─── Helper to get module ───────────────────────────────────────────────────
 
 const proSetup = require('../packages/installer/src/wizard/pro-setup');
+const wizardI18n = require('../packages/installer/src/wizard/i18n');
+
+const CORE_PRO_SETUP_COMMAND = 'npx -y -p @aiox-squads/core@latest aiox pro setup';
+const SCOPED_PRO_RECOVER_COMMAND = 'npx -y @aiox-squads/aiox-pro-cli@latest recover';
 
 // ─── maskLicenseKey ──────────────────────────────────────────────────────────
 
@@ -143,6 +147,23 @@ describe('showProHeader', () => {
     const output = console.log.mock.calls.map((c) => String(c[0] || '')).join('\n');
     expect(output).toContain('AIOX Pro');
     expect(output).toContain('Premium');
+  });
+});
+
+// ─── recovery/install command hints ─────────────────────────────────────────
+
+describe('Pro command hints', () => {
+  afterEach(() => {
+    wizardI18n.setLanguage('en');
+  });
+
+  test.each(['en', 'pt', 'es'])('uses published scoped npx commands in %s', (language) => {
+    wizardI18n.setLanguage(language);
+
+    expect(wizardI18n.t('proNeedHelp')).toContain(SCOPED_PRO_RECOVER_COMMAND);
+    expect(wizardI18n.t('proNeedHelp')).not.toContain('npx aiox-pro');
+    expect(wizardI18n.t('proModuleNotAvailable')).toContain(CORE_PRO_SETUP_COMMAND);
+    expect(wizardI18n.t('proScaffolderNotAvailable')).toContain(CORE_PRO_SETUP_COMMAND);
   });
 });
 


### PR DESCRIPTION
## Summary
- replace invalid unscoped `npx aiox-pro` recovery/setup hints with published scoped commands
- bump standalone Pro CLI/installer package versions for a patch publish
- update Pro install docs and regression tests

## Validation
- `npm run lint` PASS
- `npm run typecheck` PASS
- `npm run validate:publish` PASS
- `npm test -- --runInBand tests/pro-wizard.test.js tests/installer/pro-setup-auth.test.js tests/pro-recover.test.js tests/installer/pro-scaffolder.test.js` PASS
- `npm pack --workspace @aiox-squads/aiox-pro-cli --dry-run --json` PASS
- `npm pack --workspace @aiox-squads/installer --dry-run --json` PASS
- full `npm test -- --runInBand` had 2 transient failures outside this patch; both failed suites passed when rerun directly: `tests/unit/squad/squad-generator-blueprint.test.js` and `tests/integration/hooks/precompact-flow.integration.test.js`

## Notes
- Does not include the pre-existing local `pro` submodule pointer change.
- Partner backend compatibility patch is already pushed to `aios-license-server@856dee5`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated AIOX Pro installation, setup, troubleshooting and workflow guides and README to use the new scoped CLI invocation and aligned examples across languages.
* **Chores**
  * Bumped Pro CLI and installer package versions.
  * Updated installer/wizard help and error messages to reference the new setup commands.
* **CI**
  * Hardened Pro integration workflow: checkout/auth flow updated and a conditional step added to initialize the private Pro submodule during automated runs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/726)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->