### PR TITLE
fix: avoid Windows npm spawn failure in Pro install

### DIFF
--- a/compat/aiox-core/package.json
+++ b/compat/aiox-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiox-core",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "description": "Compatibility wrapper for @aiox-squads/core.",
   "license": "MIT",
   "bin": {
@@ -15,7 +15,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@aiox-squads/core": "5.2.3"
+    "@aiox-squads/core": "5.2.4"
   },
   "engines": {
     "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aiox-squads/core",
-      "version": "5.2.3",
+      "version": "5.2.4",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -14542,7 +14542,7 @@
     },
     "packages/installer": {
       "name": "@aiox-squads/installer",
-      "version": "3.3.3",
+      "version": "3.3.4",
       "license": "MIT",
       "dependencies": {
         "@aiox-squads/core": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.2.3",
+  "version": "5.2.4",
   "description": "Synkra AIOX: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aiox": "bin/aiox.js",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/installer",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "description": "AIOX Installer - Automated setup wizard for AIOX projects (greenfield & brownfield)",
   "main": "src/index.js",
   "bin": {

--- a/packages/installer/src/wizard/pro-setup.js
+++ b/packages/installer/src/wizard/pro-setup.js
@@ -28,6 +28,46 @@ const { t, tf } = require('./i18n');
 
 const execFileAsync = promisify(execFile);
 
+function stripWrappingQuotes(value) {
+  return String(value || '').trim().replace(/^"(.*)"$/, '$1');
+}
+
+function resolveNpmInvocation(options = {}) {
+  const platform = options.platform || process.platform;
+  const env = options.env || process.env;
+  const execPath = options.execPath || process.execPath;
+  const fileExists = options.fileExists || fs.existsSync;
+  const npmExecPath = stripWrappingQuotes(env.npm_execpath);
+
+  if (npmExecPath && /\.js$/i.test(npmExecPath) && fileExists(npmExecPath)) {
+    return {
+      command: execPath,
+      prefixArgs: [npmExecPath],
+      execOptions: {},
+    };
+  }
+
+  return {
+    command: platform === 'win32' ? 'npm.cmd' : 'npm',
+    prefixArgs: [],
+    execOptions: platform === 'win32' ? { shell: true } : {},
+  };
+}
+
+async function runNpm(args, options = {}) {
+  const invocation = resolveNpmInvocation();
+
+  return execFileAsync(
+    invocation.command,
+    [...invocation.prefixArgs, ...args],
+    {
+      ...options,
+      ...invocation.execOptions,
+      windowsHide: true,
+    },
+  );
+}
+
 /**
  * Gold color for Pro branding.
  * Falls back gracefully if chalk hex is unavailable.
@@ -749,10 +789,8 @@ async function extractProArtifactToTemp(artifactPath, tempRoot) {
     dependencies: {},
   });
 
-  const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm';
   try {
-    await execFileAsync(
-      npmBin,
+    await runNpm(
       ['install', artifactPath, '--ignore-scripts', '--no-audit', '--no-fund', '--no-save', '--silent'],
       {
         cwd: installRoot,
@@ -776,10 +814,8 @@ async function extractProArtifactToTemp(artifactPath, tempRoot) {
 async function installProArtifactIntoTarget(artifactPath, targetDir) {
   await fs.ensureDir(targetDir);
 
-  const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm';
   try {
-    await execFileAsync(
-      npmBin,
+    await runNpm(
       [
         'install',
         artifactPath,
@@ -2163,6 +2199,7 @@ module.exports = {
     generateMachineId,
     persistLicenseCache,
     resolveLicenseServerUrl,
+    resolveNpmInvocation,
     ensureKeyValidationParity,
     acquireProArtifactSourceDir,
     downloadArtifactFile,

--- a/tests/installer/pro-setup-auth.test.js
+++ b/tests/installer/pro-setup-auth.test.js
@@ -169,6 +169,53 @@ describe('pro-setup backward compatibility (AC-7)', () => {
   });
 });
 
+describe('pro-setup npm invocation', () => {
+  it('uses node + npm-cli.js on Windows when npm_execpath is available', () => {
+    const invocation = proSetup._testing.resolveNpmInvocation({
+      platform: 'win32',
+      execPath: 'C:\\Program Files\\nodejs\\node.exe',
+      env: {
+        npm_execpath: 'C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js',
+      },
+      fileExists: () => true,
+    });
+
+    expect(invocation).toEqual({
+      command: 'C:\\Program Files\\nodejs\\node.exe',
+      prefixArgs: ['C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js'],
+      execOptions: {},
+    });
+  });
+
+  it('falls back to shell execution for npm.cmd on Windows', () => {
+    const invocation = proSetup._testing.resolveNpmInvocation({
+      platform: 'win32',
+      env: {},
+      fileExists: () => false,
+    });
+
+    expect(invocation).toEqual({
+      command: 'npm.cmd',
+      prefixArgs: [],
+      execOptions: { shell: true },
+    });
+  });
+
+  it('uses npm directly on POSIX platforms', () => {
+    const invocation = proSetup._testing.resolveNpmInvocation({
+      platform: 'darwin',
+      env: {},
+      fileExists: () => false,
+    });
+
+    expect(invocation).toEqual({
+      command: 'npm',
+      prefixArgs: [],
+      execOptions: {},
+    });
+  });
+});
+
 describe('pro-setup interactive email fallback', () => {
   afterEach(() => {
     proSetup._testing.loadLicenseApi = undefined;


### PR DESCRIPTION
## Summary\n- fix Pro artifact extraction/install npm invocation on Windows by preferring node + npm-cli.js\n- fall back to shell execution for npm.cmd when npm_execpath is unavailable\n- bump @aiox-squads/core/aiox-core to 5.2.4 and installer to 3.3.4\n\n## Validation\n- npm test -- tests/installer/pro-setup-auth.test.js --runInBand\n- npm run lint -- --no-cache packages/installer/src/wizard/pro-setup.js tests/installer/pro-setup-auth.test.js\n- npm test -- tests/installer/pro-setup-auth.test.js tests/unit/wizard/validation/dependency-validator.test.js --runInBand\n- npm run validate:publish

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package versions for core (5.2.3 → 5.2.4) and installer (3.3.3 → 3.3.4)

* **Bug Fixes**
  * Improved pro setup installation reliability across different platforms

* **Tests**
  * Added test coverage for npm invocation scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/735)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->