### PR TITLE
test: tolerate Windows timing jitter

### DIFF
--- a/tests/synapse/bridge/uap-session-bridge.test.js
+++ b/tests/synapse/bridge/uap-session-bridge.test.js
@@ -547,8 +547,9 @@ describe('UAP Session Bridge — Timing Budget', () => {
     // Clean up skip tmpdir
     fs.rmSync(skipCtx.projectRoot, { recursive: true, force: true });
 
+    const timingJitterTolerance = process.platform === 'win32' ? 5 : 1;
     expect(skipMetrics.loaders.synapseSession.duration).toBeLessThanOrEqual(
-      writeMetrics.loaders.synapseSession.duration + 1, // +1ms tolerance
+      writeMetrics.loaders.synapseSession.duration + timingJitterTolerance,
     );
   });
 });


### PR DESCRIPTION
## Summary
- relax Windows-only jitter tolerance in the UAP session bridge timing comparison
- keeps the non-Windows tolerance unchanged

## Validation
- npm test -- tests/synapse/bridge/uap-session-bridge.test.js --runInBand
- npm run lint -- --no-cache tests/synapse/bridge/uap-session-bridge.test.js
- git diff --check

## Context
Follow-up to the Windows Node 18 CI failure after PR #735. The failed assertion was a millisecond-level timing flake: expected less than or equal to 2ms, received 3ms. It is not related to the Pro installer hotfix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated platform-specific timing tolerances in session bridge tests to improve test reliability across different operating systems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/736)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->