### PR TITLE
chore: bump core for Pro installer release [Story PRO-13.5]

### DIFF
--- a/docs/stories/epic-pro-13/STORY-PRO-13.5-PRIVATE-PRO-DISTRIBUTION-HARDENING.md
+++ b/docs/stories/epic-pro-13/STORY-PRO-13.5-PRIVATE-PRO-DISTRIBUTION-HARDENING.md
@@ -467,6 +467,7 @@ Expected implementation touchpoints:
 - 2026-05-12: `@aiox-squads/installer` bumped to `3.3.2` and `@aiox-squads/aiox-pro-cli` bumped to `0.2.1` so @devops can publish the signed-artifact installer and scoped CLI command fix.
 - 2026-05-12: GitHub Pro Integration checkout fixed to use `GITHUB_TOKEN` for the `aiox-core` PR merge ref and reserve `PRO_SUBMODULE_TOKEN` for private Pro submodule initialization only.
 - 2026-05-12: CodeRabbit PR follow-up applied: Pro Integration now injects the credentialized submodule URL through process-scoped `GIT_CONFIG_*` environment variables, and Pro wizard tests use repository-absolute package imports.
+- 2026-05-12: Release patch target advanced to `@aiox-squads/core@5.2.2` because npm latest is already `5.2.1`; the merged installer command fix must not be published from a regressive root package version.
 - Validation evidence:
   - `node -c packages/installer/src/wizard/pro-setup.js && node -c packages/aiox-pro-cli/bin/aiox-pro.js && node -c bin/utils/validate-publish.js`
   - `node -c packages/installer/src/pro/pro-scaffolder.js && node -c pro/license/license-api.js && node -c .aiox-core/cli/commands/pro/index.js`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.1.17",
+  "version": "5.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aiox-squads/core",
-      "version": "5.1.17",
+      "version": "5.2.2",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.1.17",
+  "version": "5.2.2",
   "description": "Synkra AIOX: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aiox": "bin/aiox.js",


### PR DESCRIPTION
## Summary\n- bump @aiox-squads/core to 5.2.2 so the Pro installer command fix can publish above npm latest 5.2.1\n- record the release-version rationale in PRO-13.5\n\n## Validation\n- npm ci\n- npm run validate:publish\n- npm pack --dry-run --json\n- npm pack --workspace @aiox-squads/installer --dry-run --json\n- npm pack --workspace @aiox-squads/aiox-pro-cli --dry-run --json\n- npx eslint tests/pro-wizard.test.js\n- npm test -- --runInBand tests/pro-wizard.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Package version bumped to 5.2.2.
  * Release documentation updated to reflect the current version target and ensure consistency with recent fixes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/727)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->