### PR TITLE
fix: allow Pro greenfield validation without package manifest

### DIFF
--- a/compat/aiox-core/package.json
+++ b/compat/aiox-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiox-core",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "Compatibility wrapper for @aiox-squads/core.",
   "license": "MIT",
   "bin": {
@@ -15,7 +15,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@aiox-squads/core": "5.2.2"
+    "@aiox-squads/core": "5.2.3"
   },
   "engines": {
     "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aiox-squads/core",
-      "version": "5.2.2",
+      "version": "5.2.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -14542,7 +14542,7 @@
     },
     "packages/installer": {
       "name": "@aiox-squads/installer",
-      "version": "3.3.2",
+      "version": "3.3.3",
       "license": "MIT",
       "dependencies": {
         "@aiox-squads/core": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "Synkra AIOX: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aiox": "bin/aiox.js",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/installer",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "description": "AIOX Installer - Automated setup wizard for AIOX projects (greenfield & brownfield)",
   "main": "src/index.js",
   "bin": {

--- a/packages/installer/src/wizard/validation/validators/dependency-validator.js
+++ b/packages/installer/src/wizard/validation/validators/dependency-validator.js
@@ -46,10 +46,15 @@ async function validateDependencies(depsContext = {}) {
     // Check node_modules existence
     const nodeModulesPath = path.join(projectRoot, 'node_modules');
     const packageJsonPath = path.join(projectRoot, 'package.json');
+    const packageJsonExists = fs.existsSync(packageJsonPath);
+    const isGreenfieldNoPackageJson =
+      depsContext.skipped === true &&
+      depsContext.reason === 'no-package-json' &&
+      !packageJsonExists;
 
     // For greenfield projects, check if package.json has dependencies
     let hasDependencies = false;
-    if (fs.existsSync(packageJsonPath)) {
+    if (packageJsonExists) {
       try {
         const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
         hasDependencies = !!(
@@ -92,14 +97,31 @@ async function validateDependencies(depsContext = {}) {
       message: 'Directory exists',
     });
 
-    // Validate package.json integrity
-    await validatePackageJson(results, projectRoot);
+    if (isGreenfieldNoPackageJson) {
+      results.checks.push({
+        component: 'Package Manifest',
+        file: packageJsonPath,
+        status: 'skipped',
+        message: 'No package.json found (greenfield project)',
+      });
+    } else {
+      // Validate package.json integrity
+      await validatePackageJson(results, projectRoot);
+    }
 
     // Validate any explicit dependency contract supplied by the caller.
     await checkRequiredDependencies(results, projectRoot, depsContext.requiredDependencies);
 
-    // Run npm audit (non-blocking - warnings only)
-    await runSecurityAudit(results, depsContext.packageManager, projectRoot);
+    if (isGreenfieldNoPackageJson) {
+      results.checks.push({
+        component: 'Security Audit',
+        status: 'skipped',
+        message: 'No package.json found (greenfield project)',
+      });
+    } else {
+      // Run npm audit (non-blocking - warnings only)
+      await runSecurityAudit(results, depsContext.packageManager, projectRoot);
+    }
 
     // Count installed packages
     await countInstalledPackages(results, nodeModulesPath);

--- a/tests/unit/wizard/validation/dependency-validator.test.js
+++ b/tests/unit/wizard/validation/dependency-validator.test.js
@@ -143,6 +143,45 @@ describe('Dependency Validator', () => {
     );
   });
 
+  it('does not fail greenfield validation when Pro creates node_modules without package.json', async () => {
+    const projectPath = '/tmp/aiox-greenfield-pro';
+
+    fs.existsSync.mockImplementation((targetPath) => (
+      samePath(targetPath, projectFile(projectPath, 'node_modules'))
+    ));
+    fs.readdirSync.mockReturnValue(['@aiox-squads', '.bin']);
+
+    const result = await validateDependencies({
+      success: true,
+      skipped: true,
+      reason: 'no-package-json',
+      packageManager: 'npm',
+      projectPath,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.errors).toEqual([]);
+    expect(result.checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          component: 'Dependencies',
+          status: 'success',
+        }),
+        expect.objectContaining({
+          component: 'Package Manifest',
+          status: 'skipped',
+          message: 'No package.json found (greenfield project)',
+        }),
+        expect.objectContaining({
+          component: 'Security Audit',
+          status: 'skipped',
+          message: 'No package.json found (greenfield project)',
+        }),
+      ]),
+    );
+    expect(childProcess.exec).not.toHaveBeenCalled();
+  });
+
   it('fails when package.json declares dependencies but node_modules is missing', async () => {
     const projectPath = '/tmp/aiox-broken';
 


### PR DESCRIPTION
## Summary\n- Treat greenfield installs that intentionally skipped package.json as valid even when Pro creates node_modules\n- Skip package manifest and security audit checks in that specific no-package.json greenfield path\n- Bump @aiox-squads/core/aiox-core to 5.2.3 and @aiox-squads/installer to 3.3.3 for publication\n\n## Validation\n- npm test -- tests/installer/pro-setup-auth.test.js tests/unit/wizard/validation/dependency-validator.test.js --runInBand\n- npm run lint -- --no-cache packages/installer/src/wizard/validation/validators/dependency-validator.js tests/unit/wizard/validation/dependency-validator.test.js\n- npm run validate:publish\n- Local guided Pro install with real account: Pro activated, 2538 files installed, Overall Status: All checks passed\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installer validation to properly handle new projects without existing package configuration files, enabling successful setup without validation errors.

* **Chores**
  * Updated package versions across core packages.

* **Tests**
  * Added test coverage for greenfield project validation scenarios without package configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/733)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->