### PR TITLE
chore(release): bump to 5.2.6 — Pro installer workspace hijack hotfix

### DIFF
--- a/.aiox-core/data/entity-registry.yaml
+++ b/.aiox-core/data/entity-registry.yaml
@@ -1,7 +1,7 @@
 metadata:
   version: 1.0.0
-  lastUpdated: '2026-05-10T16:26:31.587Z'
-  entityCount: 757
+  lastUpdated: '2026-05-17T10:02:45.444Z'
+  entityCount: 815
   checksumAlgorithm: sha256
   resolutionRate: 100
 entities:
@@ -28,7 +28,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:badc8a9859cb313e908d4ea0f4c4d7bc1be723214e38f26d55c366689fe5e3f0
-      lastVerified: '2026-03-11T00:48:55.812Z'
+      lastVerified: '2026-05-17T10:02:45.082Z'
     advanced-elicitation:
       path: .aiox-core/development/tasks/advanced-elicitation.md
       layer: L2
@@ -53,7 +53,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:897f36c94fc1e4e40c9e5728f3c7780515b40742d6a99366a5fdb5df109f6636
-      lastVerified: '2026-03-11T00:48:55.814Z'
+      lastVerified: '2026-05-17T10:02:45.084Z'
     analyst-facilitate-brainstorming:
       path: .aiox-core/development/tasks/analyst-facilitate-brainstorming.md
       layer: L2
@@ -80,7 +80,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:85bef3ab05f3e3422ff450e7d39f04f49e59fa981df2f126eeb0f8395e4a1625
-      lastVerified: '2026-03-11T00:48:55.814Z'
+      lastVerified: '2026-05-17T10:02:45.084Z'
     analyze-brownfield:
       path: .aiox-core/development/tasks/analyze-brownfield.md
       layer: L2
@@ -108,7 +108,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0d1c35b32db5ae058ee29c125b1a7ce6d39bfd37d82711aad3abe780ef99cef3
-      lastVerified: '2026-03-11T00:48:55.814Z'
+      lastVerified: '2026-05-17T10:02:45.085Z'
     analyze-cross-artifact:
       path: .aiox-core/development/tasks/analyze-cross-artifact.md
       layer: L2
@@ -134,7 +134,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ce335d997ddd6438c298b18386ab72414959f24e6176736f12ee26ea5764432b
-      lastVerified: '2026-03-11T00:48:55.815Z'
+      lastVerified: '2026-05-17T10:02:45.086Z'
     analyze-framework:
       path: .aiox-core/development/tasks/analyze-framework.md
       layer: L2
@@ -163,7 +163,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6f3bb2f12ad42600cb38d6a1677608772bf8cb63a1e5971c987400ebf3e1d685
-      lastVerified: '2026-03-11T00:48:55.815Z'
+      lastVerified: '2026-05-17T10:02:45.087Z'
     analyze-performance:
       path: .aiox-core/development/tasks/analyze-performance.md
       layer: L2
@@ -187,7 +187,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c3a78a8794d2edfbf44525e1bbe286bb957dcc0fbbee5d9b8a7876a8d0cdce4
-      lastVerified: '2026-03-11T00:48:55.815Z'
+      lastVerified: '2026-05-17T10:02:45.087Z'
     analyze-project-structure:
       path: .aiox-core/development/tasks/analyze-project-structure.md
       layer: L2
@@ -219,7 +219,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0f6acf877e5fa93796418576c239ea300226c4fb6fe28639239da8cc8225a57e
-      lastVerified: '2026-03-11T00:48:55.815Z'
+      lastVerified: '2026-05-17T10:02:45.087Z'
     apply-qa-fixes:
       path: .aiox-core/development/tasks/apply-qa-fixes.md
       layer: L2
@@ -245,7 +245,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:614731439a27c15ecc02d84abf3d320c2cf18f016075c222ca1d7bfda12d6625
-      lastVerified: '2026-03-11T00:48:55.816Z'
+      lastVerified: '2026-05-17T10:02:45.088Z'
     architect-analyze-impact:
       path: .aiox-core/development/tasks/architect-analyze-impact.md
       layer: L2
@@ -276,7 +276,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:251d2c073b917f0285672568f074ec0c77372e110e234b42f043c605e438d9ee
-      lastVerified: '2026-03-11T00:48:55.816Z'
+      lastVerified: '2026-05-17T10:02:45.089Z'
     audit-codebase:
       path: .aiox-core/development/tasks/audit-codebase.md
       layer: L2
@@ -301,7 +301,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:11a136d6e7cd6d5238a06a9298eff28d381799667612aa7668d923cc40c74ff7
-      lastVerified: '2026-03-11T00:48:55.816Z'
+      lastVerified: '2026-05-17T10:02:45.090Z'
     audit-tailwind-config:
       path: .aiox-core/development/tasks/audit-tailwind-config.md
       layer: L2
@@ -326,7 +326,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6a555a7b86f2b447b0393b9ac1a7f2be84f5705c293259c83c082b25ec849fbb
-      lastVerified: '2026-03-11T00:48:55.816Z'
+      lastVerified: '2026-05-17T10:02:45.090Z'
     audit-utilities:
       path: .aiox-core/development/tasks/audit-utilities.md
       layer: L2
@@ -351,7 +351,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1a1e4cb6be031f144d223321c6977a88108843b05b933143784ce8340198acd3
-      lastVerified: '2026-03-11T00:48:55.816Z'
+      lastVerified: '2026-05-17T10:02:45.090Z'
     bootstrap-shadcn-library:
       path: .aiox-core/development/tasks/bootstrap-shadcn-library.md
       layer: L2
@@ -377,7 +377,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3fe06f13e2ff550bab6b74cf2105f5902800e568fd7afc982dd3987c5579e769
-      lastVerified: '2026-03-11T00:48:55.817Z'
+      lastVerified: '2026-05-17T10:02:45.091Z'
     brownfield-create-epic:
       path: .aiox-core/development/tasks/brownfield-create-epic.md
       layer: L2
@@ -416,7 +416,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:554a403bdd14fdc0aa6236818d47b273e275f73b39971c3918e74978e28d9b68
-      lastVerified: '2026-03-11T00:48:55.817Z'
+      lastVerified: '2026-05-17T10:02:45.092Z'
     brownfield-create-story:
       path: .aiox-core/development/tasks/brownfield-create-story.md
       layer: L2
@@ -446,7 +446,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:29ba1fe81cda46bdece3e698cc797370c63df56903e38ca71523352b98e08dd2
-      lastVerified: '2026-03-11T00:48:55.817Z'
+      lastVerified: '2026-05-17T10:02:45.092Z'
     build-autonomous:
       path: .aiox-core/development/tasks/build-autonomous.md
       layer: L2
@@ -472,7 +472,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:90ea4c17a6a131082df1546fbe1f30817b951bba7a8b9a41a371578ce8034b39
-      lastVerified: '2026-03-11T00:48:55.817Z'
+      lastVerified: '2026-05-17T10:02:45.092Z'
     build-component:
       path: .aiox-core/development/tasks/build-component.md
       layer: L2
@@ -497,7 +497,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:026adaf174a29692f4eef293a94f5909de9c79d25d7ed226740db1708cde4389
-      lastVerified: '2026-03-11T00:48:55.817Z'
+      lastVerified: '2026-05-17T10:02:45.093Z'
     build-resume:
       path: .aiox-core/development/tasks/build-resume.md
       layer: L2
@@ -520,7 +520,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:920b1faa39d021fd7c0013b5d2ac4f66ac6de844723821b65dfaceba41d37885
-      lastVerified: '2026-03-11T00:48:55.817Z'
+      lastVerified: '2026-05-17T10:02:45.094Z'
     build-status:
       path: .aiox-core/development/tasks/build-status.md
       layer: L2
@@ -542,7 +542,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:47a5f95ab59ff99532adf442700f4b949e32bd5bd2131998d8f271327108e4e1
-      lastVerified: '2026-03-11T00:48:55.817Z'
+      lastVerified: '2026-05-17T10:02:45.094Z'
     build:
       path: .aiox-core/development/tasks/build.md
       layer: L2
@@ -564,7 +564,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2f09d24cc0e5f9e4cf527fcb5341461a7ac30fcadf82e4f78f98be161e0ea4ec
-      lastVerified: '2026-03-11T00:48:55.817Z'
+      lastVerified: '2026-05-17T10:02:45.094Z'
     calculate-roi:
       path: .aiox-core/development/tasks/calculate-roi.md
       layer: L2
@@ -590,7 +590,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa8c2073ee845a42b30eea44e2452898ebb8e5d4fceb207c9b42984f817732cc
-      lastVerified: '2026-03-11T00:48:55.818Z'
+      lastVerified: '2026-05-17T10:02:45.095Z'
     check-docs-links:
       path: .aiox-core/development/tasks/check-docs-links.md
       layer: L2
@@ -612,7 +612,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a7e1400d894777caa607486ff78b77ea454e4ace1c16d54308533ecc7f2c015
-      lastVerified: '2026-03-11T00:48:55.818Z'
+      lastVerified: '2026-05-17T10:02:45.095Z'
     ci-cd-configuration:
       path: .aiox-core/development/tasks/ci-cd-configuration.md
       layer: L2
@@ -640,7 +640,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:115634392c1838eac80c7a5b760f43f96c92ad69c7a88d9932debed64e5ad23a
-      lastVerified: '2026-03-11T00:48:55.818Z'
+      lastVerified: '2026-05-17T10:02:45.096Z'
     cleanup-utilities:
       path: .aiox-core/development/tasks/cleanup-utilities.md
       layer: L2
@@ -668,7 +668,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8945dee3b0ea9afcab4aba1f4651be00d79ae236710a36821cf04238bee3890f
-      lastVerified: '2026-03-11T00:48:55.818Z'
+      lastVerified: '2026-05-17T10:02:45.096Z'
     cleanup-worktrees:
       path: .aiox-core/development/tasks/cleanup-worktrees.md
       layer: L2
@@ -691,7 +691,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:10d9fab42ba133a03f76094829ab467d2ef53b80bcc3de39245805679cedfbbd
-      lastVerified: '2026-03-11T00:48:55.818Z'
+      lastVerified: '2026-05-17T10:02:45.096Z'
     collaborative-edit:
       path: .aiox-core/development/tasks/collaborative-edit.md
       layer: L2
@@ -719,7 +719,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9295eae7a7c8731ff06131f76dcd695d30641d714a64c164989b98d8631532d8
-      lastVerified: '2026-03-11T00:48:55.818Z'
+      lastVerified: '2026-05-17T10:02:45.097Z'
     compose-molecule:
       path: .aiox-core/development/tasks/compose-molecule.md
       layer: L2
@@ -746,7 +746,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:596b8a8e1a6068e02aceeb9d1164d64fe8686b492ff39d25ec8dcd67ad1f9c09
-      lastVerified: '2026-03-11T00:48:55.818Z'
+      lastVerified: '2026-05-17T10:02:45.098Z'
     consolidate-patterns:
       path: .aiox-core/development/tasks/consolidate-patterns.md
       layer: L2
@@ -772,7 +772,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c45d9337c0aac9fcea56e216e172234a4f09a09f45db311f013973f9d5efc05a
-      lastVerified: '2026-03-11T00:48:55.819Z'
+      lastVerified: '2026-05-17T10:02:45.098Z'
     correct-course:
       path: .aiox-core/development/tasks/correct-course.md
       layer: L2
@@ -800,7 +800,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec55430908fb25c99bd0ae0bbf8aad6b1aff36306488abb07cf6e8f2e03306cc
-      lastVerified: '2026-03-11T00:48:55.819Z'
+      lastVerified: '2026-05-17T10:02:45.099Z'
     create-agent:
       path: .aiox-core/development/tasks/create-agent.md
       layer: L2
@@ -824,7 +824,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:538954ecee93c0b4467d4dc00ce4315b2fac838ad298a11c6bc4e45366430e17
-      lastVerified: '2026-03-11T00:48:55.820Z'
+      lastVerified: '2026-05-17T10:02:45.101Z'
     create-brownfield-story:
       path: .aiox-core/development/tasks/create-brownfield-story.md
       layer: L2
@@ -854,7 +854,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:88dc7949dbfde53773135650a6864c2b7a36cbfe93239cee8edf8a9c082b0fcf
-      lastVerified: '2026-03-11T00:48:55.820Z'
+      lastVerified: '2026-05-17T10:02:45.102Z'
     create-deep-research-prompt:
       path: .aiox-core/development/tasks/create-deep-research-prompt.md
       layer: L2
@@ -889,7 +889,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c432fad72d00722db2525b3b68555ab02bb38e80f85e55b7354b389771ed943b
-      lastVerified: '2026-03-11T00:48:55.820Z'
+      lastVerified: '2026-05-17T10:02:45.102Z'
     create-doc:
       path: .aiox-core/development/tasks/create-doc.md
       layer: L2
@@ -924,7 +924,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:078b2e5ac900f5d48fc82792198e59108a32891c77ed18aa062d87db442d155e
-      lastVerified: '2026-03-11T00:48:55.821Z'
+      lastVerified: '2026-05-17T10:02:45.103Z'
     create-next-story:
       path: .aiox-core/development/tasks/create-next-story.md
       layer: L2
@@ -938,7 +938,6 @@ entities:
         - story
         - task
       usedBy:
-        - aiox-master
         - sm
       dependencies:
         - po-master-checklist
@@ -967,7 +966,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0705fe3750d229b47fe194109d3ec398cb90adfdfe1a6d7cf80ca8bdf73b6ad0
-      lastVerified: '2026-03-11T00:48:55.821Z'
+      lastVerified: '2026-05-17T10:02:45.103Z'
     create-service:
       path: .aiox-core/development/tasks/create-service.md
       layer: L2
@@ -992,7 +991,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dd9467f3e646ca4058f0cc524f99ae102c91750fa70f412f41f50f89d8f4b4e9
-      lastVerified: '2026-03-11T00:48:55.821Z'
+      lastVerified: '2026-05-17T10:02:45.104Z'
     create-suite:
       path: .aiox-core/development/tasks/create-suite.md
       layer: L2
@@ -1022,7 +1021,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0c5e7fa10bcb37d571ae3003f79fb6f98f46ed26c35234912b23b13d47091cb1
-      lastVerified: '2026-03-11T00:48:55.821Z'
+      lastVerified: '2026-05-17T10:02:45.104Z'
     create-task:
       path: .aiox-core/development/tasks/create-task.md
       layer: L2
@@ -1051,7 +1050,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2adfe4c3c8b73fbe3998444e24af796542342265b102ce52d3fc85d69d5e12af
-      lastVerified: '2026-03-11T00:48:55.821Z'
+      lastVerified: '2026-05-17T10:02:45.104Z'
     create-workflow:
       path: .aiox-core/development/tasks/create-workflow.md
       layer: L2
@@ -1080,7 +1079,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:76f47a9fa54b9690a10ddf4544c96f8d732c658550fd8487f9defd2339b8e222
-      lastVerified: '2026-03-11T00:48:55.821Z'
+      lastVerified: '2026-05-17T10:02:45.105Z'
     create-worktree:
       path: .aiox-core/development/tasks/create-worktree.md
       layer: L2
@@ -1111,7 +1110,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:143b9bdf87a4eed0faac612e137965483dec1224a7579399a68b68b6bc0689b7
-      lastVerified: '2026-03-11T00:48:55.822Z'
+      lastVerified: '2026-05-17T10:02:45.105Z'
     db-analyze-hotpaths:
       path: .aiox-core/development/tasks/db-analyze-hotpaths.md
       layer: L2
@@ -1137,7 +1136,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0993cb6e5d0c4fb22f081060e47f303c3c745889cf7b583ea2a29ab0f3b0ac6e
-      lastVerified: '2026-03-11T00:48:55.822Z'
+      lastVerified: '2026-05-17T10:02:45.106Z'
     db-apply-migration:
       path: .aiox-core/development/tasks/db-apply-migration.md
       layer: L2
@@ -1163,7 +1162,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73ca77d0858dde76a1979d6c0dce1cd6760666ea67fdc60283da0d027d73eaa2
-      lastVerified: '2026-03-11T00:48:55.822Z'
+      lastVerified: '2026-05-17T10:02:45.106Z'
     db-bootstrap:
       path: .aiox-core/development/tasks/db-bootstrap.md
       layer: L2
@@ -1188,7 +1187,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b50effd8d5d63bcbb7f42a02223678306c4b10a3d7cdbd94b024e0dc716d1e69
-      lastVerified: '2026-03-11T00:48:55.822Z'
+      lastVerified: '2026-05-17T10:02:45.106Z'
     db-domain-modeling:
       path: .aiox-core/development/tasks/db-domain-modeling.md
       layer: L2
@@ -1213,7 +1212,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:afd2911ebdb4d4164885efb6d71cb2578da1e60ca3c37397f19261a99e5bb22b
-      lastVerified: '2026-03-11T00:48:55.822Z'
+      lastVerified: '2026-05-17T10:02:45.107Z'
     db-dry-run:
       path: .aiox-core/development/tasks/db-dry-run.md
       layer: L2
@@ -1239,7 +1238,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ce848fdf956175b5dd96d6864376011972d2a7512ce37519592589eca442ec2b
-      lastVerified: '2026-03-11T00:48:55.822Z'
+      lastVerified: '2026-05-17T10:02:45.107Z'
     db-env-check:
       path: .aiox-core/development/tasks/db-env-check.md
       layer: L2
@@ -1263,7 +1262,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8a4674f5858ee709186690b45dd51fe5cbb28097a641f178e0e624e2a5331a44
-      lastVerified: '2026-03-11T00:48:55.822Z'
+      lastVerified: '2026-05-17T10:02:45.108Z'
     db-explain:
       path: .aiox-core/development/tasks/db-explain.md
       layer: L2
@@ -1287,7 +1286,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b96391756f45fc99b5cbd129921541060dc9ced1d1c269b820109d36fcd53530
-      lastVerified: '2026-03-11T00:48:55.823Z'
+      lastVerified: '2026-05-17T10:02:45.109Z'
     db-impersonate:
       path: .aiox-core/development/tasks/db-impersonate.md
       layer: L2
@@ -1312,7 +1311,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:31891339b082706882c3529d5fbae5a77e566dbe94dfb2cc011a70aef6721abd
-      lastVerified: '2026-03-11T00:48:55.823Z'
+      lastVerified: '2026-05-17T10:02:45.109Z'
     db-load-csv:
       path: .aiox-core/development/tasks/db-load-csv.md
       layer: L2
@@ -1338,7 +1337,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a4cf24a705ad7669aef945a71dcc95b7e156e2c41ee20be9d63819818422bd23
-      lastVerified: '2026-03-11T00:48:55.823Z'
+      lastVerified: '2026-05-17T10:02:45.109Z'
     db-policy-apply:
       path: .aiox-core/development/tasks/db-policy-apply.md
       layer: L2
@@ -1364,7 +1363,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5069a7786ac2f5c032f9b4aeedaa90808bccb0ecc01456d72b11d111281c8497
-      lastVerified: '2026-03-11T00:48:55.823Z'
+      lastVerified: '2026-05-17T10:02:45.109Z'
     db-rls-audit:
       path: .aiox-core/development/tasks/db-rls-audit.md
       layer: L2
@@ -1387,7 +1386,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b25183564fe08abdb5c563a19eac526ebbe14c10397cfb27e9b2f2c53f1c189b
-      lastVerified: '2026-03-11T00:48:55.824Z'
+      lastVerified: '2026-05-17T10:02:45.110Z'
     db-rollback:
       path: .aiox-core/development/tasks/db-rollback.md
       layer: L2
@@ -1411,7 +1410,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cc8b5ccbfb8184724452bd4fbaf93a5e43b137428f7cd1c6562b8bc7c10887e2
-      lastVerified: '2026-03-11T00:48:55.824Z'
+      lastVerified: '2026-05-17T10:02:45.110Z'
     db-run-sql:
       path: .aiox-core/development/tasks/db-run-sql.md
       layer: L2
@@ -1435,7 +1434,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:90b771db8d68c2cc3236aa371d24c2553175c4d39931fe3eb690cdd2ebaded1e
-      lastVerified: '2026-03-11T00:48:55.825Z'
+      lastVerified: '2026-05-17T10:02:45.110Z'
     db-schema-audit:
       path: .aiox-core/development/tasks/db-schema-audit.md
       layer: L2
@@ -1458,7 +1457,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4a70508b9d6bbe2b2e62265231682df371dc3a9295e285ef2e4356f81ed941e9
-      lastVerified: '2026-03-11T00:48:55.825Z'
+      lastVerified: '2026-05-17T10:02:45.111Z'
     db-seed:
       path: .aiox-core/development/tasks/db-seed.md
       layer: L2
@@ -1483,7 +1482,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e3553aff9781731e75c2017a7038cbb843a6945d69fb26365300aae3fd68d97e
-      lastVerified: '2026-03-11T00:48:55.825Z'
+      lastVerified: '2026-05-17T10:02:45.111Z'
     db-smoke-test:
       path: .aiox-core/development/tasks/db-smoke-test.md
       layer: L2
@@ -1507,7 +1506,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7f0672e95bedf5d5ac83f34acdd07f32d88bab743a2f210a49b6bea9bcdd04c7
-      lastVerified: '2026-03-11T00:48:55.826Z'
+      lastVerified: '2026-05-17T10:02:45.111Z'
     db-snapshot:
       path: .aiox-core/development/tasks/db-snapshot.md
       layer: L2
@@ -1532,7 +1531,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:60955c4ec4894233ef891424900d134ff4ac987ccf6fa2521f704e476865ef79
-      lastVerified: '2026-03-11T00:48:55.826Z'
+      lastVerified: '2026-05-17T10:02:45.112Z'
     db-squad-integration:
       path: .aiox-core/development/tasks/db-squad-integration.md
       layer: L2
@@ -1556,7 +1555,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:13ce5e3226dadffad490752064169e124e2c989514e2e7b3c249445b9ad3485c
-      lastVerified: '2026-03-11T00:48:55.826Z'
+      lastVerified: '2026-05-17T10:02:45.112Z'
     db-supabase-setup:
       path: .aiox-core/development/tasks/db-supabase-setup.md
       layer: L2
@@ -1581,7 +1580,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:64e02b6c69bb87d0082590484fadc0510cb88e4a6dc01b3c7015e5e6e6bcb585
-      lastVerified: '2026-03-11T00:48:55.826Z'
+      lastVerified: '2026-05-17T10:02:45.113Z'
     db-verify-order:
       path: .aiox-core/development/tasks/db-verify-order.md
       layer: L2
@@ -1607,7 +1606,30 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:478a1f94e0e4d9da5488ce5df41538308454a64e534d587d5d8361dbd9cff701
-      lastVerified: '2026-03-11T00:48:55.826Z'
+      lastVerified: '2026-05-17T10:02:45.113Z'
+    delegate-to-external-executor:
+      path: .aiox-core/development/tasks/delegate-to-external-executor.md
+      layer: L2
+      type: task
+      purpose: delegate-to-external-executor.md
+      keywords:
+        - delegate
+        - to
+        - external
+        - executor
+        - delegate-to-external-executor.md
+      usedBy: []
+      dependencies:
+        - dev
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: experimental
+      adaptability:
+        score: 0.8
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:68c73a78e4eeebcb551f69bc8c13f37157be253b91a3d3d80ea9bc52c5330808
+      lastVerified: '2026-05-17T10:02:45.113Z'
     deprecate-component:
       path: .aiox-core/development/tasks/deprecate-component.md
       layer: L2
@@ -1638,7 +1660,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:72dfca4d222b990ed868e5fd4c0d5793848cd1a9fda6d48fb7caec93e02c59ed
-      lastVerified: '2026-03-11T00:48:55.827Z'
+      lastVerified: '2026-05-17T10:02:45.114Z'
     dev-apply-qa-fixes:
       path: .aiox-core/development/tasks/dev-apply-qa-fixes.md
       layer: L2
@@ -1663,7 +1685,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a5b993cbc89e46f3669748da0f33e5cae28af4e6552d7f492b7f640f735736ba
-      lastVerified: '2026-03-11T00:48:55.827Z'
+      lastVerified: '2026-05-17T10:02:45.114Z'
     dev-backlog-debt:
       path: .aiox-core/development/tasks/dev-backlog-debt.md
       layer: L2
@@ -1692,7 +1714,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e5aa74b0fb90697be71cb5c1914d8b632d7edac0b9e42d87539a4ea1519c7ed3
-      lastVerified: '2026-03-11T00:48:55.827Z'
+      lastVerified: '2026-05-17T10:02:45.115Z'
     dev-develop-story:
       path: .aiox-core/development/tasks/dev-develop-story.md
       layer: L2
@@ -1721,8 +1743,8 @@ entities:
         score: 0.8
         constraints: []
         extensionPoints: []
-      checksum: sha256:24ef3f76f37f82c8caa0bfaec4ac1ccf14ebd1cd60c6f0fe5c355d63b113784c
-      lastVerified: '2026-03-11T00:48:55.827Z'
+      checksum: sha256:be8924aa0de759ca92a177b0ea12a5b076a3095ee2a9f530b74b3de19e996954
+      lastVerified: '2026-05-17T10:02:45.116Z'
     dev-improve-code-quality:
       path: .aiox-core/development/tasks/dev-improve-code-quality.md
       layer: L2
@@ -1755,7 +1777,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6cf78aed6cca48bf13cc1f677f2cde86aea591785f428f9f56733de478107e2f
-      lastVerified: '2026-03-11T00:48:55.828Z'
+      lastVerified: '2026-05-17T10:02:45.116Z'
     dev-optimize-performance:
       path: .aiox-core/development/tasks/dev-optimize-performance.md
       layer: L2
@@ -1786,7 +1808,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:acd5a1b14732f4d2526ebee2571897eb5ccb4c106d2388eb3560298ed85ce20d
-      lastVerified: '2026-03-11T00:48:55.828Z'
+      lastVerified: '2026-05-17T10:02:45.118Z'
     dev-suggest-refactoring:
       path: .aiox-core/development/tasks/dev-suggest-refactoring.md
       layer: L2
@@ -1817,7 +1839,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:51eebcbb72786df561ee0f25176ee4534166d71f2cfd4db1ea6eae7e8f3f6188
-      lastVerified: '2026-03-11T00:48:55.828Z'
+      lastVerified: '2026-05-17T10:02:45.118Z'
     dev-validate-next-story:
       path: .aiox-core/development/tasks/dev-validate-next-story.md
       layer: L2
@@ -1845,7 +1867,200 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6dda51884ce7a5dd814d026aab3f2125d399e89b468b2125673c19ade9091ace
-      lastVerified: '2026-03-11T00:48:55.828Z'
+      lastVerified: '2026-05-17T10:02:45.118Z'
+    devops-pro-access-grant:
+      path: .aiox-core/development/tasks/devops-pro-access-grant.md
+      layer: L2
+      type: task
+      purpose: >-
+        Grant, restore, or validate AIOX Pro access for a customer using the live license server, Supabase Auth, and
+        guided installer validation.
+      keywords:
+        - devops
+        - pro
+        - access
+        - grant
+        - 'task:'
+      usedBy:
+        - devops
+      dependencies:
+        - devops
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.8
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:11d2b342a39a95acfbd5dbb7abe9c25a9511035b9ca46abac86ec40f60d6a011
+      lastVerified: '2026-05-17T10:02:45.119Z'
+    devops-pro-activate:
+      path: .aiox-core/development/tasks/devops-pro-activate.md
+      layer: L2
+      type: task
+      purpose: Call the live `activate-pro` endpoint directly to validate or restore AIOX Pro activation for a session.
+      keywords:
+        - devops
+        - pro
+        - activate
+        - 'task:'
+      usedBy:
+        - devops
+      dependencies:
+        - devops
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.8
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:910a62a5dc9c9780a774da3d79b1b3fe3b5834ecf7f1c074775774a8bdfebd65
+      lastVerified: '2026-05-17T10:02:45.119Z'
+    devops-pro-check-access:
+      path: .aiox-core/development/tasks/devops-pro-check-access.md
+      layer: L2
+      type: task
+      purpose: Check whether an email already has AIOX Pro buyer entitlement and whether an auth account exists.
+      keywords:
+        - devops
+        - pro
+        - check
+        - access
+        - 'task:'
+      usedBy:
+        - devops
+      dependencies:
+        - devops
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.8
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:4dcff883a824899c531841bcdcda8bb5767a57fb49e8ca242a14875f41e7c694
+      lastVerified: '2026-05-17T10:02:45.119Z'
+    devops-pro-request-reset:
+      path: .aiox-core/development/tasks/devops-pro-request-reset.md
+      layer: L2
+      type: task
+      purpose: Trigger the user-facing password reset email flow for an AIOX Pro account.
+      keywords:
+        - devops
+        - pro
+        - request
+        - reset
+        - 'task:'
+      usedBy:
+        - devops
+      dependencies:
+        - devops
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.8
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:fdb5710a9c85e39750016cb3ac3e60a69396f2edaa1fc3180f0ebbf71e2c470c
+      lastVerified: '2026-05-17T10:02:45.119Z'
+    devops-pro-resend-verification:
+      path: .aiox-core/development/tasks/devops-pro-resend-verification.md
+      layer: L2
+      type: task
+      purpose: Resend the email verification link for an AIOX Pro user account.
+      keywords:
+        - devops
+        - pro
+        - resend
+        - verification
+        - 'task:'
+      usedBy:
+        - devops
+      dependencies:
+        - devops
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.8
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:e6ed30bb1bd15d1d138f09e991ec227fda48f7b2bfef6be2f7a49bcb95ab9cd4
+      lastVerified: '2026-05-17T10:02:45.119Z'
+    devops-pro-reset-password:
+      path: .aiox-core/development/tasks/devops-pro-reset-password.md
+      layer: L2
+      type: task
+      purpose: Reset an AIOX Pro password administratively, then validate login with the new password.
+      keywords:
+        - devops
+        - pro
+        - reset
+        - password
+        - 'task:'
+      usedBy:
+        - devops
+      dependencies:
+        - devops
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.8
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:1f48dd5d1110529cc20b91f41c3ad4ac2e4a095040f0bbc1aa2641955fb2559c
+      lastVerified: '2026-05-17T10:02:45.120Z'
+    devops-pro-validate-login:
+      path: .aiox-core/development/tasks/devops-pro-validate-login.md
+      layer: L2
+      type: task
+      purpose: Validate whether AIOX Pro login works for a given email and password pair.
+      keywords:
+        - devops
+        - pro
+        - validate
+        - login
+        - 'task:'
+      usedBy:
+        - devops
+      dependencies:
+        - devops
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.8
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:b9321e184b4a1c7e003b363a857be01f953aebd467b898891b701880243265fe
+      lastVerified: '2026-05-17T10:02:45.120Z'
+    devops-pro-verify-status:
+      path: .aiox-core/development/tasks/devops-pro-verify-status.md
+      layer: L2
+      type: task
+      purpose: Check email verification status for an authenticated AIOX Pro session.
+      keywords:
+        - devops
+        - pro
+        - verify
+        - status
+        - 'task:'
+      usedBy:
+        - devops
+      dependencies:
+        - devops
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.8
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:c6fff732a41370c125e5507f9284a3b567b5472a788df0cd874ad4e6c801150d
+      lastVerified: '2026-05-17T10:02:45.120Z'
     document-gotchas:
       path: .aiox-core/development/tasks/document-gotchas.md
       layer: L2
@@ -1871,7 +2086,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:84858f6252bc2a85beda75971fed74e087edee3bdd537eb29f43132f0141fbf5
-      lastVerified: '2026-03-11T00:48:55.828Z'
+      lastVerified: '2026-05-17T10:02:45.120Z'
     document-project:
       path: .aiox-core/development/tasks/document-project.md
       layer: L2
@@ -1903,7 +2118,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8123a2c9105391b46857cfb3e236a912f47bfb598fb21df1cea0a12eabbf7337
-      lastVerified: '2026-03-11T00:48:55.829Z'
+      lastVerified: '2026-05-17T10:02:45.121Z'
     environment-bootstrap:
       path: .aiox-core/development/tasks/environment-bootstrap.md
       layer: L2
@@ -1941,7 +2156,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:02ed701bea38ee11ad7e83a310ad55b3d84f36f37a344fda6b252fe3230d50cb
-      lastVerified: '2026-03-11T00:48:55.829Z'
+      lastVerified: '2026-05-17T10:02:45.122Z'
     execute-checklist:
       path: .aiox-core/development/tasks/execute-checklist.md
       layer: L2
@@ -1978,7 +2193,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9bd751605efd593e0708bac6e3f1c66a91ba5f33a5069c655b6d16cf6621859c
-      lastVerified: '2026-03-11T00:48:55.829Z'
+      lastVerified: '2026-05-17T10:02:45.122Z'
     execute-epic-plan:
       path: .aiox-core/development/tasks/execute-epic-plan.md
       layer: L2
@@ -2008,7 +2223,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0c3ee4e1802927fb8f21be172daeb356797033ff082fea07523025a373bea387
-      lastVerified: '2026-03-11T00:48:55.829Z'
+      lastVerified: '2026-05-17T10:02:45.123Z'
     export-design-tokens-dtcg:
       path: .aiox-core/development/tasks/export-design-tokens-dtcg.md
       layer: L2
@@ -2034,7 +2249,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8819918bd7c4b6b0b0b0aadd66f5aecb2d6ca0b949206c16cb497d6d1d7a72f9
-      lastVerified: '2026-03-11T00:48:55.829Z'
+      lastVerified: '2026-05-17T10:02:45.123Z'
     extend-pattern:
       path: .aiox-core/development/tasks/extend-pattern.md
       layer: L2
@@ -2058,7 +2273,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7eaccc1d33f806bbcd2e7a90e701d6c88c00e4e98f14c14b4f705ff618ef17f8
-      lastVerified: '2026-03-11T00:48:55.830Z'
+      lastVerified: '2026-05-17T10:02:45.124Z'
     extract-patterns:
       path: .aiox-core/development/tasks/extract-patterns.md
       layer: L2
@@ -2082,7 +2297,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:aa8981c254d00a76c66c6c4f9569b0be1785f4537137ee23129049abae92f3b4
-      lastVerified: '2026-03-11T00:48:55.830Z'
+      lastVerified: '2026-05-17T10:02:45.124Z'
     extract-tokens:
       path: .aiox-core/development/tasks/extract-tokens.md
       layer: L2
@@ -2108,7 +2323,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8266d4caf51507fe82510c04a54b6a33c7e2d1f10862e4e242f009b214edd7ee
-      lastVerified: '2026-03-11T00:48:55.830Z'
+      lastVerified: '2026-05-17T10:02:45.124Z'
     facilitate-brainstorming-session:
       path: .aiox-core/development/tasks/facilitate-brainstorming-session.md
       layer: L2
@@ -2133,7 +2348,29 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c351428e7aa1af079046bbf357af98668675943fd13920b98b7ecfd9f87a6081
-      lastVerified: '2026-03-11T00:48:55.830Z'
+      lastVerified: '2026-05-17T10:02:45.125Z'
+    fast-path-gate:
+      path: .aiox-core/development/tasks/fast-path-gate.md
+      layer: L2
+      type: task
+      purpose: >-
+        Choose the fastest safe execution path before starting a task. This gate prevents slow one-by-one conversational
+        edits for mechanical work such as YAML population, bulk replacements, structured data n
+      keywords:
+        - fast
+        - path
+        - gate
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.8
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:d28e2def9134ffe79e04ebcfa25de651d659471eab07367fa4c7992245f79fe2
+      lastVerified: '2026-05-17T10:02:45.125Z'
     generate-ai-frontend-prompt:
       path: .aiox-core/development/tasks/generate-ai-frontend-prompt.md
       layer: L2
@@ -2165,7 +2402,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d4c2abf28b065922f1e67c95fa2a69dd792c9828c6dd31d2fc173a5361b021aa
-      lastVerified: '2026-03-11T00:48:55.830Z'
+      lastVerified: '2026-05-17T10:02:45.125Z'
     generate-documentation:
       path: .aiox-core/development/tasks/generate-documentation.md
       layer: L2
@@ -2191,7 +2428,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec03841e1f72b8b55a156e03a7d6ef061f0cf942beb7d66f61d3bf6bdbaaa93b
-      lastVerified: '2026-03-11T00:48:55.830Z'
+      lastVerified: '2026-05-17T10:02:45.125Z'
     generate-migration-strategy:
       path: .aiox-core/development/tasks/generate-migration-strategy.md
       layer: L2
@@ -2216,7 +2453,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a944f9294553cad38c4e2a13143388a48dc330667e5b1b04dfcd1f5a2644541
-      lastVerified: '2026-03-11T00:48:55.830Z'
+      lastVerified: '2026-05-17T10:02:45.126Z'
     generate-shock-report:
       path: .aiox-core/development/tasks/generate-shock-report.md
       layer: L2
@@ -2241,7 +2478,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:04ebdca5f8bad14504f76d3e1fde4b426a4cd4ce8fe8dc4f9391f3c711bb6970
-      lastVerified: '2026-03-11T00:48:55.831Z'
+      lastVerified: '2026-05-17T10:02:45.126Z'
     github-devops-github-pr-automation:
       path: .aiox-core/development/tasks/github-devops-github-pr-automation.md
       layer: L2
@@ -2274,7 +2511,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2149c952074e661e77cfe6caa1bc2cb7366c930c9782eb308a8513a54f3d1629
-      lastVerified: '2026-03-11T00:48:55.831Z'
+      lastVerified: '2026-05-17T10:02:45.127Z'
     github-devops-pre-push-quality-gate:
       path: .aiox-core/development/tasks/github-devops-pre-push-quality-gate.md
       layer: L2
@@ -2306,7 +2543,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3709049cefce2dc03f54a16830114e67fa6b4cf37f0f999638d5d1521f0979d8
-      lastVerified: '2026-03-11T00:48:55.831Z'
+      lastVerified: '2026-05-17T10:02:45.128Z'
     github-devops-repository-cleanup:
       path: .aiox-core/development/tasks/github-devops-repository-cleanup.md
       layer: L2
@@ -2332,7 +2569,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:34135e86820be5218daf7031f4daa115d6ef9a727c7c0cb3a6f28c59f8e694c1
-      lastVerified: '2026-03-11T00:48:55.831Z'
+      lastVerified: '2026-05-17T10:02:45.128Z'
     github-devops-version-management:
       path: .aiox-core/development/tasks/github-devops-version-management.md
       layer: L2
@@ -2359,7 +2596,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1e217bea7df36731cfa5c3fb5a3b97399a57fef5989e59c303c3163bb3e5ecd7
-      lastVerified: '2026-03-11T00:48:55.831Z'
+      lastVerified: '2026-05-17T10:02:45.129Z'
     github-issue-triage:
       path: .aiox-core/development/tasks/github-issue-triage.md
       layer: L2
@@ -2380,7 +2617,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:61178caa7bc647dcae5e53d3f0515d6dab0cdc927e245b2db5844dc35d9e3d6f
-      lastVerified: '2026-03-11T00:48:55.831Z'
+      lastVerified: '2026-05-17T10:02:45.129Z'
     gotcha:
       path: .aiox-core/development/tasks/gotcha.md
       layer: L2
@@ -2405,7 +2642,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a9117d8a4c85c1be044975d829c936be0037c1751ef42b0fb2d19861702aecc6
-      lastVerified: '2026-03-11T00:48:55.831Z'
+      lastVerified: '2026-05-17T10:02:45.129Z'
     gotchas:
       path: .aiox-core/development/tasks/gotchas.md
       layer: L2
@@ -2431,7 +2668,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ecf526697d6c55416aaea97939cd2002e8f32eaa7001d31e823d7766688d2bf5
-      lastVerified: '2026-03-11T00:48:55.832Z'
+      lastVerified: '2026-05-17T10:02:45.129Z'
     ids-governor:
       path: .aiox-core/development/tasks/ids-governor.md
       layer: L2
@@ -2455,7 +2692,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cfb1aefffdf2db0d35cae8fdde2f5afbcea62b9b616e78a43390756c9b8e6b9c
-      lastVerified: '2026-03-11T00:48:55.832Z'
+      lastVerified: '2026-05-17T10:02:45.130Z'
     ids-health:
       path: .aiox-core/development/tasks/ids-health.md
       layer: L2
@@ -2478,7 +2715,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d5196b3741fb537707e1a99c71514e439447121df500002644dfebe43da4a70f
-      lastVerified: '2026-03-11T00:48:55.832Z'
+      lastVerified: '2026-05-17T10:02:45.130Z'
     ids-query:
       path: .aiox-core/development/tasks/ids-query.md
       layer: L2
@@ -2502,7 +2739,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c15596fdfc0bf86e4b6053313e7e91195c073d6c9066df4d626c5a3e2c13e99b
-      lastVerified: '2026-03-11T00:48:55.832Z'
+      lastVerified: '2026-05-17T10:02:45.130Z'
     improve-self:
       path: .aiox-core/development/tasks/improve-self.md
       layer: L2
@@ -2536,7 +2773,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ccabfaad3cdba01a151b313afdf0e1c41c8a981ec2140531f24500149b4a7646
-      lastVerified: '2026-03-11T00:48:55.832Z'
+      lastVerified: '2026-05-17T10:02:45.131Z'
     index-docs:
       path: .aiox-core/development/tasks/index-docs.md
       layer: L2
@@ -2567,7 +2804,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d8553b437ad8a4dc9dc37bd38939164ee0d0f76f2bb46d30a8318cf4413415f5
-      lastVerified: '2026-03-11T00:48:55.833Z'
+      lastVerified: '2026-05-17T10:02:45.131Z'
     init-project-status:
       path: .aiox-core/development/tasks/init-project-status.md
       layer: L2
@@ -2595,7 +2832,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0c2f801d30da8f926542e8d29507886cb79ec324e717c75607b9fbb5555dc16b
-      lastVerified: '2026-03-11T00:48:55.833Z'
+      lastVerified: '2026-05-17T10:02:45.131Z'
     integrate-squad:
       path: .aiox-core/development/tasks/integrate-squad.md
       layer: L2
@@ -2617,7 +2854,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c1dbded4048033ea0a5f10c8bb53e045e14930d8442a1bf35c67bb16c0c8939a
-      lastVerified: '2026-03-11T00:48:55.833Z'
+      lastVerified: '2026-05-17T10:02:45.132Z'
     kb-mode-interaction:
       path: .aiox-core/development/tasks/kb-mode-interaction.md
       layer: L2
@@ -2647,7 +2884,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73ef3d164b2576f80f37bfc5bc6ea2276a59778f9bcc41a77fd288fab7f2e61f
-      lastVerified: '2026-03-11T00:48:55.834Z'
+      lastVerified: '2026-05-17T10:02:45.132Z'
     learn-patterns:
       path: .aiox-core/development/tasks/learn-patterns.md
       layer: L2
@@ -2673,7 +2910,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0042edaa7d638aa4e476607d026a406411a6b9177f3a29a25d78773ee27e9c0f
-      lastVerified: '2026-03-11T00:48:55.834Z'
+      lastVerified: '2026-05-17T10:02:45.133Z'
     list-mcps:
       path: .aiox-core/development/tasks/list-mcps.md
       layer: L2
@@ -2694,7 +2931,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c2eca1a9c8d0be7c83a3e2eea59b33155bf7955f534eb0b36b27ed3852ea7dd1
-      lastVerified: '2026-03-11T00:48:55.834Z'
+      lastVerified: '2026-05-17T10:02:45.133Z'
     list-worktrees:
       path: .aiox-core/development/tasks/list-worktrees.md
       layer: L2
@@ -2723,7 +2960,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a29055766b289c22597532b5623e6e56dbbf6ca8d59193da6e6a0159213cb00b
-      lastVerified: '2026-03-11T00:48:55.834Z'
+      lastVerified: '2026-05-17T10:02:45.133Z'
     mcp-workflow:
       path: .aiox-core/development/tasks/mcp-workflow.md
       layer: L2
@@ -2745,7 +2982,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c09227efc590cc68ae9d32fe010de2dd8db621a2102b36d92a6fbb30f8f27cf
-      lastVerified: '2026-03-11T00:48:55.834Z'
+      lastVerified: '2026-05-17T10:02:45.133Z'
     merge-worktree:
       path: .aiox-core/development/tasks/merge-worktree.md
       layer: L2
@@ -2767,7 +3004,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e33a96e1961bbaba60f2258f4a98b8c9d384754a07eba705732f41d61ed2d4f4
-      lastVerified: '2026-03-11T00:48:55.834Z'
+      lastVerified: '2026-05-17T10:02:45.134Z'
     modify-agent:
       path: .aiox-core/development/tasks/modify-agent.md
       layer: L2
@@ -2795,7 +3032,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:74e6ef74967508f8a05cfc629bac7d5ffd5bd67c7d598cc623fd426442049824
-      lastVerified: '2026-03-11T00:48:55.834Z'
+      lastVerified: '2026-05-17T10:02:45.134Z'
     modify-task:
       path: .aiox-core/development/tasks/modify-task.md
       layer: L2
@@ -2821,7 +3058,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e81346cb686226a2bca0657e9c6367adcbf76d6cbd5d81cc892702c3a655d96a
-      lastVerified: '2026-03-11T00:48:55.834Z'
+      lastVerified: '2026-05-17T10:02:45.134Z'
     modify-workflow:
       path: .aiox-core/development/tasks/modify-workflow.md
       layer: L2
@@ -2848,7 +3085,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7cbfc3488912240b0782d116b27c5410d724c7822f94efe6cd64df954c3b4b50
-      lastVerified: '2026-03-11T00:48:55.835Z'
+      lastVerified: '2026-05-17T10:02:45.135Z'
     next:
       path: .aiox-core/development/tasks/next.md
       layer: L2
@@ -2873,8 +3110,8 @@ entities:
         score: 0.8
         constraints: []
         extensionPoints: []
-      checksum: sha256:f3f685218c1df95ef399a9ba3c8ea7c29607e591acc2a7fbc2847a2883f08e02
-      lastVerified: '2026-03-11T00:48:55.835Z'
+      checksum: sha256:bc65cd39c47607cef82f4d72e21f80b69ee4d5b1c42f3ffc317d91910fbae4ae
+      lastVerified: '2026-05-17T10:02:45.135Z'
     orchestrate-resume:
       path: .aiox-core/development/tasks/orchestrate-resume.md
       layer: L2
@@ -2895,7 +3132,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c15ca8e699269246cc48a581ca6a956acf6ba9b717024274836d6447cfbccc76
-      lastVerified: '2026-03-11T00:48:55.835Z'
+      lastVerified: '2026-05-17T10:02:45.135Z'
     orchestrate-status:
       path: .aiox-core/development/tasks/orchestrate-status.md
       layer: L2
@@ -2916,7 +3153,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fe47c904e6329f758c001f6cc56383ea32059ce988c3d190e8d6ebcc42376ec9
-      lastVerified: '2026-03-11T00:48:55.835Z'
+      lastVerified: '2026-05-17T10:02:45.135Z'
     orchestrate-stop:
       path: .aiox-core/development/tasks/orchestrate-stop.md
       layer: L2
@@ -2937,7 +3174,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:87f82b66a711ed468ea2f97ce5201469c2990010fed95ddbd975bb8ab49a3547
-      lastVerified: '2026-03-11T00:48:55.835Z'
+      lastVerified: '2026-05-17T10:02:45.135Z'
     orchestrate:
       path: .aiox-core/development/tasks/orchestrate.md
       layer: L2
@@ -2957,7 +3194,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ca30ad1efa28ea5c7eeebd07f944fa0202ab9522ae6c32c8a19ca9ff2d30a8ce
-      lastVerified: '2026-03-11T00:48:55.835Z'
+      lastVerified: '2026-05-17T10:02:45.136Z'
     patterns:
       path: .aiox-core/development/tasks/patterns.md
       layer: L2
@@ -2981,7 +3218,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:99dc215422f88e1dafa138e577c2c96bc65cf9657ca99b9ca00e72b3d17ec843
-      lastVerified: '2026-03-11T00:48:55.835Z'
+      lastVerified: '2026-05-17T10:02:45.136Z'
     plan-create-context:
       path: .aiox-core/development/tasks/plan-create-context.md
       layer: L2
@@ -3012,7 +3249,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2374473d1984288dc37c80c298fc564facadf0b8b886b8a98520c8b39c9bc82a
-      lastVerified: '2026-03-11T00:48:55.835Z'
+      lastVerified: '2026-05-17T10:02:45.137Z'
     plan-create-implementation:
       path: .aiox-core/development/tasks/plan-create-implementation.md
       layer: L2
@@ -3041,7 +3278,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3c186ead114afe21638b933d2e312538ed3a7bb9ee3dfee0ee0dc86fcc0025cc
-      lastVerified: '2026-03-11T00:48:55.835Z'
+      lastVerified: '2026-05-17T10:02:45.137Z'
     plan-execute-subtask:
       path: .aiox-core/development/tasks/plan-execute-subtask.md
       layer: L2
@@ -3072,7 +3309,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a6c9c283579d0b5d3f337816ed192f4dda99c3634ac55da98fa0c0d332e4d963
-      lastVerified: '2026-03-11T00:48:55.836Z'
+      lastVerified: '2026-05-17T10:02:45.138Z'
     po-backlog-add:
       path: .aiox-core/development/tasks/po-backlog-add.md
       layer: L2
@@ -3099,7 +3336,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6f553ba9bf2638c183c4a59caa56d73baa641263080125ed0f9d87a18e9f376f
-      lastVerified: '2026-03-11T00:48:55.836Z'
+      lastVerified: '2026-05-17T10:02:45.138Z'
     po-close-story:
       path: .aiox-core/development/tasks/po-close-story.md
       layer: L2
@@ -3125,7 +3362,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:df93883e8af967351586dff250f79748008f6dc2ac15b78ac85715023a8d3ba4
-      lastVerified: '2026-03-11T00:48:55.836Z'
+      lastVerified: '2026-05-17T10:02:45.138Z'
     po-manage-story-backlog:
       path: .aiox-core/development/tasks/po-manage-story-backlog.md
       layer: L2
@@ -3153,7 +3390,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ed619e87c9753428eaea969d05d046b7f26af4f825d792ffcf026dc4f475b6e5
-      lastVerified: '2026-03-11T00:48:55.836Z'
+      lastVerified: '2026-05-17T10:02:45.139Z'
     po-pull-story-from-clickup:
       path: .aiox-core/development/tasks/po-pull-story-from-clickup.md
       layer: L2
@@ -3184,7 +3421,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:27fa2887a3da901319bafd7bd714c0abb31c638554aecaf924d412d25a7072bc
-      lastVerified: '2026-03-11T00:48:55.836Z'
+      lastVerified: '2026-05-17T10:02:45.139Z'
     po-pull-story:
       path: .aiox-core/development/tasks/po-pull-story.md
       layer: L2
@@ -3211,7 +3448,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d6f23501d4f35011fddf5242ed739208e9ec4d767210cd961e6d48373f33a2a3
-      lastVerified: '2026-03-11T00:48:55.836Z'
+      lastVerified: '2026-05-17T10:02:45.139Z'
     po-stories-index:
       path: .aiox-core/development/tasks/po-stories-index.md
       layer: L2
@@ -3239,7 +3476,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9e078929826bdec66e9cddbc9f0883568d32cc130e119e3a1da3345b54121dd3
-      lastVerified: '2026-03-11T00:48:55.836Z'
+      lastVerified: '2026-05-17T10:02:45.140Z'
     po-sync-story-to-clickup:
       path: .aiox-core/development/tasks/po-sync-story-to-clickup.md
       layer: L2
@@ -3270,7 +3507,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:03f25fea39d33c6f4febd1dfd467b643bef5cd3d89ceb4766282c173ce810698
-      lastVerified: '2026-03-11T00:48:55.837Z'
+      lastVerified: '2026-05-17T10:02:45.140Z'
     po-sync-story:
       path: .aiox-core/development/tasks/po-sync-story.md
       layer: L2
@@ -3299,7 +3536,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:67c5e1b02c0d499f12c6727d88a18407f926f440741fb5f8f6e2afa937adec2e
-      lastVerified: '2026-03-11T00:48:55.837Z'
+      lastVerified: '2026-05-17T10:02:45.141Z'
     pr-automation:
       path: .aiox-core/development/tasks/pr-automation.md
       layer: L2
@@ -3329,7 +3566,34 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:90bba47136ccc37c74454a4537728b958955fd487e46e3b8dca869b994c8d1c1
-      lastVerified: '2026-03-11T00:48:55.837Z'
+      lastVerified: '2026-05-17T10:02:45.141Z'
+    project-status:
+      path: .aiox-core/development/tasks/project-status.md
+      layer: L2
+      type: task
+      purpose: >-
+        Display a comprehensive, **100% accurate** panorama of all epics and stories in the project. The status of each
+        story is read directly from its **source of truth** — the `## Status` field in each stor
+      keywords:
+        - project
+        - status
+        - 'task:'
+        - full
+        - panorama
+      usedBy: []
+      dependencies:
+        - aiox-master
+        - po
+        - sm
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: experimental
+      adaptability:
+        score: 0.8
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:3cb76eeb42b7e0b46a06ce0827bc68d2f507a7f4021174b1bd9e68d82463e5e6
+      lastVerified: '2026-05-17T10:02:45.141Z'
     propose-modification:
       path: .aiox-core/development/tasks/propose-modification.md
       layer: L2
@@ -3359,7 +3623,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa340dc0749f40ba7f1ed12ebe107c53f212f764cf7318ee7a816d059528f69e
-      lastVerified: '2026-03-11T00:48:55.837Z'
+      lastVerified: '2026-05-17T10:02:45.142Z'
     publish-npm:
       path: .aiox-core/development/tasks/publish-npm.md
       layer: L2
@@ -3385,7 +3649,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d69f833690fd01256c9b99cc7bd7bb67704f5894ffa9171af7cb94253ecd98cd
-      lastVerified: '2026-03-11T00:48:55.837Z'
+      lastVerified: '2026-05-17T10:02:45.143Z'
     qa-after-creation:
       path: .aiox-core/development/tasks/qa-after-creation.md
       layer: L2
@@ -3406,7 +3670,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e9f6ceff7a0bc00d4fc035e890b7f1178c6ea43f447d135774b46a00713450e6
-      lastVerified: '2026-03-11T00:48:55.837Z'
+      lastVerified: '2026-05-17T10:02:45.143Z'
     qa-backlog-add-followup:
       path: .aiox-core/development/tasks/qa-backlog-add-followup.md
       layer: L2
@@ -3436,7 +3700,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:167e6f253eaf69e5751c294eec6a677153996b148ce70ba242506c2812f41535
-      lastVerified: '2026-03-11T00:48:55.837Z'
+      lastVerified: '2026-05-17T10:02:45.144Z'
     qa-browser-console-check:
       path: .aiox-core/development/tasks/qa-browser-console-check.md
       layer: L2
@@ -3459,7 +3723,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:deddbb5aed026e5b8b4d100a84baea6f4f85b3a249e56033f6e35e7ac08e2f80
-      lastVerified: '2026-03-11T00:48:55.838Z'
+      lastVerified: '2026-05-17T10:02:45.144Z'
     qa-create-fix-request:
       path: .aiox-core/development/tasks/qa-create-fix-request.md
       layer: L2
@@ -3488,7 +3752,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:709ed6f4c0260bf95e9801e22ef75f2b02958f967aaf6b1b6ffc4b7ee34b3e03
-      lastVerified: '2026-03-11T00:48:55.838Z'
+      lastVerified: '2026-05-17T10:02:45.144Z'
     qa-evidence-requirements:
       path: .aiox-core/development/tasks/qa-evidence-requirements.md
       layer: L2
@@ -3511,7 +3775,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cfa30b79bf1eac27511c94de213dbae761f3fb5544da07cc38563bcbd9187569
-      lastVerified: '2026-03-11T00:48:55.838Z'
+      lastVerified: '2026-05-17T10:02:45.145Z'
     qa-false-positive-detection:
       path: .aiox-core/development/tasks/qa-false-positive-detection.md
       layer: L2
@@ -3535,7 +3799,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f1a816365c588e7521617fc3aa7435e6f08d1ed06f4f51cce86f9529901d86ce
-      lastVerified: '2026-03-11T00:48:55.838Z'
+      lastVerified: '2026-05-17T10:02:45.145Z'
     qa-fix-issues:
       path: .aiox-core/development/tasks/qa-fix-issues.md
       layer: L2
@@ -3565,7 +3829,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b5db49f2709dbe27bb50d68f46f48b2d1c9a6b176a6025158d8f299e552eb2c3
-      lastVerified: '2026-03-11T00:48:55.838Z'
+      lastVerified: '2026-05-17T10:02:45.145Z'
     qa-gate:
       path: .aiox-core/development/tasks/qa-gate.md
       layer: L2
@@ -3582,8 +3846,8 @@ entities:
       dependencies:
         - qa
         - devops
-        - dev
         - po
+        - dev
       externalDeps: []
       plannedDeps:
         - qa-master-checklist
@@ -3594,8 +3858,8 @@ entities:
         score: 0.8
         constraints: []
         extensionPoints: []
-      checksum: sha256:25fc098d7c71554836925632c4a3f99aff9ade392e1ab1c669ae0983f49c6070
-      lastVerified: '2026-03-11T00:48:55.838Z'
+      checksum: sha256:b151ea672e7ad0e9229807f86430e4f3483395ee4beae40f2f17d7f6228aee24
+      lastVerified: '2026-05-17T10:02:45.146Z'
     qa-generate-tests:
       path: .aiox-core/development/tasks/qa-generate-tests.md
       layer: L2
@@ -3630,7 +3894,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:245885950328b086ffbe9320bba2e814b3f6b5e3e5342bac904ccd814d4e8519
-      lastVerified: '2026-03-11T00:48:55.838Z'
+      lastVerified: '2026-05-17T10:02:45.147Z'
     qa-library-validation:
       path: .aiox-core/development/tasks/qa-library-validation.md
       layer: L2
@@ -3653,7 +3917,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:366df913fe32f08ec4bf883c4b6f9781af22cc4bfa23ce25cfdbe56f562b013e
-      lastVerified: '2026-03-11T00:48:55.839Z'
+      lastVerified: '2026-05-17T10:02:45.147Z'
     qa-migration-validation:
       path: .aiox-core/development/tasks/qa-migration-validation.md
       layer: L2
@@ -3675,7 +3939,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2f855a1b918066755b8b16d0db7c347b32df372996217542905713459eb29bc4
-      lastVerified: '2026-03-11T00:48:55.839Z'
+      lastVerified: '2026-05-17T10:02:45.148Z'
     qa-nfr-assess:
       path: .aiox-core/development/tasks/qa-nfr-assess.md
       layer: L2
@@ -3700,7 +3964,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f2816ad58335c6d3b68bfc18d95f58b75358f8cb2cab844c7712ef36635a5e37
-      lastVerified: '2026-03-11T00:48:55.839Z'
+      lastVerified: '2026-05-17T10:02:45.148Z'
     qa-review-build:
       path: .aiox-core/development/tasks/qa-review-build.md
       layer: L2
@@ -3730,7 +3994,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9fcc1fd52b5cd18cf0039478c817e17aacf93e09f3e06de4ed308dc36075b5d5
-      lastVerified: '2026-03-11T00:48:55.839Z'
+      lastVerified: '2026-05-17T10:02:45.148Z'
     qa-review-proposal:
       path: .aiox-core/development/tasks/qa-review-proposal.md
       layer: L2
@@ -3761,7 +4025,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:928c0c1929f9935966ba24c27e590ae98b402095f3f54de6aa209d0e5ec9220c
-      lastVerified: '2026-03-11T00:48:55.839Z'
+      lastVerified: '2026-05-17T10:02:45.149Z'
     qa-review-story:
       path: .aiox-core/development/tasks/qa-review-story.md
       layer: L2
@@ -3791,7 +4055,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cc3e189824c656ff6ed2db04bd0a2a03d6293bccbec7e9b7a321daf64b9f1563
-      lastVerified: '2026-03-11T00:48:55.840Z'
+      lastVerified: '2026-05-17T10:02:45.150Z'
     qa-risk-profile:
       path: .aiox-core/development/tasks/qa-risk-profile.md
       layer: L2
@@ -3818,7 +4082,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:69b2b6edb38330234766bef8ed3c27469843e88fb30e130837922541c717432d
-      lastVerified: '2026-03-11T00:48:55.840Z'
+      lastVerified: '2026-05-17T10:02:45.150Z'
     qa-run-tests:
       path: .aiox-core/development/tasks/qa-run-tests.md
       layer: L2
@@ -3846,7 +4110,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f40850e70ffea9aecfb266e784575e0aa0483ea390ab8aae59df3829fd5fa6d8
-      lastVerified: '2026-03-11T00:48:55.840Z'
+      lastVerified: '2026-05-17T10:02:45.151Z'
     qa-security-checklist:
       path: .aiox-core/development/tasks/qa-security-checklist.md
       layer: L2
@@ -3868,7 +4132,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e155fba83e78f55830558def7ffe03b23c65dd6c2bbe63733b3966d1df6946ab
-      lastVerified: '2026-03-11T00:48:55.840Z'
+      lastVerified: '2026-05-17T10:02:45.151Z'
     qa-test-design:
       path: .aiox-core/development/tasks/qa-test-design.md
       layer: L2
@@ -3895,7 +4159,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:00e2aac4ec1587949b4bbdbd52f84adb8dc10a06395e9f68cc339c4a6fdb7405
-      lastVerified: '2026-03-11T00:48:55.840Z'
+      lastVerified: '2026-05-17T10:02:45.152Z'
     qa-trace-requirements:
       path: .aiox-core/development/tasks/qa-trace-requirements.md
       layer: L2
@@ -3922,7 +4186,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5c4a95d42d33b16ab77606d7a2dd5b18bb78f81f3872150454f10950bc0ee047
-      lastVerified: '2026-03-11T00:48:55.841Z'
+      lastVerified: '2026-05-17T10:02:45.152Z'
     release-management:
       path: .aiox-core/development/tasks/release-management.md
       layer: L2
@@ -3951,7 +4215,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:80a9a1ead93c66bfe59cb75215661052e7b4abccc483cd9d01a07034fca2311c
-      lastVerified: '2026-03-11T00:48:55.841Z'
+      lastVerified: '2026-05-17T10:02:45.153Z'
     remove-mcp:
       path: .aiox-core/development/tasks/remove-mcp.md
       layer: L2
@@ -3972,7 +4236,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3f4bf3f8d4d651109dc783e95598ab21569447295f22a7b868d3973f0848aa4c
-      lastVerified: '2026-03-11T00:48:55.841Z'
+      lastVerified: '2026-05-17T10:02:45.153Z'
     remove-worktree:
       path: .aiox-core/development/tasks/remove-worktree.md
       layer: L2
@@ -4001,7 +4265,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0ac9497e0a85e16f9e0a5357da43ae8571d1bf2ba98028f9968d2656df3ee36f
-      lastVerified: '2026-03-11T00:48:55.842Z'
+      lastVerified: '2026-05-17T10:02:45.154Z'
     resolve-github-issue:
       path: .aiox-core/development/tasks/resolve-github-issue.md
       layer: L2
@@ -4028,7 +4292,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d1e8f775eee3367f0a553f3e767477bad1833e72a731a2df94cde56d5b5eda97
-      lastVerified: '2026-03-11T00:48:55.842Z'
+      lastVerified: '2026-05-17T10:02:45.154Z'
     review-contributor-pr:
       path: .aiox-core/development/tasks/review-contributor-pr.md
       layer: L2
@@ -4050,7 +4314,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dfb5f03fae16171777742b06a9e54ee25711d1d94cedc2152ef9c9331310b608
-      lastVerified: '2026-03-11T00:48:55.842Z'
+      lastVerified: '2026-05-17T10:02:45.154Z'
     run-design-system-pipeline:
       path: .aiox-core/development/tasks/run-design-system-pipeline.md
       layer: L2
@@ -4076,7 +4340,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ff4c225b922da347b63aeb6d8aa95484c1c9281eb1e4b4c4ab0ecef0a1a54c26
-      lastVerified: '2026-03-11T00:48:55.842Z'
+      lastVerified: '2026-05-17T10:02:45.155Z'
     run-workflow-engine:
       path: .aiox-core/development/tasks/run-workflow-engine.md
       layer: L2
@@ -4096,6 +4360,7 @@ entities:
       dependencies:
         - workflow-state-manager.js
         - workflow-validator.js
+        - session-state.js
         - aiox-master
       externalDeps: []
       plannedDeps: []
@@ -4104,8 +4369,8 @@ entities:
         score: 0.8
         constraints: []
         extensionPoints: []
-      checksum: sha256:885b63bbfb3506740398768bc4979947acfc4063c5638d89566f6e6da74aaabb
-      lastVerified: '2026-03-11T00:48:55.842Z'
+      checksum: sha256:c1f10d20c25283675ca8b7f3644699c17298d7ffd2745640e252aa40bb654397
+      lastVerified: '2026-05-17T10:02:45.155Z'
     run-workflow:
       path: .aiox-core/development/tasks/run-workflow.md
       layer: L2
@@ -4121,6 +4386,7 @@ entities:
         - aiox-master
       dependencies:
         - run-workflow-engine
+        - session-state.js
         - aiox-master
       externalDeps: []
       plannedDeps:
@@ -4130,8 +4396,8 @@ entities:
         score: 0.8
         constraints: []
         extensionPoints: []
-      checksum: sha256:01a7addd0554399249541012f93f3ab2dd46e69336ba4f96737bc4e271b22b4b
-      lastVerified: '2026-03-11T00:48:55.842Z'
+      checksum: sha256:484bb719fc4b4584875370647c59c04bdc24b57eaaf6b99460404b57f80772b1
+      lastVerified: '2026-05-17T10:02:45.156Z'
     search-mcp:
       path: .aiox-core/development/tasks/search-mcp.md
       layer: L2
@@ -4153,7 +4419,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c7d9239c740b250baf9d82a5aa3baf1cd0bb8c671f0889c9a6fc6c0a668ac9c
-      lastVerified: '2026-03-11T00:48:55.842Z'
+      lastVerified: '2026-05-17T10:02:45.156Z'
     security-audit:
       path: .aiox-core/development/tasks/security-audit.md
       layer: L2
@@ -4175,7 +4441,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8ae6068628080d67c4c981d0c6e87d6347ddcc2e363d985ef578de22e94d6ae1
-      lastVerified: '2026-03-11T00:48:55.843Z'
+      lastVerified: '2026-05-17T10:02:45.157Z'
     security-scan:
       path: .aiox-core/development/tasks/security-scan.md
       layer: L2
@@ -4198,7 +4464,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2232ced35524452c49197fb4c09099dfc61c4980f31a8cd7fda3cc1b152068ca
-      lastVerified: '2026-03-11T00:48:55.843Z'
+      lastVerified: '2026-05-17T10:02:45.157Z'
     session-resume:
       path: .aiox-core/development/tasks/session-resume.md
       layer: L2
@@ -4221,7 +4487,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0130ea9c24b5c74a7803985f485663dd373edd366c8cbaa5d0143119a4e3cc3e
-      lastVerified: '2026-03-11T00:48:55.843Z'
+      lastVerified: '2026-05-17T10:02:45.158Z'
     setup-database:
       path: .aiox-core/development/tasks/setup-database.md
       layer: L2
@@ -4245,7 +4511,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3240013a44d42143a63280f0a1d6a8756a2572027e39b6fe913c1ed956442a38
-      lastVerified: '2026-03-11T00:48:55.843Z'
+      lastVerified: '2026-05-17T10:02:45.158Z'
     setup-design-system:
       path: .aiox-core/development/tasks/setup-design-system.md
       layer: L2
@@ -4270,7 +4536,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9cb43d28c66a6b7a8d36a16fc0256ea25c9bb49e214e37bce42cae4908450677
-      lastVerified: '2026-03-11T00:48:55.843Z'
+      lastVerified: '2026-05-17T10:02:45.158Z'
     setup-github:
       path: .aiox-core/development/tasks/setup-github.md
       layer: L2
@@ -4297,7 +4563,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:515cc5f26383c6fde61e38acb4678ead15d701ddc32c668a9b9bcfc9a02f2850
-      lastVerified: '2026-03-11T00:48:55.843Z'
+      lastVerified: '2026-05-17T10:02:45.159Z'
     setup-llm-routing:
       path: .aiox-core/development/tasks/setup-llm-routing.md
       layer: L2
@@ -4323,7 +4589,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:97334fdf1e679d9bd1deecf048f54760c3efdebf38af4daafe82094323f05865
-      lastVerified: '2026-03-11T00:48:55.844Z'
+      lastVerified: '2026-05-17T10:02:45.160Z'
     setup-mcp-docker:
       path: .aiox-core/development/tasks/setup-mcp-docker.md
       layer: L2
@@ -4349,7 +4615,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b65a663641b6667ac46848eab02ecb75da28e09e2cfa4d7d12f979c423eef999
-      lastVerified: '2026-03-11T00:48:55.844Z'
+      lastVerified: '2026-05-17T10:02:45.160Z'
     setup-project-docs:
       path: .aiox-core/development/tasks/setup-project-docs.md
       layer: L2
@@ -4381,7 +4647,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5e2969779d62d05a26fb49d5959d25224de748d2c70aaa72b6f219fb149decee
-      lastVerified: '2026-03-11T00:48:55.844Z'
+      lastVerified: '2026-05-17T10:02:45.160Z'
     shard-doc:
       path: .aiox-core/development/tasks/shard-doc.md
       layer: L2
@@ -4414,7 +4680,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:614fb73a40c4569d30e42a6a5536fbb374f2174bd709a73ad1026df595f50f52
-      lastVerified: '2026-03-11T00:48:55.844Z'
+      lastVerified: '2026-05-17T10:02:45.161Z'
     sm-create-next-story:
       path: .aiox-core/development/tasks/sm-create-next-story.md
       layer: L2
@@ -4452,7 +4718,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:86ee70cbe6ac6812dd9bbacc6e591046a9def3455efba19581155258173f91ba
-      lastVerified: '2026-03-11T00:48:55.844Z'
+      lastVerified: '2026-05-17T10:02:45.161Z'
     spec-assess-complexity:
       path: .aiox-core/development/tasks/spec-assess-complexity.md
       layer: L2
@@ -4478,7 +4744,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:860d6c4641282a426840ccea8bed766c8eddeb9806e4e0a806a330f70e5b6eca
-      lastVerified: '2026-03-11T00:48:55.844Z'
+      lastVerified: '2026-05-17T10:02:45.162Z'
     spec-critique:
       path: .aiox-core/development/tasks/spec-critique.md
       layer: L2
@@ -4507,7 +4773,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d2c3615b84dff942bb1c36fe1d89d025a5c52eedf15a382e75bba6cee085e7dd
-      lastVerified: '2026-03-11T00:48:55.845Z'
+      lastVerified: '2026-05-17T10:02:45.162Z'
     spec-gather-requirements:
       path: .aiox-core/development/tasks/spec-gather-requirements.md
       layer: L2
@@ -4534,7 +4800,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b2ae9cd6da1233bd610a0a8023dcf1dfece81ab75a1cb6da6b9016e0351a7d40
-      lastVerified: '2026-03-11T00:48:55.845Z'
+      lastVerified: '2026-05-17T10:02:45.163Z'
     spec-research-dependencies:
       path: .aiox-core/development/tasks/spec-research-dependencies.md
       layer: L2
@@ -4561,7 +4827,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c13f6fed7af8e1f8e20295e697637fc6831e559ba9d67d7649786626f2619a43
-      lastVerified: '2026-03-11T00:48:55.845Z'
+      lastVerified: '2026-05-17T10:02:45.163Z'
     spec-write-spec:
       path: .aiox-core/development/tasks/spec-write-spec.md
       layer: L2
@@ -4593,7 +4859,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1ecef348cf83403243398c362629e016ff299b4e0634d7a0581b39d779a113bf
-      lastVerified: '2026-03-11T00:48:55.845Z'
+      lastVerified: '2026-05-17T10:02:45.164Z'
     squad-creator-analyze:
       path: .aiox-core/development/tasks/squad-creator-analyze.md
       layer: L2
@@ -4620,7 +4886,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8aeeae86b0afd75c4f79e8a5f1cca02b3633c9d925ee39725a66795befecc8a8
-      lastVerified: '2026-03-11T00:48:55.845Z'
+      lastVerified: '2026-05-17T10:02:45.164Z'
     squad-creator-create:
       path: .aiox-core/development/tasks/squad-creator-create.md
       layer: L2
@@ -4648,7 +4914,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e4a8b8799837fb0ea60eb9baf3bbe57a27f1c1c7dd67ec8fd0c9d5d8a17bbce2
-      lastVerified: '2026-03-11T00:48:55.845Z'
+      lastVerified: '2026-05-17T10:02:45.165Z'
     squad-creator-design:
       path: .aiox-core/development/tasks/squad-creator-design.md
       layer: L2
@@ -4673,7 +4939,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b5851f22a2466107bf506707a01be7ff857b27b19d5d4ec4c5d0506cb6719e80
-      lastVerified: '2026-03-11T00:48:55.845Z'
+      lastVerified: '2026-05-17T10:02:45.165Z'
     squad-creator-download:
       path: .aiox-core/development/tasks/squad-creator-download.md
       layer: L2
@@ -4695,7 +4961,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5d75af6d41624a4c40d6734031ebc2a8f7eb4eb3ec22f10de32c92d600ddf332
-      lastVerified: '2026-03-11T00:48:55.845Z'
+      lastVerified: '2026-05-17T10:02:45.165Z'
     squad-creator-extend:
       path: .aiox-core/development/tasks/squad-creator-extend.md
       layer: L2
@@ -4724,7 +4990,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2d4a0bbe65d21aea5869b8df3a1e1d81a67e027402c4270b8dd1cc8b7c595573
-      lastVerified: '2026-03-11T00:48:55.845Z'
+      lastVerified: '2026-05-17T10:02:45.166Z'
     squad-creator-list:
       path: .aiox-core/development/tasks/squad-creator-list.md
       layer: L2
@@ -4748,7 +5014,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6bc04c23b31daa2f4e8448a5c28540ed8c35903c1b2c77e3ce7b0986268c8710
-      lastVerified: '2026-03-11T00:48:55.846Z'
+      lastVerified: '2026-05-17T10:02:45.166Z'
     squad-creator-migrate:
       path: .aiox-core/development/tasks/squad-creator-migrate.md
       layer: L2
@@ -4774,7 +5040,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:69a15d3db12cc1268740378fcd411a0a011c3f441e3eea6feaaf0b95f4bf8c1e
-      lastVerified: '2026-03-11T00:48:55.846Z'
+      lastVerified: '2026-05-17T10:02:45.166Z'
     squad-creator-publish:
       path: .aiox-core/development/tasks/squad-creator-publish.md
       layer: L2
@@ -4796,7 +5062,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9f744f0c1e70e18945bfdc22ea48a103862cdb7fffcbc36ac61d44473248b124
-      lastVerified: '2026-03-11T00:48:55.846Z'
+      lastVerified: '2026-05-17T10:02:45.167Z'
     squad-creator-sync-ide-command:
       path: .aiox-core/development/tasks/squad-creator-sync-ide-command.md
       layer: L2
@@ -4819,7 +5085,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4221574f07adb5fb53c7c0c9f85656222a97e623b5e4072cee37e34b82f3f379
-      lastVerified: '2026-03-11T00:48:55.846Z'
+      lastVerified: '2026-05-17T10:02:45.167Z'
     squad-creator-sync-synkra:
       path: .aiox-core/development/tasks/squad-creator-sync-synkra.md
       layer: L2
@@ -4842,7 +5108,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dd03f844de8aa1f1caac31b7791ae96b4a221a650728fb13ff6a6245f2e5f75a
-      lastVerified: '2026-03-11T00:48:55.846Z'
+      lastVerified: '2026-05-17T10:02:45.167Z'
     squad-creator-validate:
       path: .aiox-core/development/tasks/squad-creator-validate.md
       layer: L2
@@ -4868,7 +5134,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:782cc7e67b8d061475d94eff8312d5ec23d3ea84630797d9190384d3b3fafd8e
-      lastVerified: '2026-03-11T00:48:55.846Z'
+      lastVerified: '2026-05-17T10:02:45.167Z'
     story-checkpoint:
       path: .aiox-core/development/tasks/story-checkpoint.md
       layer: L2
@@ -4894,7 +5160,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:467fabe8b0c0c7fcd1bd122fdbdc883992a54656c6774c8cea2963789873ee4a
-      lastVerified: '2026-03-11T00:48:55.846Z'
+      lastVerified: '2026-05-17T10:02:45.168Z'
     sync-documentation:
       path: .aiox-core/development/tasks/sync-documentation.md
       layer: L2
@@ -4918,7 +5184,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8be6c2123aa935ddab5e845375c28213f70476cc9dfb10fd0e444c6d40a7e4ae
-      lastVerified: '2026-03-11T00:48:55.846Z'
+      lastVerified: '2026-05-17T10:02:45.168Z'
     sync-registry-intel:
       path: .aiox-core/development/tasks/sync-registry-intel.md
       layer: L2
@@ -4942,7 +5208,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:908df7d093442ccfd15805dabbd9f16e1f34b92ddb692f408a77484bb3d69a53
-      lastVerified: '2026-03-11T00:48:55.847Z'
+      lastVerified: '2026-05-17T10:02:45.168Z'
     tailwind-upgrade:
       path: .aiox-core/development/tasks/tailwind-upgrade.md
       layer: L2
@@ -4967,7 +5233,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa0bea0fc5513e13782bbb0bdb0564f15d7cc2d30b7954f26e52c980767d4469
-      lastVerified: '2026-03-11T00:48:55.847Z'
+      lastVerified: '2026-05-17T10:02:45.169Z'
     test-as-user:
       path: .aiox-core/development/tasks/test-as-user.md
       layer: L2
@@ -4994,7 +5260,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9117f1cf85c63be672b0e0f7207274ad73f384cf0299f5c32f9c2f7ad092a701
-      lastVerified: '2026-03-11T00:48:55.847Z'
+      lastVerified: '2026-05-17T10:02:45.169Z'
     test-validation-task:
       path: .aiox-core/development/tasks/test-validation-task.md
       layer: L2
@@ -5016,7 +5282,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2868bd169192b345cba423f2134d46a0d0337f9fe7135476b593e8e9b81617db
-      lastVerified: '2026-03-11T00:48:55.847Z'
+      lastVerified: '2026-05-17T10:02:45.169Z'
     triage-github-issues:
       path: .aiox-core/development/tasks/triage-github-issues.md
       layer: L2
@@ -5041,7 +5307,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73e1e42f0998a701f8855de6e8666150a284e44efd41878927defa17eded4cfe
-      lastVerified: '2026-03-11T00:48:55.847Z'
+      lastVerified: '2026-05-17T10:02:45.170Z'
     undo-last:
       path: .aiox-core/development/tasks/undo-last.md
       layer: L2
@@ -5068,7 +5334,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c038fd862dadcf7a4ad62e347ffa66e6335bc9bbd63d2e675a810381fb257f8a
-      lastVerified: '2026-03-11T00:48:55.847Z'
+      lastVerified: '2026-05-17T10:02:45.170Z'
     update-aiox:
       path: .aiox-core/development/tasks/update-aiox.md
       layer: L2
@@ -5092,7 +5358,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a88b1f79f52aad5aaaf2c7d385314718fd5f09316f37b65553b838b2cb445f95
-      lastVerified: '2026-03-11T00:48:55.847Z'
+      lastVerified: '2026-05-17T10:02:45.170Z'
     update-manifest:
       path: .aiox-core/development/tasks/update-manifest.md
       layer: L2
@@ -5118,7 +5384,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0ef0a5ed8638d1fa00317796acbd8419ca1bbbfa0c5e42109dda3d82300d8c12
-      lastVerified: '2026-03-11T00:48:55.847Z'
+      lastVerified: '2026-05-17T10:02:45.170Z'
     update-source-tree:
       path: .aiox-core/development/tasks/update-source-tree.md
       layer: L2
@@ -5142,7 +5408,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1d7eb7cbc8fa582375edc0275e98415f110e0507cb77744954fa342592ac1c56
-      lastVerified: '2026-03-11T00:48:55.847Z'
+      lastVerified: '2026-05-17T10:02:45.171Z'
     ux-create-wireframe:
       path: .aiox-core/development/tasks/ux-create-wireframe.md
       layer: L2
@@ -5167,7 +5433,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d3fe6c03050d98d0a46024c6c6aae32d4fb5e6d7b4a06b01401c54b0853469ce
-      lastVerified: '2026-03-11T00:48:55.848Z'
+      lastVerified: '2026-05-17T10:02:45.171Z'
     ux-ds-scan-artifact:
       path: .aiox-core/development/tasks/ux-ds-scan-artifact.md
       layer: L2
@@ -5195,7 +5461,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5a6eb9d40350c3cc15099f8f42beb8a15d64021916e4ec2e82142b33cecb1635
-      lastVerified: '2026-03-11T00:48:55.848Z'
+      lastVerified: '2026-05-17T10:02:45.171Z'
     ux-user-research:
       path: .aiox-core/development/tasks/ux-user-research.md
       layer: L2
@@ -5221,7 +5487,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0c497783693c6b49d71a99c136f3c016f94afe1fd7556eb6c050aa05a60adade
-      lastVerified: '2026-03-11T00:48:55.848Z'
+      lastVerified: '2026-05-17T10:02:45.172Z'
     validate-agents:
       path: .aiox-core/development/tasks/validate-agents.md
       layer: L2
@@ -5241,7 +5507,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b278ba27cf8171d143aba30bd2f708b9226526dae70e9b881f52b5e1e908525f
-      lastVerified: '2026-03-11T00:48:55.848Z'
+      lastVerified: '2026-05-17T10:02:45.172Z'
     validate-next-story:
       path: .aiox-core/development/tasks/validate-next-story.md
       layer: L2
@@ -5268,6 +5534,7 @@ entities:
         - architect
         - pm
         - qa
+        - po
         - sm
       externalDeps: []
       plannedDeps:
@@ -5278,8 +5545,8 @@ entities:
         score: 0.8
         constraints: []
         extensionPoints: []
-      checksum: sha256:a7e0dbd89753d72248a6171d6bd4aa88d97e9c5051a5889d566c509d048d113c
-      lastVerified: '2026-03-11T00:48:55.848Z'
+      checksum: sha256:f121211b1fbe915e181399d10bd30c435aec55c0af9b49d99c533473574a4907
+      lastVerified: '2026-05-17T10:02:45.172Z'
     validate-tech-preset:
       path: .aiox-core/development/tasks/validate-tech-preset.md
       layer: L2
@@ -5302,7 +5569,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:50a65289c223c1a79b0bebe4120f3f703df45d42522309e658f6d0f5c9fdb54e
-      lastVerified: '2026-03-11T00:48:55.848Z'
+      lastVerified: '2026-05-17T10:02:45.173Z'
     validate-workflow:
       path: .aiox-core/development/tasks/validate-workflow.md
       layer: L2
@@ -5327,7 +5594,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e01147feb106d803a298447e5a4988d5310e65cd5b5e291f771923d457056008
-      lastVerified: '2026-03-11T00:48:55.848Z'
+      lastVerified: '2026-05-17T10:02:45.173Z'
     verify-subtask:
       path: .aiox-core/development/tasks/verify-subtask.md
       layer: L2
@@ -5351,7 +5618,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4ad9d89256ed9c34f104ae951e7d3b3739f6c5611f22fcf98ab5b666b60cc39f
-      lastVerified: '2026-03-11T00:48:55.848Z'
+      lastVerified: '2026-05-17T10:02:45.173Z'
     waves:
       path: .aiox-core/development/tasks/waves.md
       layer: L2
@@ -5376,7 +5643,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f5bfc1c3d03bf9fbf7c7ac859dd5c388d327abc154f6c064e33dcbae3f94dbd9
-      lastVerified: '2026-03-11T00:48:55.848Z'
+      lastVerified: '2026-05-17T10:02:45.174Z'
     yolo-toggle:
       path: .aiox-core/development/tasks/yolo-toggle.md
       layer: L2
@@ -5399,7 +5666,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4fd6b6d8b2dc0130377ab66fcdf328e48df7701fb621cf919932245886642405
-      lastVerified: '2026-03-11T00:48:55.849Z'
+      lastVerified: '2026-05-17T10:02:45.174Z'
     README:
       path: .aiox-core/development/tasks/blocks/README.md
       layer: L2
@@ -5422,7 +5689,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:484409d3b069c30a14ba28873388567f06d613e6feb9acb14537434d1db03446
-      lastVerified: '2026-03-11T00:48:55.849Z'
+      lastVerified: '2026-05-17T10:02:45.174Z'
     agent-prompt-template:
       path: .aiox-core/development/tasks/blocks/agent-prompt-template.md
       layer: L2
@@ -5446,7 +5713,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7f61c142e66622159ed2ef119ed0abbc95ed514f21749a957f1aaa3babc57b36
-      lastVerified: '2026-03-11T00:48:55.849Z'
+      lastVerified: '2026-05-17T10:02:45.175Z'
     context-loading:
       path: .aiox-core/development/tasks/blocks/context-loading.md
       layer: L2
@@ -5469,7 +5736,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:281c958fa18a2a104c41a3b4b0d0338298034e4bf4e4f5b5085d10d8f603d797
-      lastVerified: '2026-03-11T00:48:55.849Z'
+      lastVerified: '2026-05-17T10:02:45.175Z'
     execution-pattern:
       path: .aiox-core/development/tasks/blocks/execution-pattern.md
       layer: L2
@@ -5491,7 +5758,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a29498d6f59be665a1fe494f3d2ce138da1b7f7eb62028f60acbe7a577bb2bd
-      lastVerified: '2026-03-11T00:48:55.849Z'
+      lastVerified: '2026-05-17T10:02:45.175Z'
     finalization:
       path: .aiox-core/development/tasks/blocks/finalization.md
       layer: L2
@@ -5512,7 +5779,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8414839ac579a6e25c8ad8cc3218bb5f216288ef30a0a995dde59d3d7dc9130e
-      lastVerified: '2026-03-11T00:48:55.849Z'
+      lastVerified: '2026-05-17T10:02:45.175Z'
   templates:
     activation-instructions-inline-greeting:
       path: .aiox-core/product/templates/activation-instructions-inline-greeting.yaml
@@ -5535,7 +5802,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d4d3dc2bf0c06c0094ab0e76029c0ad322222e3420240ac3abcac6c150a4ae01
-      lastVerified: '2026-03-11T00:48:55.851Z'
+      lastVerified: '2026-05-17T10:02:45.179Z'
     activation-instructions-template:
       path: .aiox-core/product/templates/activation-instructions-template.md
       layer: L2
@@ -5556,7 +5823,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b4df5343728e565d975c28cad8a1a9dac370d0cf827689ced1c553268dc265e7
-      lastVerified: '2026-03-11T00:48:55.851Z'
+      lastVerified: '2026-05-17T10:02:45.180Z'
     agent-template:
       path: .aiox-core/product/templates/agent-template.yaml
       layer: L2
@@ -5579,7 +5846,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:98676fcc493c0d5f09264dcc52fcc2cf1129f9a195824ecb4c2ec035c2515121
-      lastVerified: '2026-03-11T00:48:55.851Z'
+      lastVerified: '2026-05-17T10:02:45.180Z'
     aiox-ai-config:
       path: .aiox-core/product/templates/aiox-ai-config.yaml
       layer: L2
@@ -5601,7 +5868,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:14efe89e4be87326f621b1ff2a03c928806566ec134e74b191ff24156d5a0140
-      lastVerified: '2026-05-08T21:25:19.323Z'
+      lastVerified: '2026-05-17T10:02:45.181Z'
     architecture-tmpl:
       path: .aiox-core/product/templates/architecture-tmpl.yaml
       layer: L2
@@ -5622,7 +5889,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9483f38486932842e1bc1a73c35b3f90fa2cd9c703c7d5effabea7dc8f76350a
-      lastVerified: '2026-03-11T00:48:55.852Z'
+      lastVerified: '2026-05-17T10:02:45.181Z'
     brainstorming-output-tmpl:
       path: .aiox-core/product/templates/brainstorming-output-tmpl.yaml
       layer: L2
@@ -5643,7 +5910,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:acd98caed4a32328afdf3f3f42554a4f45e507cc527e95593fb7e63ccb8e66a1
-      lastVerified: '2026-03-11T00:48:55.852Z'
+      lastVerified: '2026-05-17T10:02:45.182Z'
     brownfield-architecture-tmpl:
       path: .aiox-core/product/templates/brownfield-architecture-tmpl.yaml
       layer: L2
@@ -5665,7 +5932,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5d399d93a42b674758515e5cf70ffb21cd77befc9f54a8fe0b9dba0773bbbf66
-      lastVerified: '2026-03-11T00:48:55.852Z'
+      lastVerified: '2026-05-17T10:02:45.182Z'
     brownfield-prd-tmpl:
       path: .aiox-core/product/templates/brownfield-prd-tmpl.yaml
       layer: L2
@@ -5687,7 +5954,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bc1852d15e3a383c7519e5976094de3055c494fdd467acd83137700c900c4c61
-      lastVerified: '2026-03-11T00:48:55.853Z'
+      lastVerified: '2026-05-17T10:02:45.183Z'
     brownfield-risk-report-tmpl:
       path: .aiox-core/product/templates/brownfield-risk-report-tmpl.yaml
       layer: L2
@@ -5710,7 +5977,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2aca2b93e48ea944bce3c933f7466b4e520e4c26ec486e23f0a82cccf6e0356b
-      lastVerified: '2026-03-11T00:48:55.853Z'
+      lastVerified: '2026-05-17T10:02:45.183Z'
     changelog-template:
       path: .aiox-core/product/templates/changelog-template.md
       layer: L2
@@ -5730,7 +5997,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:af44d857c9bf8808e89419d1d859557c3c827de143be3c0f36f2a053c9ee9197
-      lastVerified: '2026-03-11T00:48:55.853Z'
+      lastVerified: '2026-05-17T10:02:45.184Z'
     command-rationalization-matrix:
       path: .aiox-core/product/templates/command-rationalization-matrix.md
       layer: L2
@@ -5752,7 +6019,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:651157c5e6ad75323e24d5685660addb4f2cfe8bfa01e0c64a8e7e10c90f1d12
-      lastVerified: '2026-03-11T00:48:55.853Z'
+      lastVerified: '2026-05-17T10:02:45.184Z'
     competitor-analysis-tmpl:
       path: .aiox-core/product/templates/competitor-analysis-tmpl.yaml
       layer: L2
@@ -5774,7 +6041,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:690cde6406250883a765eddcbad415c737268525340cf2c8679c8f3074c9d507
-      lastVerified: '2026-03-11T00:48:55.853Z'
+      lastVerified: '2026-05-17T10:02:45.184Z'
     current-approach-tmpl:
       path: .aiox-core/product/templates/current-approach-tmpl.md
       layer: L2
@@ -5797,7 +6064,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec258049a5cda587b24523faf6b26ed0242765f4e732af21c4f42e42cf326714
-      lastVerified: '2026-03-11T00:48:55.853Z'
+      lastVerified: '2026-05-17T10:02:45.184Z'
     design-story-tmpl:
       path: .aiox-core/product/templates/design-story-tmpl.yaml
       layer: L2
@@ -5824,7 +6091,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2bfefc11ae2bcfc679dbd924c58f8b764fa23538c14cb25344d6edef41968f29
-      lastVerified: '2026-03-11T00:48:55.853Z'
+      lastVerified: '2026-05-17T10:02:45.185Z'
     ds-artifact-analysis:
       path: .aiox-core/product/templates/ds-artifact-analysis.md
       layer: L2
@@ -5847,7 +6114,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2ef1866841e4dcd55f9510f7ca14fd1f754f1e9c8a66cdc74d37ebcee13ede5d
-      lastVerified: '2026-03-11T00:48:55.853Z'
+      lastVerified: '2026-05-17T10:02:45.185Z'
     front-end-architecture-tmpl:
       path: .aiox-core/product/templates/front-end-architecture-tmpl.yaml
       layer: L2
@@ -5870,7 +6137,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de0432b4f98236c3a1d6cc9975b90fbc57727653bdcf6132355c0bcf0b4dbb9c
-      lastVerified: '2026-03-11T00:48:55.853Z'
+      lastVerified: '2026-05-17T10:02:45.186Z'
     front-end-spec-tmpl:
       path: .aiox-core/product/templates/front-end-spec-tmpl.yaml
       layer: L2
@@ -5893,7 +6160,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9033c7cccbd0893c11545c680f29c6743de8e7ad8e761c6c2487e2985b0a4411
-      lastVerified: '2026-03-11T00:48:55.854Z'
+      lastVerified: '2026-05-17T10:02:45.186Z'
     fullstack-architecture-tmpl:
       path: .aiox-core/product/templates/fullstack-architecture-tmpl.yaml
       layer: L2
@@ -5915,7 +6182,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1ac74304138be53d87808b8e4afe6f870936a1f3a9e35e18c3321b3d42145215
-      lastVerified: '2026-03-11T00:48:55.854Z'
+      lastVerified: '2026-05-17T10:02:45.187Z'
     github-actions-cd:
       path: .aiox-core/product/templates/github-actions-cd.yml
       layer: L2
@@ -5937,7 +6204,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e6d6f2da3909a76d188137962076988f8e639a8f580e278ddb076b917a159a63
-      lastVerified: '2026-03-11T00:48:55.854Z'
+      lastVerified: '2026-05-17T10:02:45.187Z'
     github-actions-ci:
       path: .aiox-core/product/templates/github-actions-ci.yml
       layer: L2
@@ -5959,7 +6226,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5628f43737eb39ba06d9c127dc42c9d89dc1ac712560ea948dee4cc3707fb517
-      lastVerified: '2026-03-11T00:48:55.854Z'
+      lastVerified: '2026-05-17T10:02:45.187Z'
     github-pr-template:
       path: .aiox-core/product/templates/github-pr-template.md
       layer: L2
@@ -5982,7 +6249,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:472729ec721fbf37ece2027861bb44e0d7a8f5a5f12d6fddb5b4a58a1fc34dd6
-      lastVerified: '2026-03-11T00:48:55.854Z'
+      lastVerified: '2026-05-17T10:02:45.187Z'
     gordon-mcp:
       path: .aiox-core/product/templates/gordon-mcp.yaml
       layer: L2
@@ -6004,7 +6271,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:54d961455a216f968bcb8234c5bf6cda3676e683f43dfcad7a18abc92dc767ab
-      lastVerified: '2026-03-11T00:48:55.854Z'
+      lastVerified: '2026-05-17T10:02:45.187Z'
     index-strategy-tmpl:
       path: .aiox-core/product/templates/index-strategy-tmpl.yaml
       layer: L2
@@ -6025,7 +6292,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6db2b40f6eef47f4faa31ce513ee7b0d5f04d9a5e081a72e0cdbad402eb444ae
-      lastVerified: '2026-03-11T00:48:55.854Z'
+      lastVerified: '2026-05-17T10:02:45.188Z'
     market-research-tmpl:
       path: .aiox-core/product/templates/market-research-tmpl.yaml
       layer: L2
@@ -6047,7 +6314,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a908f070009aa0403f9db542585401912aabe7913726bd2fa26b7954f162b674
-      lastVerified: '2026-03-11T00:48:55.854Z'
+      lastVerified: '2026-05-17T10:02:45.188Z'
     migration-plan-tmpl:
       path: .aiox-core/product/templates/migration-plan-tmpl.yaml
       layer: L2
@@ -6068,7 +6335,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d0b8580cab768484a2730b7a7f1032e2bab9643940d29dd3c351b7ac930e8ea1
-      lastVerified: '2026-03-11T00:48:55.855Z'
+      lastVerified: '2026-05-17T10:02:45.189Z'
     migration-strategy-tmpl:
       path: .aiox-core/product/templates/migration-strategy-tmpl.md
       layer: L2
@@ -6091,7 +6358,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:957ffccbe9eb1f1ea90a8951ef9eb187d22e50c2f95c2ff048580892d2f2e25b
-      lastVerified: '2026-03-11T00:48:55.855Z'
+      lastVerified: '2026-05-17T10:02:45.189Z'
     personalized-agent-template:
       path: .aiox-core/product/templates/personalized-agent-template.md
       layer: L2
@@ -6112,7 +6379,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:64062d7d4756859c3522e2a228b9079d1c7a5e22c8d1da69a7f0aa148f6181f2
-      lastVerified: '2026-03-11T00:48:55.855Z'
+      lastVerified: '2026-05-17T10:02:45.189Z'
     personalized-checklist-template:
       path: .aiox-core/product/templates/personalized-checklist-template.md
       layer: L2
@@ -6137,7 +6404,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:269ea02fb70b16e94f84ca1910e1911b1fe9fb190f6ed6e22ced869bde3a2e2d
-      lastVerified: '2026-03-11T00:48:55.855Z'
+      lastVerified: '2026-05-17T10:02:45.190Z'
     personalized-task-template-v2:
       path: .aiox-core/product/templates/personalized-task-template-v2.md
       layer: L2
@@ -6160,7 +6427,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:50dae1fdfd967c1713c76e51a418bb0d00f5d9546cade796973da94faac978d3
-      lastVerified: '2026-03-11T00:48:55.855Z'
+      lastVerified: '2026-05-17T10:02:45.192Z'
     personalized-task-template:
       path: .aiox-core/product/templates/personalized-task-template.md
       layer: L2
@@ -6182,7 +6449,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7d47e5603d8c950afcfd64dc54820bb93681c35f040a842dfcf7f77ead16f53f
-      lastVerified: '2026-03-11T00:48:55.855Z'
+      lastVerified: '2026-05-17T10:02:45.192Z'
     personalized-template-file:
       path: .aiox-core/product/templates/personalized-template-file.yaml
       layer: L2
@@ -6205,7 +6472,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8de995f022e873f8230000c07b55510c52c1477f30c4cd868f1c6fc5ffa9fd9b
-      lastVerified: '2026-03-11T00:48:55.855Z'
+      lastVerified: '2026-05-17T10:02:45.192Z'
     personalized-workflow-template:
       path: .aiox-core/product/templates/personalized-workflow-template.yaml
       layer: L2
@@ -6228,7 +6495,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2e61ec76a8638046aad135b3a8538810f32b1c7abc6353e35af61766453f74ba
-      lastVerified: '2026-03-11T00:48:55.856Z'
+      lastVerified: '2026-05-17T10:02:45.193Z'
     prd-tmpl:
       path: .aiox-core/product/templates/prd-tmpl.yaml
       layer: L2
@@ -6249,7 +6516,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:25c239f40e05f24aee1986601a98865188dbe3ea00a705028efc3adad6d420f3
-      lastVerified: '2026-03-11T00:48:55.856Z'
+      lastVerified: '2026-05-17T10:02:45.193Z'
     project-brief-tmpl:
       path: .aiox-core/product/templates/project-brief-tmpl.yaml
       layer: L2
@@ -6271,7 +6538,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b8d388268c24dc5018f48a87036d591b11cb122fafe9b59c17809b06ea5d9d58
-      lastVerified: '2026-03-11T00:48:55.856Z'
+      lastVerified: '2026-05-17T10:02:45.193Z'
     qa-gate-tmpl:
       path: .aiox-core/product/templates/qa-gate-tmpl.yaml
       layer: L2
@@ -6292,7 +6559,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a0d3e4a37ee8f719aacb8a31949522bfa239982198d0f347ea7d3f44ad8003ca
-      lastVerified: '2026-03-11T00:48:55.856Z'
+      lastVerified: '2026-05-17T10:02:45.194Z'
     qa-report-tmpl:
       path: .aiox-core/product/templates/qa-report-tmpl.md
       layer: L2
@@ -6314,7 +6581,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b2b0059050648fad63bfad7fa128225990b2fa6a6fb914902b2a5baf707c1cc6
-      lastVerified: '2026-03-11T00:48:55.856Z'
+      lastVerified: '2026-05-17T10:02:45.194Z'
     rls-policies-tmpl:
       path: .aiox-core/product/templates/rls-policies-tmpl.yaml
       layer: L2
@@ -6335,7 +6602,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3c303ab5a5f95c89f0caf9c632296e8ca43e29a921484523016c1c5bc320428f
-      lastVerified: '2026-03-11T00:48:55.856Z'
+      lastVerified: '2026-05-17T10:02:45.195Z'
     schema-design-tmpl:
       path: .aiox-core/product/templates/schema-design-tmpl.yaml
       layer: L2
@@ -6356,7 +6623,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7c5b7dfc67e1332e1fbf39657169094e2b92cd4fd6c7b441c3586981c732af95
-      lastVerified: '2026-03-11T00:48:55.856Z'
+      lastVerified: '2026-05-17T10:02:45.195Z'
     spec-tmpl:
       path: .aiox-core/product/templates/spec-tmpl.md
       layer: L2
@@ -6377,7 +6644,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ff625ad82e4e0f07c137ab5cd0567caac7980ab985783d2f76443dc900bffa5
-      lastVerified: '2026-03-11T00:48:55.857Z'
+      lastVerified: '2026-05-17T10:02:45.195Z'
     state-persistence-tmpl:
       path: .aiox-core/product/templates/state-persistence-tmpl.yaml
       layer: L2
@@ -6401,7 +6668,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7ff9caabce83ccc14acb05e9d06eaf369a8ebd54c2ddf4988efcc942f6c51037
-      lastVerified: '2026-03-11T00:48:55.857Z'
+      lastVerified: '2026-05-17T10:02:45.195Z'
     story-tmpl:
       path: .aiox-core/product/templates/story-tmpl.yaml
       layer: L2
@@ -6432,7 +6699,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0b64b49e5332cbce7d36da1ff40495628cb6ce650855b752dc82372706d41e13
-      lastVerified: '2026-03-11T00:48:55.857Z'
+      lastVerified: '2026-05-17T10:02:45.196Z'
     task-execution-report:
       path: .aiox-core/product/templates/task-execution-report.md
       layer: L2
@@ -6453,7 +6720,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e0f08a3e199234f3d2207ba8f435786b7d8e1b36174f46cb82fc3666b9a9309e
-      lastVerified: '2026-03-11T00:48:55.857Z'
+      lastVerified: '2026-05-17T10:02:45.196Z'
     task-template:
       path: .aiox-core/product/templates/task-template.md
       layer: L2
@@ -6474,7 +6741,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:aeb3a2843c1ca70a094601573899a47bb5956f3b5cd7a8bbad9d624ae39cf1fe
-      lastVerified: '2026-03-11T00:48:55.857Z'
+      lastVerified: '2026-05-17T10:02:45.196Z'
     tokens-schema-tmpl:
       path: .aiox-core/product/templates/tokens-schema-tmpl.yaml
       layer: L2
@@ -6496,7 +6763,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:66a7c164278cbe8b41dcc8525e382bdf5c59673a6694930aa33b857f199b4c2b
-      lastVerified: '2026-03-11T00:48:55.857Z'
+      lastVerified: '2026-05-17T10:02:45.197Z'
     workflow-template:
       path: .aiox-core/product/templates/workflow-template.yaml
       layer: L2
@@ -6518,7 +6785,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7185fbc069702ef6c4444c2c0cbf3d95f692435406ab3cad811768de4b7d4a28
-      lastVerified: '2026-03-11T00:48:55.857Z'
+      lastVerified: '2026-05-17T10:02:45.197Z'
     antigravity-rules:
       path: .aiox-core/product/templates/ide-rules/antigravity-rules.md
       layer: L2
@@ -6547,7 +6814,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:150fd84d590c2d41f169afdc2368743cb5a90a94a29df2f217b5e5a8e9c3ee1b
-      lastVerified: '2026-03-11T00:48:55.857Z'
+      lastVerified: '2026-05-17T10:02:45.197Z'
     claude-rules:
       path: .aiox-core/product/templates/ide-rules/claude-rules.md
       layer: L2
@@ -6580,7 +6847,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d5723c0a6d77b7137e9b8699937841f7452302b60905cd35276a319e6ce01742
-      lastVerified: '2026-03-11T00:48:55.857Z'
+      lastVerified: '2026-05-17T10:02:45.197Z'
     codex-rules:
       path: .aiox-core/product/templates/ide-rules/codex-rules.md
       layer: L2
@@ -6615,7 +6882,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:18302f137bda51c687b7c7ad76a17f73d84a1e254801ab9e72837d577962b7c5
-      lastVerified: '2026-03-11T00:48:55.858Z'
+      lastVerified: '2026-05-17T10:02:45.197Z'
     copilot-rules:
       path: .aiox-core/product/templates/ide-rules/copilot-rules.md
       layer: L2
@@ -6638,12 +6905,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5f7ecf4f6dbac28bc49b3a61d0902dcc28023b2918082195aab721b0a24847be
-      lastVerified: '2026-03-11T00:48:55.858Z'
+      lastVerified: '2026-05-17T10:02:45.197Z'
     cursor-rules:
       path: .aiox-core/product/templates/ide-rules/cursor-rules.md
       layer: L2
       type: template
-      purpose: Synkra AIOX Development Rules for Cursor
+      purpose: Synkra AIOX global rules loaded on every Cursor conversation
       keywords:
         - cursor
         - rules
@@ -6666,8 +6933,8 @@ entities:
         score: 0.5
         constraints: []
         extensionPoints: []
-      checksum: sha256:40c5a75ec40a9d2da713336ced608eb4606bf7e76fe9b34827e888ed27903464
-      lastVerified: '2026-03-11T00:48:55.858Z'
+      checksum: sha256:ea607f2b6a089afccbcaaec3b1197b5396c4446e76a689a51867a78bceda09b2
+      lastVerified: '2026-05-17T10:02:45.198Z'
     gemini-rules:
       path: .aiox-core/product/templates/ide-rules/gemini-rules.md
       layer: L2
@@ -6688,7 +6955,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:20f687384c4deb909e9171f8e83f40b962a9cc717755b62d88db285316b2188a
-      lastVerified: '2026-03-11T00:48:55.858Z'
+      lastVerified: '2026-05-17T10:02:45.198Z'
   scripts:
     activation-runtime:
       path: .aiox-core/development/scripts/activation-runtime.js
@@ -6710,7 +6977,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3750084310b5a88e2f8d345ad4b417a408f2633d10dab11f4d648e8e10caa90c
-      lastVerified: '2026-03-11T00:48:55.859Z'
+      lastVerified: '2026-05-17T10:02:45.199Z'
     agent-assignment-resolver:
       path: .aiox-core/development/scripts/agent-assignment-resolver.js
       layer: L2
@@ -6730,7 +6997,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ae8a89d038cd9af894d9ec45d8b97ed930f84f70e88f17dbf1a3c556e336c75e
-      lastVerified: '2026-03-11T00:48:55.859Z'
+      lastVerified: '2026-05-17T10:02:45.200Z'
     agent-config-loader:
       path: .aiox-core/development/scripts/agent-config-loader.js
       layer: L2
@@ -6755,7 +7022,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6935a5574f887d88101c44340a96f2a4f8d01b2bdeb433108b84253178a106c7
-      lastVerified: '2026-03-11T00:48:55.859Z'
+      lastVerified: '2026-05-17T10:02:45.200Z'
     agent-exit-hooks:
       path: .aiox-core/development/scripts/agent-exit-hooks.js
       layer: L2
@@ -6776,7 +7043,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7aee7f33cae1bc4192a5085898caaf57f4866ce68488637d0f90a6372b616ce8
-      lastVerified: '2026-03-11T00:48:55.859Z'
+      lastVerified: '2026-05-17T10:02:45.200Z'
     apply-inline-greeting-all-agents:
       path: .aiox-core/development/scripts/apply-inline-greeting-all-agents.js
       layer: L2
@@ -6798,7 +7065,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5de6a7ddcab1ae34043b8a030b664deb9ce79e187ca30d22656716240e76a030
-      lastVerified: '2026-03-11T00:48:55.859Z'
+      lastVerified: '2026-05-17T10:02:45.201Z'
     approval-workflow:
       path: .aiox-core/development/scripts/approval-workflow.js
       layer: L2
@@ -6817,7 +7084,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:06979905e62b61e6dde1d2e1714ce61b9a4538a31f31ae1e5f41365f36395b09
-      lastVerified: '2026-03-11T00:48:55.859Z'
+      lastVerified: '2026-05-17T10:02:45.201Z'
     audit-agent-config:
       path: .aiox-core/development/scripts/audit-agent-config.js
       layer: L2
@@ -6837,7 +7104,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d3908286737b3951a0140224aae604d63ab485d503d1f0fb83bc902112637db0
-      lastVerified: '2026-03-11T00:48:55.859Z'
+      lastVerified: '2026-05-17T10:02:45.201Z'
     backlog-manager:
       path: .aiox-core/development/scripts/backlog-manager.js
       layer: L2
@@ -6859,7 +7126,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7790e867301aed155dcad303feb8113ffd45abe99052e70749ceaae894e9620b
-      lastVerified: '2026-03-11T00:48:55.859Z'
+      lastVerified: '2026-05-17T10:02:45.201Z'
     backup-manager:
       path: .aiox-core/development/scripts/backup-manager.js
       layer: L2
@@ -6880,7 +7147,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:81c9fd6a4b8a8e7feb1f7a9d6ba790e597ad8113a9ca0723ae20eb111bfb3cee
-      lastVerified: '2026-03-11T00:48:55.859Z'
+      lastVerified: '2026-05-17T10:02:45.202Z'
     batch-update-agents-session-context:
       path: .aiox-core/development/scripts/batch-update-agents-session-context.js
       layer: L2
@@ -6902,7 +7169,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d6fa38b55d788f0832021a15492d6b19d8967b481c05b87ab67d33a90ff7269b
-      lastVerified: '2026-03-11T00:48:55.859Z'
+      lastVerified: '2026-05-17T10:02:45.202Z'
     branch-manager:
       path: .aiox-core/development/scripts/branch-manager.js
       layer: L2
@@ -6922,7 +7189,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5d292b329fea370ee9e0930c5d6e9cb5c69af78ec1435ee194ddba0c3d2232a1
-      lastVerified: '2026-03-11T00:48:55.860Z'
+      lastVerified: '2026-05-17T10:02:45.202Z'
     code-quality-improver:
       path: .aiox-core/development/scripts/code-quality-improver.js
       layer: L2
@@ -6942,7 +7209,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d0c844089e53dcd6c06755d4cb432a60fbebcedcf5a86ed635650573549a1941
-      lastVerified: '2026-03-11T00:48:55.860Z'
+      lastVerified: '2026-05-17T10:02:45.203Z'
     commit-message-generator:
       path: .aiox-core/development/scripts/commit-message-generator.js
       layer: L2
@@ -6964,7 +7231,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c5990a5a012a2994d9a4d29ded445fef21d51e0b8203292104fbbd76b3e23826
-      lastVerified: '2026-03-11T00:48:55.860Z'
+      lastVerified: '2026-05-17T10:02:45.203Z'
     conflict-resolver:
       path: .aiox-core/development/scripts/conflict-resolver.js
       layer: L2
@@ -6984,7 +7251,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8971b9aca2ab23a9478ac70e59710ec843f483fcbe088371444f4fc9b56c5278
-      lastVerified: '2026-03-11T00:48:55.860Z'
+      lastVerified: '2026-05-17T10:02:45.204Z'
     decision-context:
       path: .aiox-core/development/scripts/decision-context.js
       layer: L2
@@ -7004,7 +7271,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7deca4e738f078e2ccded6e8e26d2322697ea7b9fedf5a48fe8eec18e227c347
-      lastVerified: '2026-03-11T00:48:55.860Z'
+      lastVerified: '2026-05-17T10:02:45.204Z'
     decision-log-generator:
       path: .aiox-core/development/scripts/decision-log-generator.js
       layer: L2
@@ -7031,7 +7298,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:15f1c67d72d2572c68cf8738dfc549166c424475f6706502496f4e21596db504
-      lastVerified: '2026-03-11T00:48:55.860Z'
+      lastVerified: '2026-05-17T10:02:45.204Z'
     decision-log-indexer:
       path: .aiox-core/development/scripts/decision-log-indexer.js
       layer: L2
@@ -7052,7 +7319,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4525176b92aefc6ea7387fc350e325192af044769b4774fde5bf35d74f93fd56
-      lastVerified: '2026-03-11T00:48:55.860Z'
+      lastVerified: '2026-05-17T10:02:45.205Z'
     decision-recorder:
       path: .aiox-core/development/scripts/decision-recorder.js
       layer: L2
@@ -7075,7 +7342,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73a259407434e4c4653232e578d408ea6dbde5b809a8c16b7cb169933b941c1c
-      lastVerified: '2026-03-11T00:48:55.860Z'
+      lastVerified: '2026-05-17T10:02:45.205Z'
     dependency-analyzer:
       path: .aiox-core/development/scripts/dependency-analyzer.js
       layer: L2
@@ -7094,7 +7361,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0ab1a54c3df1cd81c8bc4b7f4d769f91c7b0bfa6ce38b8c7e1d7d5b223d2245f
-      lastVerified: '2026-03-11T00:48:55.860Z'
+      lastVerified: '2026-05-17T10:02:45.205Z'
     dev-context-loader:
       path: .aiox-core/development/scripts/dev-context-loader.js
       layer: L2
@@ -7114,7 +7381,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0db8d8c4ec863935b02263560d90a901462fb51a87e922baee26882c9d3b8f7c
-      lastVerified: '2026-03-11T00:48:55.861Z'
+      lastVerified: '2026-05-17T10:02:45.206Z'
     diff-generator:
       path: .aiox-core/development/scripts/diff-generator.js
       layer: L2
@@ -7133,7 +7400,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cad97b0096fc034fa6ed6cbd14a963abe32d880c1ce8034b6aa62af2e2239833
-      lastVerified: '2026-03-11T00:48:55.861Z'
+      lastVerified: '2026-05-17T10:02:45.206Z'
     elicitation-engine:
       path: .aiox-core/development/scripts/elicitation-engine.js
       layer: L2
@@ -7154,7 +7421,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ce7ea9b9c7e3600fcec27eee444a2860c15ec187ca449f3b63564f453d71c50
-      lastVerified: '2026-03-11T00:48:55.861Z'
+      lastVerified: '2026-05-17T10:02:45.206Z'
     elicitation-session-manager:
       path: .aiox-core/development/scripts/elicitation-session-manager.js
       layer: L2
@@ -7175,7 +7442,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0a7141f2cf61e8fa32f8c861633b50e87e75bc6023b650756c1b55ad947d314b
-      lastVerified: '2026-03-11T00:48:55.861Z'
+      lastVerified: '2026-05-17T10:02:45.206Z'
     generate-greeting:
       path: .aiox-core/development/scripts/generate-greeting.js
       layer: L2
@@ -7195,7 +7462,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:49b857fe36a0216a0df8395a6847f14608bd6a228817276201d22598a6862a4f
-      lastVerified: '2026-03-11T00:48:55.861Z'
+      lastVerified: '2026-05-17T10:02:45.206Z'
     git-wrapper:
       path: .aiox-core/development/scripts/git-wrapper.js
       layer: L2
@@ -7215,7 +7482,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ca880db21647162725bbc5bcd4a01613ad2cc4911aa829a9b9242a05bb62283a
-      lastVerified: '2026-05-06T22:00:40.770Z'
+      lastVerified: '2026-05-17T10:02:45.207Z'
     greeting-builder:
       path: .aiox-core/development/scripts/greeting-builder.js
       layer: L2
@@ -7233,21 +7500,20 @@ entities:
         - workflow-navigator
         - greeting-preference-manager
         - project-status-loader
-        - permissions
+        - permissions-index
         - config-resolver
         - validate-user-profile
         - session-state
         - surface-checker
       externalDeps: []
-      plannedDeps:
-        - permissions
+      plannedDeps: []
       lifecycle: production
       adaptability:
         score: 0.7
         constraints: []
         extensionPoints: []
       checksum: sha256:dd0c50dc690a44fdddd9cf8adde609ea0ef2aa6916a78b9fcc971195ddff5656
-      lastVerified: '2026-05-06T20:38:53.200Z'
+      lastVerified: '2026-05-17T10:02:45.208Z'
     greeting-config-cli:
       path: .aiox-core/development/scripts/greeting-config-cli.js
       layer: L2
@@ -7268,7 +7534,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c6e5c4dac08349b17cae64562311a5c2fab8d7c29bc96d86cbe2b43846312b3d
-      lastVerified: '2026-03-11T00:48:55.861Z'
+      lastVerified: '2026-05-17T10:02:45.209Z'
     greeting-preference-manager:
       path: .aiox-core/development/scripts/greeting-preference-manager.js
       layer: L2
@@ -7291,7 +7557,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f6e8034fb7eb27a05f0ef186351282073c3e9b7d5d1db67fb88814c9b72fc219
-      lastVerified: '2026-03-11T00:48:55.861Z'
+      lastVerified: '2026-05-17T10:02:45.209Z'
     issue-triage:
       path: .aiox-core/development/scripts/issue-triage.js
       layer: L2
@@ -7310,7 +7576,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a9f9741b1426732f19803bf9f292b15d8eed0fb875cf02df70735f48512f2310
-      lastVerified: '2026-03-11T00:48:55.861Z'
+      lastVerified: '2026-05-17T10:02:45.209Z'
     manifest-preview:
       path: .aiox-core/development/scripts/manifest-preview.js
       layer: L2
@@ -7331,7 +7597,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:93fff0b2f1993f1f03352a8d9162b93368a7f3b0caf1223ea23b228d092d2084
-      lastVerified: '2026-03-11T00:48:55.862Z'
+      lastVerified: '2026-05-17T10:02:45.209Z'
     metrics-tracker:
       path: .aiox-core/development/scripts/metrics-tracker.js
       layer: L2
@@ -7351,7 +7617,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ac90ed08276a66591c8170ef5b5501f46cb1ba9d276b383e20fc77a563083312
-      lastVerified: '2026-03-11T00:48:55.862Z'
+      lastVerified: '2026-05-17T10:02:45.209Z'
     migrate-task-to-v2:
       path: .aiox-core/development/scripts/migrate-task-to-v2.js
       layer: L2
@@ -7372,7 +7638,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6bfef70de9592d53657f10a4e5c4582ac0ff11868d29e78b86676db45816152d
-      lastVerified: '2026-03-11T00:48:55.862Z'
+      lastVerified: '2026-05-17T10:02:45.209Z'
     modification-validator:
       path: .aiox-core/development/scripts/modification-validator.js
       layer: L2
@@ -7394,7 +7660,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8bff78c5ce3a7c1add30f21f3b835aafd1b54b1752b7f24fc687a672026d7b13
-      lastVerified: '2026-03-11T00:48:55.862Z'
+      lastVerified: '2026-05-17T10:02:45.210Z'
     pattern-learner:
       path: .aiox-core/development/scripts/pattern-learner.js
       layer: L2
@@ -7414,7 +7680,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d562b095bd15dc12a4f474883a1ddb25fa4b7353729c1ff1eaa53675b964de52
-      lastVerified: '2026-03-11T00:48:55.862Z'
+      lastVerified: '2026-05-17T10:02:45.210Z'
     performance-analyzer:
       path: .aiox-core/development/scripts/performance-analyzer.js
       layer: L2
@@ -7433,7 +7699,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:52fc6c7dd22d7bdbbdfe51393c845075ee4fad75067fd91665682b9f0654e7c4
-      lastVerified: '2026-03-11T00:48:55.862Z'
+      lastVerified: '2026-05-17T10:02:45.211Z'
     populate-entity-registry:
       path: .aiox-core/development/scripts/populate-entity-registry.js
       layer: L2
@@ -7454,7 +7720,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:418fcbf6ca3a6259f8d13e3290e8e49d6a16917b304039a6470264c5fdece89e
-      lastVerified: '2026-05-08T14:34:39.788Z'
+      lastVerified: '2026-05-17T10:02:45.211Z'
     refactoring-suggester:
       path: .aiox-core/development/scripts/refactoring-suggester.js
       layer: L2
@@ -7473,7 +7739,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d50ea6b609c9cf8385979386fee4b4385d11ebcde15460260f66d04c705f6cd9
-      lastVerified: '2026-03-11T00:48:55.863Z'
+      lastVerified: '2026-05-17T10:02:45.211Z'
     rollback-handler:
       path: .aiox-core/development/scripts/rollback-handler.js
       layer: L2
@@ -7494,7 +7760,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1017334a2fcc7c13cf46f12da127525435c0689e4d123d44156699431e941cd8
-      lastVerified: '2026-03-11T00:48:55.863Z'
+      lastVerified: '2026-05-17T10:02:45.212Z'
     security-checker:
       path: .aiox-core/development/scripts/security-checker.js
       layer: L2
@@ -7513,7 +7779,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e567af91b0b79e7ba51399cf6bfe4279417e632465f923bc8334c28f9405883c
-      lastVerified: '2026-03-11T00:48:55.863Z'
+      lastVerified: '2026-05-17T10:02:45.212Z'
     skill-validator:
       path: .aiox-core/development/scripts/skill-validator.js
       layer: L2
@@ -7532,7 +7798,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b6bab880896a6fdb16d288c11e1d8fe3fa9f57f144b213bcb6eca1560ec38af1
-      lastVerified: '2026-03-11T00:48:55.863Z'
+      lastVerified: '2026-05-17T10:02:45.212Z'
     story-index-generator:
       path: .aiox-core/development/scripts/story-index-generator.js
       layer: L2
@@ -7553,7 +7819,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c9ce1d2f89e76b9b2250aaa2b49a2881fc331dfbdec0bc0c5b7e1ec7767af140
-      lastVerified: '2026-03-11T00:48:55.863Z'
+      lastVerified: '2026-05-17T10:02:45.212Z'
     story-manager:
       path: .aiox-core/development/scripts/story-manager.js
       layer: L2
@@ -7579,7 +7845,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ba05c6dc3b29dad5ca57b0dafad8951d750bc30bdc04a9b083d4878c6f84f8f2
-      lastVerified: '2026-03-11T00:48:55.863Z'
+      lastVerified: '2026-05-17T10:02:45.213Z'
     story-update-hook:
       path: .aiox-core/development/scripts/story-update-hook.js
       layer: L2
@@ -7601,7 +7867,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:554a162e434717f86858ef04d8fdfe3ac40decf060cdc3d4d4987959fb2c51df
-      lastVerified: '2026-03-11T00:48:55.863Z'
+      lastVerified: '2026-05-17T10:02:45.213Z'
     task-identifier-resolver:
       path: .aiox-core/development/scripts/task-identifier-resolver.js
       layer: L2
@@ -7621,7 +7887,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ef63e5302a7393d4409e50fc437fdf33bd85f40b1907862ccfd507188f072d22
-      lastVerified: '2026-03-11T00:48:55.863Z'
+      lastVerified: '2026-05-17T10:02:45.213Z'
     template-engine:
       path: .aiox-core/development/scripts/template-engine.js
       layer: L2
@@ -7640,7 +7906,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b97d091cb9a09e64d8632ae106cd00b3fd8a25bfbdb60d8cda6e5591c7dfd67f
-      lastVerified: '2026-03-11T00:48:55.863Z'
+      lastVerified: '2026-05-17T10:02:45.213Z'
     template-validator:
       path: .aiox-core/development/scripts/template-validator.js
       layer: L2
@@ -7660,7 +7926,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fb87e8d076b57469d33034f2cae32fd01eae81900317a267d26ab18eebaacb17
-      lastVerified: '2026-03-11T00:48:55.863Z'
+      lastVerified: '2026-05-17T10:02:45.214Z'
     test-generator:
       path: .aiox-core/development/scripts/test-generator.js
       layer: L2
@@ -7679,7 +7945,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c49f0d828ba4e5d996f6dc4fedd540fe2a95091de5e45093018686181493d164
-      lastVerified: '2026-03-11T00:48:55.864Z'
+      lastVerified: '2026-05-17T10:02:45.214Z'
     test-greeting-system:
       path: .aiox-core/development/scripts/test-greeting-system.js
       layer: L2
@@ -7700,7 +7966,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:598f32f09db543e67c0e79da78aaa6e2c78eb54b8f91a5014a27c67468e663bb
-      lastVerified: '2026-03-11T00:48:55.864Z'
+      lastVerified: '2026-05-17T10:02:45.214Z'
     transaction-manager:
       path: .aiox-core/development/scripts/transaction-manager.js
       layer: L2
@@ -7720,7 +7986,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c1049e40ffa489206b48a8c95b0a55093ebf95fc2b2fb522e33b0fc8023d7d2a
-      lastVerified: '2026-03-11T00:48:55.864Z'
+      lastVerified: '2026-05-17T10:02:45.215Z'
     unified-activation-pipeline:
       path: .aiox-core/development/scripts/unified-activation-pipeline.js
       layer: L2
@@ -7738,15 +8004,13 @@ entities:
         - context-loader
         - project-status-loader
         - git-config-detector
-        - permissions
+        - permissions-index
         - greeting-preference-manager
         - context-detector
         - workflow-navigator
         - atomic-write
-        - pro-detector
       externalDeps: []
       plannedDeps:
-        - permissions
         - pro-detector
       lifecycle: production
       adaptability:
@@ -7754,7 +8018,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6910a7f6b0cef65a0886e0b29bbcb0ee401ca4fb444eb255a7a368cb67327aa7
-      lastVerified: '2026-05-06T23:18:07.594Z'
+      lastVerified: '2026-05-17T10:02:45.216Z'
     usage-tracker:
       path: .aiox-core/development/scripts/usage-tracker.js
       layer: L2
@@ -7774,7 +8038,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6057623755bf0ee1d9e0fb36740fc41914a5f8ca8ad994d40edec260e273744b
-      lastVerified: '2026-03-11T00:48:55.864Z'
+      lastVerified: '2026-05-17T10:02:45.216Z'
     validate-filenames:
       path: .aiox-core/development/scripts/validate-filenames.js
       layer: L2
@@ -7793,7 +8057,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0228b1538ff02dfe1f747038cbb5e86630683a3c950e27d6315bcd762b1a93fd
-      lastVerified: '2026-03-11T00:48:55.864Z'
+      lastVerified: '2026-05-17T10:02:45.217Z'
     validate-task-v2:
       path: .aiox-core/development/scripts/validate-task-v2.js
       layer: L2
@@ -7813,7 +8077,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4abe50b097c2d0f7a722b691ecd84021ea48b76a017ad76f4c49f748d002fe09
-      lastVerified: '2026-03-11T00:48:55.864Z'
+      lastVerified: '2026-05-17T10:02:45.217Z'
     verify-workflow-gaps:
       path: .aiox-core/development/scripts/verify-workflow-gaps.js
       layer: L2
@@ -7839,7 +8103,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a06a3fac2c4fdf995f18d6108d48855a1156b763ef906a3943b94dc9a709c167
-      lastVerified: '2026-03-11T00:48:55.865Z'
+      lastVerified: '2026-05-17T10:02:45.217Z'
     version-tracker:
       path: .aiox-core/development/scripts/version-tracker.js
       layer: L2
@@ -7858,7 +8122,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d11804b82497e2a9c6e83191095681f5d57ac956b69975294f3f9d2efd0a7bdd
-      lastVerified: '2026-03-11T00:48:55.865Z'
+      lastVerified: '2026-05-17T10:02:45.218Z'
     workflow-navigator:
       path: .aiox-core/development/scripts/workflow-navigator.js
       layer: L2
@@ -7879,8 +8143,8 @@ entities:
         score: 0.7
         constraints: []
         extensionPoints: []
-      checksum: sha256:45bd9f0317b6a0b9e9577b5b26550f1b7fafec2c45c1b542a6947ffd69a70fec
-      lastVerified: '2026-03-11T00:48:55.865Z'
+      checksum: sha256:e9af315c4b6ed0f3a0ccc0956921b04f75865a019ada427bdb1d871a1a059bcb
+      lastVerified: '2026-05-17T10:02:45.218Z'
     workflow-state-manager:
       path: .aiox-core/development/scripts/workflow-state-manager.js
       layer: L2
@@ -7902,8 +8166,8 @@ entities:
         score: 0.7
         constraints: []
         extensionPoints: []
-      checksum: sha256:3a896079b32b8efb8c532c0626c4ce14fb52cc92afbb086f6f2d2a0367d60dec
-      lastVerified: '2026-03-11T00:48:55.865Z'
+      checksum: sha256:34b249724bb9b4625b4c6e0c67f412d341927323278867367faf8999d09e741c
+      lastVerified: '2026-05-17T10:02:45.218Z'
     workflow-validator:
       path: .aiox-core/development/scripts/workflow-validator.js
       layer: L2
@@ -7927,7 +8191,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:abb16e5cd34ec06bbca0a31af3fc500c3a5c98f66d0a72546e4a2827653abcd3
-      lastVerified: '2026-03-11T00:48:55.865Z'
+      lastVerified: '2026-05-17T10:02:45.219Z'
     yaml-validator:
       path: .aiox-core/development/scripts/yaml-validator.js
       layer: L2
@@ -7946,7 +8210,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:916864f9e56e1ccb7fc1596bd2da47400e4037f848a0d4e2bc46d0fa24cc544f
-      lastVerified: '2026-03-11T00:48:55.865Z'
+      lastVerified: '2026-05-17T10:02:45.219Z'
     index:
       path: .aiox-core/development/scripts/squad/index.js
       layer: L2
@@ -7972,7 +8236,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d9bab56298104c00cc55d5e68bcf8bf660bc0f2a3f8c7609dc2ed911d34a4492
-      lastVerified: '2026-03-11T00:48:55.865Z'
+      lastVerified: '2026-05-17T10:02:45.219Z'
     squad-analyzer:
       path: .aiox-core/development/scripts/squad/squad-analyzer.js
       layer: L2
@@ -7992,7 +8256,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3aa6fd5273ee0cc35331d4150ed98ef43e8ab678c7c7eaaf4b6ea4b40c657b0c
-      lastVerified: '2026-03-11T00:48:55.865Z'
+      lastVerified: '2026-05-17T10:02:45.220Z'
     squad-designer:
       path: .aiox-core/development/scripts/squad/squad-designer.js
       layer: L2
@@ -8015,7 +8279,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:101cbb7d6ded0d6f991b29ac63dfee2c7bb86cbc8c4fefef728b7d12c3352829
-      lastVerified: '2026-03-11T00:48:55.866Z'
+      lastVerified: '2026-05-17T10:02:45.220Z'
     squad-downloader:
       path: .aiox-core/development/scripts/squad/squad-downloader.js
       layer: L2
@@ -8037,7 +8301,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e171444c33222c3ee7b34a874ce2298de010ddf9f883d9741084621084564dc9
-      lastVerified: '2026-03-11T00:48:55.866Z'
+      lastVerified: '2026-05-17T10:02:45.221Z'
     squad-extender:
       path: .aiox-core/development/scripts/squad/squad-extender.js
       layer: L2
@@ -8058,7 +8322,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de3ee647aa5d1fb32a4216777f3bd4716022fec64f0566c0a004b0ea4d110cca
-      lastVerified: '2026-03-11T00:48:55.866Z'
+      lastVerified: '2026-05-17T10:02:45.221Z'
     squad-generator:
       path: .aiox-core/development/scripts/squad/squad-generator.js
       layer: L2
@@ -8082,7 +8346,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c8c75b71af915c95b781662ba5cdee5899fd6842966fd8b90019923e091be575
-      lastVerified: '2026-03-11T00:48:55.866Z'
+      lastVerified: '2026-05-17T10:02:45.222Z'
     squad-loader:
       path: .aiox-core/development/scripts/squad/squad-loader.js
       layer: L2
@@ -8108,7 +8372,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7093b9457c93da6845722bf7eac660164963d5007c459afae2149340a7979f1f
-      lastVerified: '2026-03-11T00:48:55.866Z'
+      lastVerified: '2026-05-17T10:02:45.222Z'
     squad-migrator:
       path: .aiox-core/development/scripts/squad/squad-migrator.js
       layer: L2
@@ -8129,7 +8393,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:38d7906b3718701130c79ed66f2916710f0f13fb2d445b13e8cdb1c199192a0d
-      lastVerified: '2026-03-11T00:48:55.866Z'
+      lastVerified: '2026-05-17T10:02:45.222Z'
     squad-publisher:
       path: .aiox-core/development/scripts/squad/squad-publisher.js
       layer: L2
@@ -8151,7 +8415,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73b3adcf1b6edb16cd1679fe37852d1f2fde5c89cee4ea7b0ae8ca95f7ff85d2
-      lastVerified: '2026-03-11T00:48:55.866Z'
+      lastVerified: '2026-05-17T10:02:45.223Z'
     squad-validator:
       path: .aiox-core/development/scripts/squad/squad-validator.js
       layer: L2
@@ -8180,7 +8444,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bba0ca266653ca7d6162de011165256e6e49ebe34f2136ae16a4c3393901ab27
-      lastVerified: '2026-03-11T00:48:55.867Z'
+      lastVerified: '2026-05-17T10:02:45.223Z'
   modules:
     index.esm:
       path: .aiox-core/core/index.esm.js
@@ -8211,7 +8475,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:10586193db3efc151c4347d24786a657a01f611a0ffb55ce4008e62c6fe89e40
-      lastVerified: '2026-03-11T00:48:55.872Z'
+      lastVerified: '2026-05-17T10:02:45.229Z'
     index:
       path: .aiox-core/core/index.js
       layer: L1
@@ -8233,19 +8497,18 @@ entities:
         - output-formatter
         - yaml-validator
         - registry-loader
-        - resilience-index
-      externalDeps: []
-      plannedDeps:
         - health-check-index
         - external-executors-index
-        - health-check
+        - resilience-index
+      externalDeps: []
+      plannedDeps: []
       lifecycle: experimental
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:b09d5546bdb1507c60ddc5dc9b48760b55e4e6a4ccc8fdcb63e168e8ea334b13
-      lastVerified: '2026-05-09T07:56:57.018Z'
+      lastVerified: '2026-05-17T10:02:45.229Z'
     code-intel-client:
       path: .aiox-core/core/code-intel/code-intel-client.js
       layer: L1
@@ -8255,19 +8518,20 @@ entities:
         - code
         - intel
         - client
-      usedBy: []
+      usedBy:
+        - code-intel-index
       dependencies:
         - code-graph-provider
         - registry-provider
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:6c9a08a37775acf90397aa079a4ad2c5edcc47f2cfd592b26ae9f3d154d1deb8
-      lastVerified: '2026-03-11T00:48:55.873Z'
+      lastVerified: '2026-05-17T10:02:45.229Z'
     code-intel-enricher:
       path: .aiox-core/core/code-intel/code-intel-enricher.js
       layer: L1
@@ -8277,17 +8541,18 @@ entities:
         - code
         - intel
         - enricher
-      usedBy: []
+      usedBy:
+        - code-intel-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:ee54acdce08258a5f52ee51b38e5c4ffe727e42c8682818120addf7f6863549f
-      lastVerified: '2026-03-11T00:48:55.874Z'
+      lastVerified: '2026-05-17T10:02:45.229Z'
     hook-runtime:
       path: .aiox-core/core/code-intel/hook-runtime.js
       layer: L1
@@ -8307,7 +8572,33 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4d812dc503650ef90249ad2993b3f713aea806138a27455a6a9757329d829c8e
-      lastVerified: '2026-03-11T00:48:55.874Z'
+      lastVerified: '2026-05-17T10:02:45.230Z'
+    code-intel-index:
+      path: .aiox-core/core/code-intel/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/code-intel/index.js
+      keywords:
+        - index
+      usedBy:
+        - registry-syncer
+        - code-intel-source
+        - metrics-source
+      dependencies:
+        - code-intel-client
+        - code-intel-enricher
+        - provider-interface
+        - code-graph-provider
+        - registry-provider
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:c8103fb966def9e8ed53dc1840e0e853b5fa4f13291a73a179cbae3545f38754
+      lastVerified: '2026-05-17T10:02:45.230Z'
     registry-syncer:
       path: .aiox-core/core/code-intel/registry-syncer.js
       layer: L1
@@ -8319,17 +8610,17 @@ entities:
       usedBy:
         - sync-registry-intel
       dependencies:
+        - code-intel-index
         - registry-loader
       externalDeps: []
-      plannedDeps:
-        - code-intel-index
+      plannedDeps: []
       lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:0fc20a7f90fc1ac2078878267db64517fd2ae75d8d2a81101d0cac77d1bf6458
-      lastVerified: '2026-05-10T16:26:31.572Z'
+      lastVerified: '2026-05-17T10:02:45.231Z'
     config-cache:
       path: .aiox-core/core/config/config-cache.js
       layer: L1
@@ -8347,8 +8638,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:b659dfae25865c732555d71abcb1939db908684586d0a06b699d3176077e486e
-      lastVerified: '2026-03-11T00:48:55.875Z'
+      checksum: sha256:9f3c3f90f574d5f49dd94592ab28109465d025b3a740d8639ab781c2560c12ab
+      lastVerified: '2026-05-17T10:02:45.231Z'
     config-loader:
       path: .aiox-core/core/config/config-loader.js
       layer: L1
@@ -8368,8 +8659,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:e19fee885b060c85ee75df71a016259b8e4c21e6c7045a58514afded3a2386a8
-      lastVerified: '2026-03-11T00:48:55.875Z'
+      checksum: sha256:05c8cfa5fe8c0bd659ac65791e5b551767e581a465cad6bb42a9c0a31847e4b4
+      lastVerified: '2026-05-17T10:02:45.231Z'
     config-resolver:
       path: .aiox-core/core/config/config-resolver.js
       layer: L1
@@ -8396,7 +8687,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3b29df6954cec440debef87cb4e4e7610c94dc74e562d32c74b8ec57d893213b
-      lastVerified: '2026-03-11T00:48:55.876Z'
+      lastVerified: '2026-05-17T10:02:45.231Z'
     env-interpolator:
       path: .aiox-core/core/config/env-interpolator.js
       layer: L1
@@ -8417,7 +8708,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d9d9782d1c685fc1734034f656903ff35ac71665c0bedb3fc479544c89d1ece1
-      lastVerified: '2026-03-11T00:48:55.876Z'
+      lastVerified: '2026-05-17T10:02:45.232Z'
     merge-utils:
       path: .aiox-core/core/config/merge-utils.js
       layer: L1
@@ -8429,6 +8720,7 @@ entities:
       usedBy:
         - config-resolver
         - env-interpolator
+        - context-manager
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -8438,7 +8730,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e25cb65f4c4e855cfeb4acced46d64a8c9cf7e55a97ac051ec3d985b8855c823
-      lastVerified: '2026-03-11T00:48:55.876Z'
+      lastVerified: '2026-05-17T10:02:45.232Z'
     migrate-config:
       path: .aiox-core/core/config/migrate-config.js
       layer: L1
@@ -8457,7 +8749,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5f46e718e0891d6bf5f46d0f9375960a8e12d010b9699cb287bd0fe71f252f41
-      lastVerified: '2026-03-11T00:48:55.876Z'
+      lastVerified: '2026-05-17T10:02:45.232Z'
     template-overrides:
       path: .aiox-core/core/config/template-overrides.js
       layer: L1
@@ -8475,8 +8767,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:1708dc8764e7f88dfefd7684240afcd5f13657170ac104aed99145e2bb8ae82c
-      lastVerified: '2026-03-11T00:48:55.876Z'
+      checksum: sha256:202d141a292bc5a8dd0697e044d7627b260839ae8b7119fd40ae486b3a1b0825
+      lastVerified: '2026-05-17T10:02:45.233Z'
     fix-handler:
       path: .aiox-core/core/doctor/fix-handler.js
       layer: L1
@@ -8485,10 +8777,33 @@ entities:
       keywords:
         - fix
         - handler
-      usedBy: []
+      usedBy:
+        - doctor-index
       dependencies:
         - rules-files
         - agent-memory
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:c8255536f08a622b2773819080bdbf5d65f8f3f43b77eb257d98064cd74903a3
+      lastVerified: '2026-05-17T10:02:45.233Z'
+    doctor-index:
+      path: .aiox-core/core/doctor/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/doctor/index.js
+      keywords:
+        - index
+      usedBy: []
+      dependencies:
+        - doctor-checks-index
+        - text
+        - json
+        - fix-handler
       externalDeps: []
       plannedDeps: []
       lifecycle: experimental
@@ -8496,8 +8811,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:c8255536f08a622b2773819080bdbf5d65f8f3f43b77eb257d98064cd74903a3
-      lastVerified: '2026-03-11T00:48:55.876Z'
+      checksum: sha256:a6072bf0e5c198b6d83ecf3fb5425d63982ad3a201455ba9e3ae3bd51f690ad6
+      lastVerified: '2026-05-17T10:02:45.233Z'
     agent-elicitation:
       path: .aiox-core/core/elicitation/agent-elicitation.js
       layer: L1
@@ -8518,7 +8833,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ef13ebff1375279e7b8f0f0bbd3699a0d201f9a67127efa64c4142159a26f417
-      lastVerified: '2026-03-11T00:48:55.876Z'
+      lastVerified: '2026-05-17T10:02:45.233Z'
     elicitation-engine:
       path: .aiox-core/core/elicitation/elicitation-engine.js
       layer: L1
@@ -8543,7 +8858,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:256f31ef3a5dd0ba085beb2a1556194e5f2e47d4d15cfeba6896b0022933400c
-      lastVerified: '2026-03-11T00:48:55.876Z'
+      lastVerified: '2026-05-17T10:02:45.234Z'
     session-manager:
       path: .aiox-core/core/elicitation/session-manager.js
       layer: L1
@@ -8565,7 +8880,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:79e410d808c4b15802d04c9c7f806796c048e846a69d1a69783c619954771f9b
-      lastVerified: '2026-03-11T00:48:55.877Z'
+      lastVerified: '2026-05-17T10:02:45.234Z'
     task-elicitation:
       path: .aiox-core/core/elicitation/task-elicitation.js
       layer: L1
@@ -8586,7 +8901,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cc44ad635e60cbdb67d18209b4b50d1fb2824de2234ec607a6639eb1754bfc75
-      lastVerified: '2026-03-11T00:48:55.877Z'
+      lastVerified: '2026-05-17T10:02:45.234Z'
     workflow-elicitation:
       path: .aiox-core/core/elicitation/workflow-elicitation.js
       layer: L1
@@ -8608,7 +8923,145 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:722d9b28d2485e3b5b89af6ea136e6d3907b805b9870f6e07e943d0264dc7fff
-      lastVerified: '2026-03-11T00:48:55.877Z'
+      lastVerified: '2026-05-17T10:02:45.234Z'
+    aiox-error:
+      path: .aiox-core/core/errors/aiox-error.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/errors/aiox-error.js
+      keywords:
+        - aiox
+        - error
+      usedBy:
+        - errors-index
+      dependencies:
+        - constants
+        - error-registry
+        - serializer
+        - utils
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:6734641df389f921f1d139c129ec007d15b3a08114a15fe9faf792ed1036d0c8
+      lastVerified: '2026-05-17T10:02:45.234Z'
+    constants:
+      path: .aiox-core/core/errors/constants.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/errors/constants.js
+      keywords:
+        - constants
+      usedBy:
+        - aiox-error
+        - error-registry
+        - errors-index
+        - serializer
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:9f6fa0b1a9b8538d321674ac43628f42452ce2ac770d0433c1ab84b55b1e56dd
+      lastVerified: '2026-05-17T10:02:45.234Z'
+    error-registry:
+      path: .aiox-core/core/errors/error-registry.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/errors/error-registry.js
+      keywords:
+        - error
+        - registry
+      usedBy:
+        - aiox-error
+        - errors-index
+      dependencies:
+        - constants
+        - utils
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:7ba8dffa725860a285618593b8ed47b05c4fa488fdedf1282c2e214881c370bc
+      lastVerified: '2026-05-17T10:02:45.234Z'
+    errors-index:
+      path: .aiox-core/core/errors/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/errors/index.js
+      keywords:
+        - index
+      usedBy:
+        - build-state-manager
+        - synapse-engine
+      dependencies:
+        - constants
+        - error-registry
+        - aiox-error
+        - serializer
+        - utils
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:462d0aed6f57f2e4b9d51bcb20467451473c927e0d182b5c3ad43f352f44122c
+      lastVerified: '2026-05-17T10:02:45.235Z'
+    serializer:
+      path: .aiox-core/core/errors/serializer.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/errors/serializer.js
+      keywords:
+        - serializer
+      usedBy:
+        - aiox-error
+        - errors-index
+      dependencies:
+        - constants
+        - utils
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:7144adaf3a245afd732aef16e2cdb61f08246badb6b90ac1a7f4b73705ff3ce8
+      lastVerified: '2026-05-17T10:02:45.235Z'
+    utils:
+      path: .aiox-core/core/errors/utils.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/errors/utils.js
+      keywords:
+        - utils
+      usedBy:
+        - aiox-error
+        - error-registry
+        - errors-index
+        - serializer
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:24b8ff80e98efc2b562843262490b7ac537ee77565715b644f212652192ced62
+      lastVerified: '2026-05-17T10:02:45.235Z'
     dashboard-emitter:
       path: .aiox-core/core/events/dashboard-emitter.js
       layer: L1
@@ -8618,6 +9071,7 @@ entities:
         - dashboard
         - emitter
       usedBy:
+        - events-index
         - bob-orchestrator
       dependencies:
         - types
@@ -8628,8 +9082,29 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:20f3d2297c29a64bae34ac8097cc0b54f4f706b19f0dbd6c752a20d7c4ad9eb1
-      lastVerified: '2026-03-11T00:48:55.877Z'
+      checksum: sha256:6c694e4fc5765d6c396b25617cc34e3447068af780fdbb202b060a31cd357549
+      lastVerified: '2026-05-17T10:02:45.235Z'
+    events-index:
+      path: .aiox-core/core/events/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/events/index.js
+      keywords:
+        - index
+      usedBy:
+        - dashboard-integration
+      dependencies:
+        - types
+        - dashboard-emitter
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:c5a3a1ba660f1a0d7963e4e8a29ee536a301621c941d962c00f67ade17ba7db3
+      lastVerified: '2026-05-17T10:02:45.235Z'
     types:
       path: .aiox-core/core/events/types.js
       layer: L1
@@ -8639,6 +9114,7 @@ entities:
         - types
       usedBy:
         - dashboard-emitter
+        - events-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -8648,7 +9124,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b9b69520fb8f51aaa9c768006282dfbf17846df9edc829ddc6557d7fa9930865
-      lastVerified: '2026-03-11T00:48:55.877Z'
+      lastVerified: '2026-05-17T10:02:45.235Z'
     autonomous-build-loop:
       path: .aiox-core/core/execution/autonomous-build-loop.js
       layer: L1
@@ -8674,7 +9150,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:22246474800340c7a97c8b865f5f9e3cb162efd45c5db1be2f9f729969a0b6d0
-      lastVerified: '2026-03-11T00:48:55.877Z'
+      lastVerified: '2026-05-17T10:02:45.236Z'
     build-orchestrator:
       path: .aiox-core/core/execution/build-orchestrator.js
       layer: L1
@@ -8698,8 +9174,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:3698635011a845dfc43c46dfd7f15c0aa3ab488938ea3bd281de29157f5c4687
-      lastVerified: '2026-03-11T00:48:55.877Z'
+      checksum: sha256:51aec922a58d5d4121ef156bb961ac7b8f29db711679897fdade6ca71a1635e5
+      lastVerified: '2026-05-17T10:02:45.237Z'
     build-state-manager:
       path: .aiox-core/core/execution/build-state-manager.js
       layer: L1
@@ -8725,7 +9201,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:02bafb4a29e7f769ae775fbc4e571ad34882569665f61ebc28eb87f7043eafc8
-      lastVerified: '2026-05-08T14:34:39.786Z'
+      lastVerified: '2026-05-17T10:02:45.238Z'
     context-injector:
       path: .aiox-core/core/execution/context-injector.js
       layer: L1
@@ -8735,9 +9211,7 @@ entities:
         - context
         - injector
       usedBy: []
-      dependencies:
-        - memory-query
-        - session-memory
+      dependencies: []
       externalDeps: []
       plannedDeps:
         - memory-query
@@ -8748,7 +9222,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7654f6e6c3d555f3963369e71edf84b15c0fdec53bd161800b71782f78275244
-      lastVerified: '2026-05-07T14:31:05.474Z'
+      lastVerified: '2026-05-17T10:02:45.238Z'
     parallel-executor:
       path: .aiox-core/core/execution/parallel-executor.js
       layer: L1
@@ -8758,6 +9232,7 @@ entities:
         - parallel
         - executor
       usedBy:
+        - orchestration-index
         - workflow-orchestrator
       dependencies: []
       externalDeps: []
@@ -8768,7 +9243,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:46870e5c8ff8db3ee0386e477d427cc98eeb008f630818b093a9524b410590ae
-      lastVerified: '2026-03-11T00:48:55.878Z'
+      lastVerified: '2026-05-17T10:02:45.239Z'
     parallel-monitor:
       path: .aiox-core/core/execution/parallel-monitor.js
       layer: L1
@@ -8787,7 +9262,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:58ecd92f5de9c688f28cf952ae6cc5ee07ddf14dc89fb0ea13b2f0a527e29fae
-      lastVerified: '2026-03-11T00:48:55.878Z'
+      lastVerified: '2026-05-17T10:02:45.239Z'
     rate-limit-manager:
       path: .aiox-core/core/execution/rate-limit-manager.js
       layer: L1
@@ -8808,7 +9283,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b6e2ca99cf59a9dfa5a4e48109d0a47f36262efcc73e69f11a1c0c727d48abb
-      lastVerified: '2026-03-11T00:48:55.878Z'
+      lastVerified: '2026-05-17T10:02:45.239Z'
     result-aggregator:
       path: .aiox-core/core/execution/result-aggregator.js
       layer: L1
@@ -8827,7 +9302,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bcd102ca46e74d61af151aa7877921807c9bf5aba45bfba73f9f5c8cf714d8e2
-      lastVerified: '2026-05-07T15:02:59.785Z'
+      lastVerified: '2026-05-17T10:02:45.240Z'
     semantic-merge-engine:
       path: .aiox-core/core/execution/semantic-merge-engine.js
       layer: L1
@@ -8848,7 +9323,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:26f2a057407cf114a0611944960a8e6d58d93c5e03abe905489e6b699cb98a75
-      lastVerified: '2026-03-11T00:48:55.878Z'
+      lastVerified: '2026-05-17T10:02:45.241Z'
     subagent-dispatcher:
       path: .aiox-core/core/execution/subagent-dispatcher.js
       layer: L1
@@ -8869,7 +9344,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa8ce6aa5fdd85f7a06c3c560a85d904222658076158c35031ddae19bb63efe1
-      lastVerified: '2026-05-08T21:25:19.321Z'
+      lastVerified: '2026-05-17T10:02:45.242Z'
     wave-executor:
       path: .aiox-core/core/execution/wave-executor.js
       layer: L1
@@ -8890,7 +9365,47 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4e2324edb37ae0729062b5ac029f2891e050e7efd3a48d0f4a1dc4f227a6716b
-      lastVerified: '2026-03-11T00:48:55.879Z'
+      lastVerified: '2026-05-17T10:02:45.243Z'
+    delegate-cli:
+      path: .aiox-core/core/external-executors/delegate-cli.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/external-executors/delegate-cli.js
+      keywords:
+        - delegate
+        - cli
+      usedBy:
+        - external-executors-index
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:3f4bb7d4edd742ad13dc91ebdc7296b94ac762caa50ea6943429d93cd65c0ce1
+      lastVerified: '2026-05-17T10:02:45.243Z'
+    external-executors-index:
+      path: .aiox-core/core/external-executors/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/external-executors/index.js
+      keywords:
+        - index
+      usedBy:
+        - index
+      dependencies:
+        - delegate-cli
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:db61bee165e4a7dba3627275d52d6b162e3b2cbf47d31d88beb38682cb8352db
+      lastVerified: '2026-05-17T10:02:45.243Z'
     cli:
       path: .aiox-core/core/graph-dashboard/cli.js
       layer: L1
@@ -8898,7 +9413,8 @@ entities:
       purpose: Entity at .aiox-core/core/graph-dashboard/cli.js
       keywords:
         - cli
-      usedBy: []
+      usedBy:
+        - graph-dashboard-index
       dependencies:
         - code-intel-source
         - registry-source
@@ -8912,13 +9428,34 @@ entities:
         - html-formatter
       externalDeps: []
       plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:29f273a06fecc77eb3e39162ba1aaf28e1cbadb2a000158f009817021a30b4d1
+      lastVerified: '2026-05-17T10:02:45.243Z'
+    graph-dashboard-index:
+      path: .aiox-core/core/graph-dashboard/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/graph-dashboard/index.js
+      keywords:
+        - index
+      usedBy: []
+      dependencies:
+        - code-intel-source
+        - tree-renderer
+        - cli
+      externalDeps: []
+      plannedDeps: []
       lifecycle: experimental
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:1f2fd6c6b5ace42f3bddc89695fe32d01949321d96057bbf50e2e48892f2c8f5
-      lastVerified: '2026-03-11T00:48:55.879Z'
+      checksum: sha256:d4e43c674dd7c119afd0afacc5b899c35de82890a61a3bcefc957819314f8cee
+      lastVerified: '2026-05-17T10:02:45.244Z'
     base-check:
       path: .aiox-core/core/health-check/base-check.js
       layer: L1
@@ -8930,7 +9467,10 @@ entities:
       usedBy:
         - check-registry
         - engine
+        - health-check-index
+        - health-check-healers-index
         - console
+        - health-check-reporters-json
         - markdown
         - build-config
         - ci-config
@@ -8949,6 +9489,7 @@ entities:
         - aiox-directory
         - dependencies
         - framework-config
+        - health-check-checks-project-node-version
         - package-json
         - task-definitions
         - workflow-dependencies
@@ -8974,7 +9515,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4bdc81b92825c72ab185fa8f161aa0348d63071f2bc0d894317199e00c269f8d
-      lastVerified: '2026-03-11T00:48:55.879Z'
+      lastVerified: '2026-05-17T10:02:45.244Z'
     check-registry:
       path: .aiox-core/core/health-check/check-registry.js
       layer: L1
@@ -8983,23 +9524,24 @@ entities:
       keywords:
         - check
         - registry
-      usedBy: []
+      usedBy:
+        - health-check-index
       dependencies:
         - base-check
+        - health-check-checks-project-index
+        - health-check-checks-local-index
+        - health-check-checks-repository-index
+        - health-check-checks-deployment-index
+        - health-check-checks-services-index
       externalDeps: []
-      plannedDeps:
-        - project
-        - local
-        - repository
-        - deployment
-        - services
-      lifecycle: experimental
+      plannedDeps: []
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:131564effd0499f61a2420914be706b9134db955b4adf09bd03eee511c323867
-      lastVerified: '2026-03-11T00:48:55.879Z'
+      lastVerified: '2026-05-17T10:02:45.244Z'
     engine:
       path: .aiox-core/core/health-check/engine.js
       layer: L1
@@ -9007,18 +9549,43 @@ entities:
       purpose: Entity at .aiox-core/core/health-check/engine.js
       keywords:
         - engine
-      usedBy: []
+      usedBy:
+        - health-check-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:7a53405621243960ce482e8d3052a40caf8704d670a9f3388eca294056971497
-      lastVerified: '2026-03-11T00:48:55.879Z'
+      lastVerified: '2026-05-17T10:02:45.245Z'
+    health-check-index:
+      path: .aiox-core/core/health-check/index.js
+      layer: L1
+      type: module
+      purpose: '{'
+      keywords:
+        - index
+      usedBy:
+        - index
+      dependencies:
+        - engine
+        - base-check
+        - check-registry
+        - health-check-healers-index
+        - health-check-reporters-index
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:738bec37c11cfb02e9df96e3631f74fa0652f5a531c7b0f1d8887e0141b1f72e
+      lastVerified: '2026-05-17T10:02:45.245Z'
     ideation-engine:
       path: .aiox-core/core/ideation/ideation-engine.js
       layer: L1
@@ -9031,13 +9598,13 @@ entities:
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: orphan
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:a154a0ce92f6b39b358529a030025b9709e0e4e2b85f6af02bd474e15c1aeb83
-      lastVerified: '2026-05-07T14:31:05.479Z'
+      checksum: sha256:c91f7bc999eca74394eeae9bc7400e63e134de4092d6bdc08b92bf423e423ec3
+      lastVerified: '2026-05-17T10:02:45.245Z'
     circuit-breaker:
       path: .aiox-core/core/ids/circuit-breaker.js
       layer: L1
@@ -9047,6 +9614,7 @@ entities:
         - circuit
         - breaker
       usedBy:
+        - ids-index
         - verification-gate
       dependencies: []
       externalDeps: []
@@ -9057,7 +9625,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:63be126f2e0d320daa60cb5b68b21df93cad4c19d1f959e06a6ac776213f8eba
-      lastVerified: '2026-05-07T13:24:28.323Z'
+      lastVerified: '2026-05-17T10:02:45.246Z'
     framework-governor:
       path: .aiox-core/core/ids/framework-governor.js
       layer: L1
@@ -9066,20 +9634,21 @@ entities:
       keywords:
         - framework
         - governor
-      usedBy: []
+      usedBy:
+        - ids-index
       dependencies:
         - registry-loader
         - incremental-decision-engine
         - registry-updater
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:ef7a3b7444a51f2f122c114c662b1db544d1c9e7833dc6f77dce30ac3a2005a2
-      lastVerified: '2026-03-11T00:48:55.879Z'
+      lastVerified: '2026-05-17T10:02:45.246Z'
     incremental-decision-engine:
       path: .aiox-core/core/ids/incremental-decision-engine.js
       layer: L1
@@ -9091,6 +9660,7 @@ entities:
         - engine
       usedBy:
         - framework-governor
+        - ids-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -9100,7 +9670,37 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:257b1f67f6df8eb91fe0a95405563611b8bf2f836cbca2398a0a394e40d6c219
-      lastVerified: '2026-03-11T00:48:55.879Z'
+      lastVerified: '2026-05-17T10:02:45.247Z'
+    ids-index:
+      path: .aiox-core/core/ids/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/ids/index.js
+      keywords:
+        - index
+      usedBy: []
+      dependencies:
+        - registry-loader
+        - incremental-decision-engine
+        - registry-updater
+        - registry-healer
+        - circuit-breaker
+        - verification-gate
+        - g1-epic-creation
+        - g2-story-creation
+        - g3-story-validation
+        - g4-dev-context
+        - g5-semantic-handshake
+        - framework-governor
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: experimental
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:363ef37a0fcc18e9e2646650f74750a77c21a95e16de976f64f52825cc50a6a1
+      lastVerified: '2026-05-17T10:02:45.247Z'
     layer-classifier:
       path: .aiox-core/core/ids/layer-classifier.js
       layer: L1
@@ -9119,8 +9719,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:4ae1e7d341076a13d08b8b5baf7a687ad2c7df673d50fc3554d522fe79debcdc
-      lastVerified: '2026-03-11T00:48:55.880Z'
+      checksum: sha256:2a240b70ac3507e50a64b96d580c4d933bf2116125fb52c8237db2ed9ebf27b7
+      lastVerified: '2026-05-17T10:02:45.247Z'
     registry-healer:
       path: .aiox-core/core/ids/registry-healer.js
       layer: L1
@@ -9131,6 +9731,7 @@ entities:
         - healer
       usedBy:
         - ids-health
+        - ids-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -9140,7 +9741,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2b128ea4c1e8bc8f9324390ab55c1b3623c9ad3352522cbecec1acaefe472c5d
-      lastVerified: '2026-03-11T00:48:55.880Z'
+      lastVerified: '2026-05-17T10:02:45.248Z'
     registry-loader:
       path: .aiox-core/core/ids/registry-loader.js
       layer: L1
@@ -9153,6 +9754,7 @@ entities:
         - index
         - registry-syncer
         - framework-governor
+        - ids-index
         - code-intel-source
         - registry-source
       dependencies: []
@@ -9164,7 +9766,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:88c67bace0a5ab6a14cb1d096e3f9cab9f5edc0dd8377788e27b692ccefbd487
-      lastVerified: '2026-03-11T00:48:55.880Z'
+      lastVerified: '2026-05-17T10:02:45.248Z'
     registry-updater:
       path: .aiox-core/core/ids/registry-updater.js
       layer: L1
@@ -9175,6 +9777,7 @@ entities:
         - updater
       usedBy:
         - framework-governor
+        - ids-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -9184,7 +9787,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:00ae2e78486a9e7b3c8bf8e9ca0e9e955211ee4ae795c630e7f2934840d5596d
-      lastVerified: '2026-05-08T14:34:39.787Z'
+      lastVerified: '2026-05-17T10:02:45.249Z'
     verification-gate:
       path: .aiox-core/core/ids/verification-gate.js
       layer: L1
@@ -9193,18 +9796,19 @@ entities:
       keywords:
         - verification
         - gate
-      usedBy: []
+      usedBy:
+        - ids-index
       dependencies:
         - circuit-breaker
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:96050661c90fa52bfc755911d02c9194ec35c00e71fc6bbc92a13686dd53bb91
-      lastVerified: '2026-03-11T00:48:55.880Z'
+      lastVerified: '2026-05-17T10:02:45.249Z'
     manifest-generator:
       path: .aiox-core/core/manifest/manifest-generator.js
       layer: L1
@@ -9223,7 +9827,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:81b796990dd747bbb9785d205dbe5f6d5556754fc51745fb84b7ce4675acbdbf
-      lastVerified: '2026-03-11T00:48:55.880Z'
+      lastVerified: '2026-05-17T10:02:45.249Z'
     manifest-validator:
       path: .aiox-core/core/manifest/manifest-validator.js
       layer: L1
@@ -9242,7 +9846,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3558e7dbf653eac385222a299d0eddaaf77e119a70ec034f7a7291c401d7be2c
-      lastVerified: '2026-03-11T00:48:55.881Z'
+      lastVerified: '2026-05-17T10:02:45.249Z'
     config-migrator:
       path: .aiox-core/core/mcp/config-migrator.js
       layer: L1
@@ -9251,19 +9855,20 @@ entities:
       keywords:
         - config
         - migrator
-      usedBy: []
+      usedBy:
+        - mcp-index
       dependencies:
         - global-config-manager
         - symlink-manager
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:0603a288d79e8526a2c757834bab5191bbc240b1b9dcb548b09d10cee97de322
-      lastVerified: '2026-03-11T00:48:55.881Z'
+      lastVerified: '2026-05-17T10:02:45.250Z'
     global-config-manager:
       path: .aiox-core/core/mcp/global-config-manager.js
       layer: L1
@@ -9275,6 +9880,7 @@ entities:
         - manager
       usedBy:
         - config-migrator
+        - mcp-index
       dependencies:
         - os-detector
       externalDeps: []
@@ -9285,7 +9891,29 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c010cfff03119c8369a3c4c3cc73ce31d79108dc15c5c66e67f63766a2a2c5d8
-      lastVerified: '2026-03-11T00:48:55.881Z'
+      lastVerified: '2026-05-17T10:02:45.250Z'
+    mcp-index:
+      path: .aiox-core/core/mcp/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/mcp/index.js
+      keywords:
+        - index
+      usedBy: []
+      dependencies:
+        - os-detector
+        - global-config-manager
+        - symlink-manager
+        - config-migrator
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: experimental
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:4f9be6c05a2d6d305f6a3c0130e5e1eca18feb41de47245e51ebe1c9a32ffa7f
+      lastVerified: '2026-05-17T10:02:45.250Z'
     os-detector:
       path: .aiox-core/core/mcp/os-detector.js
       layer: L1
@@ -9296,6 +9924,7 @@ entities:
         - detector
       usedBy:
         - global-config-manager
+        - mcp-index
         - symlink-manager
       dependencies: []
       externalDeps: []
@@ -9306,7 +9935,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7c5eb398bf1e53ddc5e31a9367d01709eba56bc53f653430ea7de07e32aa2a11
-      lastVerified: '2026-03-11T00:48:55.881Z'
+      lastVerified: '2026-05-17T10:02:45.250Z'
     symlink-manager:
       path: .aiox-core/core/mcp/symlink-manager.js
       layer: L1
@@ -9317,6 +9946,7 @@ entities:
         - manager
       usedBy:
         - config-migrator
+        - mcp-index
       dependencies:
         - os-detector
       externalDeps: []
@@ -9327,7 +9957,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b2c68e5664f7f8595b81cbfba69be16d7f37f8d21608c99ddd066808aa2653c1
-      lastVerified: '2026-03-11T00:48:55.881Z'
+      lastVerified: '2026-05-17T10:02:45.250Z'
     gotchas-memory:
       path: .aiox-core/core/memory/gotchas-memory.js
       layer: L1
@@ -9350,8 +9980,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:0063eff42caf0dda759c0390ac323e7b102f5507f27b8beb7b0acc2fbec407c4
-      lastVerified: '2026-03-11T00:48:55.881Z'
+      checksum: sha256:deeb90a6dff9ef284537a1dabf52566cec3f64244f31f4081432515985a94e25
+      lastVerified: '2026-05-17T10:02:45.251Z'
     agent-invoker:
       path: .aiox-core/core/orchestration/agent-invoker.js
       layer: L1
@@ -9361,6 +9991,7 @@ entities:
         - agent
         - invoker
       usedBy:
+        - orchestration-index
         - master-orchestrator
       dependencies: []
       externalDeps: []
@@ -9371,7 +10002,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5e1e3428163c35b0c91f694b76a5ca1e520249de1f7f65aae87e6723c01a45e7
-      lastVerified: '2026-03-11T00:48:55.881Z'
+      lastVerified: '2026-05-17T10:02:45.251Z'
     bob-orchestrator:
       path: .aiox-core/core/orchestration/bob-orchestrator.js
       layer: L1
@@ -9381,6 +10012,7 @@ entities:
         - bob
         - orchestrator
       usedBy:
+        - orchestration-index
         - pm
       dependencies:
         - config-resolver
@@ -9403,8 +10035,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:35219c5113c262a39f249866e66c76f9f1206465dd68a66eb27d82c623b46048
-      lastVerified: '2026-03-11T00:48:55.881Z'
+      checksum: sha256:971a21ed77f09ab76dc2822030c4b36edd1fd9d8ec405b25b32f36f0cd606ec8
+      lastVerified: '2026-05-17T10:02:45.252Z'
     bob-status-writer:
       path: .aiox-core/core/orchestration/bob-status-writer.js
       layer: L1
@@ -9416,6 +10048,7 @@ entities:
         - writer
       usedBy:
         - bob-orchestrator
+        - orchestration-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -9425,7 +10058,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d0368d44b8b45549f503d737b0fdb21afb02db8d544b19f4d0289828501ac016
-      lastVerified: '2026-03-11T00:48:55.882Z'
+      lastVerified: '2026-05-17T10:02:45.252Z'
     brownfield-handler:
       path: .aiox-core/core/orchestration/brownfield-handler.js
       layer: L1
@@ -9436,6 +10069,7 @@ entities:
         - handler
       usedBy:
         - bob-orchestrator
+        - orchestration-index
       dependencies:
         - workflow-executor
         - surface-checker
@@ -9447,8 +10081,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:370599a3de3c936e8ebf2f5d14a1d09b8b33c3ccda3027d68740171314888215
-      lastVerified: '2026-03-11T00:48:55.882Z'
+      checksum: sha256:153eed3dcad1b5f58e0abb9ec4fb0c7013f441efeb169ea4a0cfda23f75928fc
+      lastVerified: '2026-05-17T10:02:45.253Z'
     checklist-runner:
       path: .aiox-core/core/orchestration/checklist-runner.js
       layer: L1
@@ -9458,6 +10092,7 @@ entities:
         - checklist
         - runner
       usedBy:
+        - orchestration-index
         - workflow-orchestrator
       dependencies: []
       externalDeps: []
@@ -9468,7 +10103,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:40f17b74c2fe6746f45aa5750c0b85b5af22221e010951eb6e93f5796fb70a8f
-      lastVerified: '2026-03-11T00:48:55.883Z'
+      lastVerified: '2026-05-17T10:02:45.254Z'
     cli-commands:
       path: .aiox-core/core/orchestration/cli-commands.js
       layer: L1
@@ -9477,18 +10112,19 @@ entities:
       keywords:
         - cli
         - commands
-      usedBy: []
+      usedBy:
+        - orchestration-index
       dependencies:
         - master-orchestrator
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:cedd09f6938b3e1e0e19c06f4763de00281ddb31529d16ab9e4f74d194a3bd3b
-      lastVerified: '2026-03-11T00:48:55.883Z'
+      lastVerified: '2026-05-17T10:02:45.254Z'
     condition-evaluator:
       path: .aiox-core/core/orchestration/condition-evaluator.js
       layer: L1
@@ -9498,6 +10134,7 @@ entities:
         - condition
         - evaluator
       usedBy:
+        - orchestration-index
         - workflow-orchestrator
       dependencies: []
       externalDeps: []
@@ -9507,8 +10144,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:8bf565cf56194340ff4e1d642647150775277bce649411d0338faa2c96106745
-      lastVerified: '2026-03-11T00:48:55.883Z'
+      checksum: sha256:daa6755c76359bb99a2e687c9c56f74b52b7151b0b0677a771b8fff24538d2ad
+      lastVerified: '2026-05-17T10:02:45.254Z'
     context-manager:
       path: .aiox-core/core/orchestration/context-manager.js
       layer: L1
@@ -9518,8 +10155,10 @@ entities:
         - context
         - manager
       usedBy:
+        - orchestration-index
         - workflow-orchestrator
-      dependencies: []
+      dependencies:
+        - merge-utils
       externalDeps: []
       plannedDeps: []
       lifecycle: production
@@ -9527,8 +10166,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:7bf273723a2c08cb84e670b9d4c55aacec51819b1fbd5f3b0c46c4ccfa2ec192
-      lastVerified: '2026-03-11T00:48:55.883Z'
+      checksum: sha256:b6ed0e4eb069558998f95ab0c68fa040b1b8c2aab74ab44e26ab682fe9e247b4
+      lastVerified: '2026-05-17T10:02:45.255Z'
     dashboard-integration:
       path: .aiox-core/core/orchestration/dashboard-integration.js
       layer: L1
@@ -9538,18 +10177,19 @@ entities:
         - dashboard
         - integration
       usedBy:
+        - orchestration-index
         - master-orchestrator
-      dependencies: []
+      dependencies:
+        - events-index
       externalDeps: []
-      plannedDeps:
-        - events
+      plannedDeps: []
       lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:8f2dd7d3885a9eaf58957505d312923e149f2771ae3ca0cda879631683f826c9
-      lastVerified: '2026-03-11T00:48:55.883Z'
+      lastVerified: '2026-05-17T10:02:45.255Z'
     data-lifecycle-manager:
       path: .aiox-core/core/orchestration/data-lifecycle-manager.js
       layer: L1
@@ -9561,6 +10201,7 @@ entities:
         - manager
       usedBy:
         - bob-orchestrator
+        - orchestration-index
         - pm
       dependencies:
         - lock-manager
@@ -9571,8 +10212,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:031c351aa28e96eb232db709741eb3474fbe8c25bfc834f607834fdddd8cb632
-      lastVerified: '2026-03-11T00:48:55.883Z'
+      checksum: sha256:7fe6c9d9a278a1d7714e7fdba8710fafbc221520b096639be46f2ce1549a5c2a
+      lastVerified: '2026-05-17T10:02:45.256Z'
     epic-context-accumulator:
       path: .aiox-core/core/orchestration/epic-context-accumulator.js
       layer: L1
@@ -9582,17 +10223,18 @@ entities:
         - epic
         - context
         - accumulator
-      usedBy: []
+      usedBy:
+        - orchestration-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:4f342f7fc05f404de2b899358f86143106737b56d6c486c98e988a67d420078b
-      lastVerified: '2026-03-11T00:48:55.883Z'
+      lastVerified: '2026-05-17T10:02:45.256Z'
     execution-profile-resolver:
       path: .aiox-core/core/orchestration/execution-profile-resolver.js
       layer: L1
@@ -9603,6 +10245,7 @@ entities:
         - profile
         - resolver
       usedBy:
+        - orchestration-index
         - workflow-orchestrator
       dependencies: []
       externalDeps: []
@@ -9613,7 +10256,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bb35f1c16c47c9306128c5f3e6c90df3ed91f9358576ea97a59007b74f5e9927
-      lastVerified: '2026-03-11T00:48:55.883Z'
+      lastVerified: '2026-05-17T10:02:45.256Z'
     executor-assignment:
       path: .aiox-core/core/orchestration/executor-assignment.js
       layer: L1
@@ -9625,6 +10268,7 @@ entities:
       usedBy:
         - brownfield-create-epic
         - bob-orchestrator
+        - orchestration-index
         - workflow-executor
       dependencies: []
       externalDeps: []
@@ -9635,7 +10279,28 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c046e3e837dbbb82d3877985192d3438d49f369274ac709789b913c502ada617
-      lastVerified: '2026-03-11T00:48:55.884Z'
+      lastVerified: '2026-05-17T10:02:45.257Z'
+    fast-path-gate:
+      path: .aiox-core/core/orchestration/fast-path-gate.js
+      layer: L1
+      type: module
+      purpose: String(task.description || task.summary || task.title || ''),
+      keywords:
+        - fast
+        - path
+        - gate
+      usedBy:
+        - orchestration-index
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:ecd04d15600bcbf1c717cfe5f1ac3ce38bdde30275fd38f7f48f96cf0757b249
+      lastVerified: '2026-05-17T10:02:45.257Z'
     gate-evaluator:
       path: .aiox-core/core/orchestration/gate-evaluator.js
       layer: L1
@@ -9645,6 +10310,7 @@ entities:
         - gate
         - evaluator
       usedBy:
+        - orchestration-index
         - master-orchestrator
       dependencies: []
       externalDeps: []
@@ -9654,8 +10320,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:66a6ff6afefcdbf3e5149100b8e10aad95feaa5a84a0a993255ddb939b1c0eb4
-      lastVerified: '2026-03-11T00:48:55.884Z'
+      checksum: sha256:4e9e78745f937ee78b13704f3acdb45b19d4aab9bc0f17a5adaf5eecfc58e653
+      lastVerified: '2026-05-17T10:02:45.257Z'
     gemini-model-selector:
       path: .aiox-core/core/orchestration/gemini-model-selector.js
       layer: L1
@@ -9676,7 +10342,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2fe54c401ae60c0b5dc07f74c7a464992a0558b10c0b61f183c06943441d0d57
-      lastVerified: '2026-03-11T00:48:55.884Z'
+      lastVerified: '2026-05-17T10:02:45.257Z'
     greenfield-handler:
       path: .aiox-core/core/orchestration/greenfield-handler.js
       layer: L1
@@ -9687,6 +10353,7 @@ entities:
         - handler
       usedBy:
         - bob-orchestrator
+        - orchestration-index
       dependencies:
         - workflow-executor
         - surface-checker
@@ -9699,8 +10366,56 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:e4e951e1347f846f4df0af2a7692838a734418030331cb25ce6fa86721beafdf
-      lastVerified: '2026-03-11T00:48:55.884Z'
+      checksum: sha256:949c80c9c0430d4ddb1fa6e721661bad479ab476a4fb529aad8bf8dafa6e57fd
+      lastVerified: '2026-05-17T10:02:45.258Z'
+    orchestration-index:
+      path: .aiox-core/core/orchestration/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/orchestration/index.js
+      keywords:
+        - index
+      usedBy: []
+      dependencies:
+        - workflow-orchestrator
+        - subagent-prompt-builder
+        - context-manager
+        - checklist-runner
+        - parallel-executor
+        - tech-stack-detector
+        - condition-evaluator
+        - skill-dispatcher
+        - execution-profile-resolver
+        - fast-path-gate
+        - master-orchestrator
+        - recovery-handler
+        - gate-evaluator
+        - agent-invoker
+        - dashboard-integration
+        - cli-commands
+        - executor-assignment
+        - terminal-spawner
+        - workflow-executor
+        - surface-checker
+        - session-state
+        - ui-index
+        - bob-orchestrator
+        - lock-manager
+        - data-lifecycle-manager
+        - epic-context-accumulator
+        - bob-status-writer
+        - message-formatter
+        - brownfield-handler
+        - greenfield-handler
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: experimental
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:eaebc2df86ad8fdd91082c4b1f007f967b2de89eb1ac4e5902e3b46b2eb5b169
+      lastVerified: '2026-05-17T10:02:45.259Z'
     lock-manager:
       path: .aiox-core/core/orchestration/lock-manager.js
       layer: L1
@@ -9712,6 +10427,7 @@ entities:
       usedBy:
         - bob-orchestrator
         - data-lifecycle-manager
+        - orchestration-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -9720,8 +10436,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:3917ef9443f8a0e0de0c79715de54fe1e9451faa9860ee2f0c0f588dfaaf7a09
-      lastVerified: '2026-03-11T00:48:55.884Z'
+      checksum: sha256:30af501b40da2a7bcfd591c62e367c5667eefd40af91d265c986521c93e7d1f2
+      lastVerified: '2026-05-17T10:02:45.259Z'
     master-orchestrator:
       path: .aiox-core/core/orchestration/master-orchestrator.js
       layer: L1
@@ -9732,23 +10448,23 @@ entities:
         - orchestrator
       usedBy:
         - cli-commands
+        - orchestration-index
       dependencies:
         - tech-stack-detector
-        - executors
+        - orchestration-executors-index
         - recovery-handler
         - gate-evaluator
         - agent-invoker
         - dashboard-integration
       externalDeps: []
-      plannedDeps:
-        - executors
+      plannedDeps: []
       lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:88238a9e0ef7d058efe0ca2fe7a9d0e34202bff7e409fd1a97886b0a8ccdce97
-      lastVerified: '2026-05-08T06:26:24.445Z'
+      lastVerified: '2026-05-17T10:02:45.260Z'
     message-formatter:
       path: .aiox-core/core/orchestration/message-formatter.js
       layer: L1
@@ -9759,6 +10475,7 @@ entities:
         - formatter
       usedBy:
         - bob-orchestrator
+        - orchestration-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -9768,7 +10485,26 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b7413c04fa22db1c5fc2f5c2aa47bb8ca0374e079894a44df21b733da6c258ae
-      lastVerified: '2026-03-11T00:48:55.885Z'
+      lastVerified: '2026-05-17T10:02:45.260Z'
+    orchestration-parallel-executor:
+      path: .aiox-core/core/orchestration/parallel-executor.js
+      layer: L1
+      type: module
+      purpose: '{'
+      keywords:
+        - parallel
+        - executor
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:17b9669337d080509cb270eb8564a0f5684b2abbad1056f81b6947bb0b2b594f
+      lastVerified: '2026-05-17T10:02:45.261Z'
     recovery-handler:
       path: .aiox-core/core/orchestration/recovery-handler.js
       layer: L1
@@ -9778,6 +10514,7 @@ entities:
         - recovery
         - handler
       usedBy:
+        - orchestration-index
         - master-orchestrator
       dependencies:
         - stuck-detector
@@ -9790,8 +10527,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:6a9ef025f95885849aa893188299aca698cea2ea428cc302012833032c9e106e
-      lastVerified: '2026-03-11T00:48:55.885Z'
+      checksum: sha256:3224718aa40bbdd08e117b27ac71f4ec66252d9874acaf9bb3addfe8ca4d0c06
+      lastVerified: '2026-05-17T10:02:45.261Z'
     session-state:
       path: .aiox-core/core/orchestration/session-state.js
       layer: L1
@@ -9801,11 +10538,14 @@ entities:
         - session
         - state
       usedBy:
+        - run-workflow-engine
+        - run-workflow
         - session-resume
         - greeting-builder
         - bob-orchestrator
         - brownfield-handler
         - greenfield-handler
+        - orchestration-index
         - workflow-executor
       dependencies: []
       externalDeps: []
@@ -9815,8 +10555,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:72aa24d7a7a256a56973d7b4e7b03c968eabeb0d22be23af75f65f2e45ac88b3
-      lastVerified: '2026-03-11T00:48:55.885Z'
+      checksum: sha256:70d511bf6a03e8cacefcec0065a4727cfb380471c89762bb291840968f55b44b
+      lastVerified: '2026-05-17T10:02:45.261Z'
     skill-dispatcher:
       path: .aiox-core/core/orchestration/skill-dispatcher.js
       layer: L1
@@ -9826,6 +10566,7 @@ entities:
         - skill
         - dispatcher
       usedBy:
+        - orchestration-index
         - workflow-orchestrator
       dependencies: []
       externalDeps: []
@@ -9836,7 +10577,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ebee66973a1df5d9dfed195ac6d83765a92023ba504e1814674345094fb8117
-      lastVerified: '2026-03-11T00:48:55.885Z'
+      lastVerified: '2026-05-17T10:02:45.262Z'
     subagent-prompt-builder:
       path: .aiox-core/core/orchestration/subagent-prompt-builder.js
       layer: L1
@@ -9847,6 +10588,7 @@ entities:
         - prompt
         - builder
       usedBy:
+        - orchestration-index
         - workflow-orchestrator
       dependencies: []
       externalDeps: []
@@ -9857,7 +10599,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c014eaae229e6c84742273701a6ef21a19343e34ef8be38d5d6a9bc59ecd8b02
-      lastVerified: '2026-03-11T00:48:55.885Z'
+      lastVerified: '2026-05-17T10:02:45.262Z'
     surface-checker:
       path: .aiox-core/core/orchestration/surface-checker.js
       layer: L1
@@ -9871,6 +10613,7 @@ entities:
         - bob-orchestrator
         - brownfield-handler
         - greenfield-handler
+        - orchestration-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -9880,7 +10623,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:92e9d5bea78c3db4940c39f79e537821b36451cd524d69e6b738272aa63c08b6
-      lastVerified: '2026-03-11T00:48:55.885Z'
+      lastVerified: '2026-05-17T10:02:45.262Z'
     task-complexity-classifier:
       path: .aiox-core/core/orchestration/task-complexity-classifier.js
       layer: L1
@@ -9901,7 +10644,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:33b3b7c349352d607c156e0018c508f0869a1c7d233d107bed194a51bc608c93
-      lastVerified: '2026-03-11T00:48:55.885Z'
+      lastVerified: '2026-05-17T10:02:45.262Z'
     tech-stack-detector:
       path: .aiox-core/core/orchestration/tech-stack-detector.js
       layer: L1
@@ -9912,6 +10655,7 @@ entities:
         - stack
         - detector
       usedBy:
+        - orchestration-index
         - master-orchestrator
         - workflow-orchestrator
       dependencies: []
@@ -9923,7 +10667,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:074c52757e181cc1e344b26ae191ac67488d18e9da2b06b5def23abb6c64c056
-      lastVerified: '2026-03-11T00:48:55.885Z'
+      lastVerified: '2026-05-17T10:02:45.263Z'
     terminal-spawner:
       path: .aiox-core/core/orchestration/terminal-spawner.js
       layer: L1
@@ -9934,6 +10678,7 @@ entities:
         - spawner
       usedBy:
         - greenfield-handler
+        - orchestration-index
         - workflow-executor
       dependencies: []
       externalDeps: []
@@ -9944,7 +10689,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a6453c6acf0ff007444adeaa5e4620890fff38f0b31b058a2da04d790fb098ab
-      lastVerified: '2026-03-11T00:48:55.886Z'
+      lastVerified: '2026-05-17T10:02:45.263Z'
     workflow-executor:
       path: .aiox-core/core/orchestration/workflow-executor.js
       layer: L1
@@ -9958,6 +10703,7 @@ entities:
         - bob-orchestrator
         - brownfield-handler
         - greenfield-handler
+        - orchestration-index
       dependencies:
         - executor-assignment
         - terminal-spawner
@@ -9970,7 +10716,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:49372791e5729fd7987c80efe1400168e8d59eac000a009b88d9fde6735cf4db
-      lastVerified: '2026-03-11T00:48:55.886Z'
+      lastVerified: '2026-05-17T10:02:45.263Z'
     workflow-orchestrator:
       path: .aiox-core/core/orchestration/workflow-orchestrator.js
       layer: L1
@@ -9979,7 +10725,8 @@ entities:
       keywords:
         - workflow
         - orchestrator
-      usedBy: []
+      usedBy:
+        - orchestration-index
       dependencies:
         - subagent-prompt-builder
         - context-manager
@@ -9991,13 +10738,36 @@ entities:
         - execution-profile-resolver
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:82816bd5e6fecc9bbb77292444e53254c72bf93e5c04260784743354c6a58627
-      lastVerified: '2026-03-11T00:48:55.886Z'
+      lastVerified: '2026-05-17T10:02:45.264Z'
+    permissions-index:
+      path: .aiox-core/core/permissions/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/permissions/index.js
+      keywords:
+        - index
+      usedBy:
+        - greeting-builder
+        - unified-activation-pipeline
+      dependencies:
+        - permission-mode
+        - operation-guard
+      externalDeps: []
+      plannedDeps:
+        - permissions
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:5748821f5b7fcc2c54e74956ddd9e05326fa96520a753a506feb9910042f562b
+      lastVerified: '2026-05-17T10:02:45.264Z'
     operation-guard:
       path: .aiox-core/core/permissions/operation-guard.js
       layer: L1
@@ -10007,6 +10777,7 @@ entities:
         - operation
         - guard
       usedBy:
+        - permissions-index
         - permission-mode.test
       dependencies:
         - permission-mode
@@ -10018,7 +10789,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f9b1b1bd547145c0d8a0f47534af0678ee852df6236acd05c53e479cb0e3f0bd
-      lastVerified: '2026-03-11T00:48:55.886Z'
+      lastVerified: '2026-05-17T10:02:45.264Z'
     permission-mode:
       path: .aiox-core/core/permissions/permission-mode.js
       layer: L1
@@ -10028,6 +10799,7 @@ entities:
         - permission
         - mode
       usedBy:
+        - permissions-index
         - operation-guard
         - permission-mode.test
       dependencies: []
@@ -10039,7 +10811,26 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:84f09067c7154d97cb2252b9a7def00562acf569cfc3b035d6d4e39fb40d4033
-      lastVerified: '2026-03-11T00:48:55.886Z'
+      lastVerified: '2026-05-17T10:02:45.264Z'
+    pro-updater:
+      path: .aiox-core/core/pro/pro-updater.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/pro/pro-updater.js
+      keywords:
+        - pro
+        - updater
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:30ea78b8ab088e695936ae662057697410856751f463eeb649e00b67dcc31531
+      lastVerified: '2026-05-17T10:02:45.265Z'
     base-layer:
       path: .aiox-core/core/quality-gates/base-layer.js
       layer: L1
@@ -10061,7 +10852,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a9a3921da08176b0bd44f338a59abc1f5107f3b1ee56571e840bf4e8ed233f4
-      lastVerified: '2026-03-11T00:48:55.887Z'
+      lastVerified: '2026-05-17T10:02:45.265Z'
     checklist-generator:
       path: .aiox-core/core/quality-gates/checklist-generator.js
       layer: L1
@@ -10081,7 +10872,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7f2800f6e2465a846c9bef8a73403e7b91bf18d1d1425804d31244bd883ec55a
-      lastVerified: '2026-03-11T00:48:55.887Z'
+      lastVerified: '2026-05-17T10:02:45.265Z'
     focus-area-recommender:
       path: .aiox-core/core/quality-gates/focus-area-recommender.js
       layer: L1
@@ -10102,7 +10893,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f6364e2d444d19a8a3d0fb59d5264ae55137d48e008f5a3efe57f92465c4b53e
-      lastVerified: '2026-03-11T00:48:55.887Z'
+      lastVerified: '2026-05-17T10:02:45.265Z'
     human-review-orchestrator:
       path: .aiox-core/core/quality-gates/human-review-orchestrator.js
       layer: L1
@@ -10125,7 +10916,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3462b577d1bfa561156e72483241cb3bd0a6756448bd17acb3f4d92ead144781
-      lastVerified: '2026-03-11T00:48:55.887Z'
+      lastVerified: '2026-05-17T10:02:45.265Z'
     layer1-precommit:
       path: .aiox-core/core/quality-gates/layer1-precommit.js
       layer: L1
@@ -10146,7 +10937,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:250b62740b473383e41b371bb59edddabd8a312f5f48a5a8e883e6196a48b8f3
-      lastVerified: '2026-03-11T00:48:55.887Z'
+      lastVerified: '2026-05-17T10:02:45.265Z'
     layer2-pr-automation:
       path: .aiox-core/core/quality-gates/layer2-pr-automation.js
       layer: L1
@@ -10168,7 +10959,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:af31e7ac60b74b52ee983d0fcff7457042eea553b6127538cab41eb94eaee8e0
-      lastVerified: '2026-03-11T00:48:55.889Z'
+      lastVerified: '2026-05-17T10:02:45.265Z'
     layer3-human-review:
       path: .aiox-core/core/quality-gates/layer3-human-review.js
       layer: L1
@@ -10191,7 +10982,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9bf79d5adfddae55d7dddfda777cd2775aa76f82204ddd0f660f6edbd093b16b
-      lastVerified: '2026-03-11T00:48:55.889Z'
+      lastVerified: '2026-05-17T10:02:45.266Z'
     notification-manager:
       path: .aiox-core/core/quality-gates/notification-manager.js
       layer: L1
@@ -10212,7 +11003,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:89466b448383f8021075f43b870036b2e1d0277e543bd4357dd4988dc7c31b14
-      lastVerified: '2026-03-11T00:48:55.889Z'
+      lastVerified: '2026-05-17T10:02:45.266Z'
     quality-gate-manager:
       path: .aiox-core/core/quality-gates/quality-gate-manager.js
       layer: L1
@@ -10237,7 +11028,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b0d5ce2653218eae63121e892d886c3234a87bf98536369c75b537163e07fb26
-      lastVerified: '2026-03-11T00:48:55.889Z'
+      lastVerified: '2026-05-17T10:02:45.266Z'
     build-registry:
       path: .aiox-core/core/registry/build-registry.js
       layer: L1
@@ -10256,7 +11047,26 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e23f7e4f2d378de42204698eb0a818f6f8a4868a97341c8fbb92158c3e7d4767
-      lastVerified: '2026-03-11T00:48:55.889Z'
+      lastVerified: '2026-05-17T10:02:45.266Z'
+    registry-registry-loader:
+      path: .aiox-core/core/registry/registry-loader.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/registry/registry-loader.js
+      keywords:
+        - registry
+        - loader
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:0cf9fa2ca39f7c4ca20043f3c4d7742e40dec7e94f81b706cf9318ebee199975
+      lastVerified: '2026-05-17T10:02:45.267Z'
     validate-registry:
       path: .aiox-core/core/registry/validate-registry.js
       layer: L1
@@ -10275,7 +11085,47 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d9805ce445661a3a2d9e6c73bf35cbd1bc2403419825442cd7b8f01cc1409cb3
-      lastVerified: '2026-03-11T00:48:55.890Z'
+      lastVerified: '2026-05-17T10:02:45.267Z'
+    agent-immortality:
+      path: .aiox-core/core/resilience/agent-immortality.js
+      layer: L1
+      type: module
+      purpose: truncate(summary, options.maxLegacyChars ?? DEFAULT_CONFIG.maxLegacyChars),
+      keywords:
+        - agent
+        - immortality
+      usedBy:
+        - resilience-index
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:d1612c672e91a802924c4a61d8beade66d5740487ca0a244950a2c8249a70962
+      lastVerified: '2026-05-17T10:02:45.267Z'
+    resilience-index:
+      path: .aiox-core/core/resilience/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/resilience/index.js
+      keywords:
+        - index
+      usedBy:
+        - index
+      dependencies:
+        - agent-immortality
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:5acbb55fbbf25fc052c0ee2eac5f35d30228144e9f426083b89aabc9e54d084f
+      lastVerified: '2026-05-17T10:02:45.267Z'
     context-detector:
       path: .aiox-core/core/session/context-detector.js
       layer: L1
@@ -10301,7 +11151,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5537563d5dfc613e16fd610c9e1407e7811c4f19745a78a4fc81c34af20000f4
-      lastVerified: '2026-03-11T00:48:55.890Z'
+      lastVerified: '2026-05-17T10:02:45.267Z'
     context-loader:
       path: .aiox-core/core/session/context-loader.js
       layer: L1
@@ -10325,7 +11175,51 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e810e119059dce081d1143b16e4e6bb7aa65684169b4ebc36f55ecbaf109bd63
-      lastVerified: '2026-03-11T00:48:55.890Z'
+      lastVerified: '2026-05-17T10:02:45.267Z'
+    synapse-engine:
+      path: .aiox-core/core/synapse/engine.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/synapse/engine.js
+      keywords:
+        - engine
+      usedBy: []
+      dependencies:
+        - errors-index
+        - context-tracker
+        - context-builder
+        - formatter
+        - memory-bridge
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: experimental
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:1b65523b2fec6a44ab380298c4d98f0569209dec8b50be3922479ffcd6548df0
+      lastVerified: '2026-05-17T10:02:45.268Z'
+    ui-index:
+      path: .aiox-core/core/ui/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/ui/index.js
+      keywords:
+        - index
+      usedBy:
+        - orchestration-index
+      dependencies:
+        - observability-panel
+        - panel-renderer
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:49f683bbedad4f161006e7317c409ec12af2aa9f7ba0750c4d1d15ac3df05350
+      lastVerified: '2026-05-17T10:02:45.268Z'
     observability-panel:
       path: .aiox-core/core/ui/observability-panel.js
       layer: L1
@@ -10336,6 +11230,7 @@ entities:
         - panel
       usedBy:
         - bob-orchestrator
+        - ui-index
       dependencies:
         - panel-renderer
       externalDeps: []
@@ -10346,7 +11241,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f73bb7b80e60d8158c5044b13bb4dd4945270d3d44b8ac3e2c30635e5040f0f8
-      lastVerified: '2026-03-11T00:48:55.890Z'
+      lastVerified: '2026-05-17T10:02:45.268Z'
     panel-renderer:
       path: .aiox-core/core/ui/panel-renderer.js
       layer: L1
@@ -10356,6 +11251,7 @@ entities:
         - panel
         - renderer
       usedBy:
+        - ui-index
         - observability-panel
       dependencies: []
       externalDeps: []
@@ -10366,7 +11262,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d51a8a9d1dd76ce6bc08d38eaf53f4f7df948cc4edc8e7f56d68c39522f64dc6
-      lastVerified: '2026-03-11T00:48:55.890Z'
+      lastVerified: '2026-05-17T10:02:45.268Z'
     output-formatter:
       path: .aiox-core/core/utils/output-formatter.js
       layer: L1
@@ -10385,7 +11281,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6fdfee469b7c108ec24a045b9b2719d836a242052abd285957a9ac732c6fc594
-      lastVerified: '2026-03-11T00:48:55.890Z'
+      lastVerified: '2026-05-17T10:02:45.268Z'
     security-utils:
       path: .aiox-core/core/utils/security-utils.js
       layer: L1
@@ -10404,7 +11300,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:00c938eda0e142b8c204b50afdd662864b5209b60a32a0e6e847e4e4cbceee09
-      lastVerified: '2026-03-11T00:48:55.890Z'
+      lastVerified: '2026-05-17T10:02:45.269Z'
     yaml-validator:
       path: .aiox-core/core/utils/yaml-validator.js
       layer: L1
@@ -10422,8 +11318,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:41e3715845262c2e49f58745a773e81f4feaaa2325e54bcb0226e4bf08f709dd
-      lastVerified: '2026-03-11T00:48:55.890Z'
+      checksum: sha256:05084596198634dd2a670a752d5c451edfe268e16e3bae511db52184f895366f
+      lastVerified: '2026-05-17T10:02:45.269Z'
     creation-helper:
       path: .aiox-core/core/code-intel/helpers/creation-helper.js
       layer: L1
@@ -10443,7 +11339,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e674fdbe6979dbe961853f080d5971ba264dee23ab70abafcc21ee99356206e7
-      lastVerified: '2026-03-11T00:48:55.890Z'
+      lastVerified: '2026-05-17T10:02:45.269Z'
     dev-helper:
       path: .aiox-core/core/code-intel/helpers/dev-helper.js
       layer: L1
@@ -10463,8 +11359,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:2418a5f541003c73cc284e88a6b0cb666896a47ffd5ed4c08648269d281efc4c
-      lastVerified: '2026-03-11T00:48:55.891Z'
+      checksum: sha256:7e7f9bb92725ca1d85b0a7151668bc5bcdd6fc9b73fed5b2b2c28217d14535ab
+      lastVerified: '2026-05-17T10:02:45.269Z'
     devops-helper:
       path: .aiox-core/core/code-intel/helpers/devops-helper.js
       layer: L1
@@ -10485,8 +11381,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:c40cfa9ac2f554a707ff68c7709ae436349041bf00ad2f42811ccbe8ba842462
-      lastVerified: '2026-03-11T00:48:55.891Z'
+      checksum: sha256:e72f95de2f3737b6e12094526eabfb4974a8339ce6d25f2e323f734fe567c155
+      lastVerified: '2026-05-17T10:02:45.269Z'
     planning-helper:
       path: .aiox-core/core/code-intel/helpers/planning-helper.js
       layer: L1
@@ -10510,8 +11406,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:2edcf275122125205a9e737035c8b25efdc4af13e7349ffc10c3ebe8ebe7654d
-      lastVerified: '2026-03-11T00:48:55.891Z'
+      checksum: sha256:9ca5b57b74b5729685369662659e15a91e35ec3a33691973be000ecd85974f3d
+      lastVerified: '2026-05-17T10:02:45.269Z'
     qa-helper:
       path: .aiox-core/core/code-intel/helpers/qa-helper.js
       layer: L1
@@ -10530,8 +11426,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:ca069dad294224dd5c3369826fb39d5c24287d49d74360049f8bbc55f190eeda
-      lastVerified: '2026-03-11T00:48:55.891Z'
+      checksum: sha256:9dbb84c1c4ed1aa57385ad2a6c74520f2020e6f8883012dd57c51486172ee528
+      lastVerified: '2026-05-17T10:02:45.269Z'
     story-helper:
       path: .aiox-core/core/code-intel/helpers/story-helper.js
       layer: L1
@@ -10551,7 +11447,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:778466253ac66103ebc3b1caf71f44b06a0d5fb3d39fe8d3d473dd4bc73fefc6
-      lastVerified: '2026-03-11T00:48:55.891Z'
+      lastVerified: '2026-05-17T10:02:45.270Z'
     code-graph-provider:
       path: .aiox-core/core/code-intel/providers/code-graph-provider.js
       layer: L1
@@ -10563,6 +11459,7 @@ entities:
         - provider
       usedBy:
         - code-intel-client
+        - code-intel-index
       dependencies:
         - provider-interface
       externalDeps: []
@@ -10573,7 +11470,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:83251871bc2d65864a4e148e3921408e74662a2739bfbd12395a2daaa4bde9a0
-      lastVerified: '2026-03-11T00:48:55.891Z'
+      lastVerified: '2026-05-17T10:02:45.270Z'
     provider-interface:
       path: .aiox-core/core/code-intel/providers/provider-interface.js
       layer: L1
@@ -10583,6 +11480,7 @@ entities:
         - provider
         - interface
       usedBy:
+        - code-intel-index
         - code-graph-provider
         - registry-provider
       dependencies: []
@@ -10594,7 +11492,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:74df278e31f240ee4499f10989c4b6f8c7c7cba6e8f317cb433a23fd6693c487
-      lastVerified: '2026-03-11T00:48:55.891Z'
+      lastVerified: '2026-05-17T10:02:45.270Z'
     registry-provider:
       path: .aiox-core/core/code-intel/providers/registry-provider.js
       layer: L1
@@ -10606,6 +11504,7 @@ entities:
       usedBy:
         - code-intel-client
         - hook-runtime
+        - code-intel-index
       dependencies:
         - provider-interface
       externalDeps: []
@@ -10616,7 +11515,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d7173384a1c0ff33326d1f45ee3fba0a6cbf7d7fe0476c1a60fda5442f5486e3
-      lastVerified: '2026-03-11T00:48:55.891Z'
+      lastVerified: '2026-05-17T10:02:45.270Z'
     agent-memory:
       path: .aiox-core/core/doctor/checks/agent-memory.js
       layer: L1
@@ -10627,6 +11526,7 @@ entities:
         - memory
       usedBy:
         - fix-handler
+        - doctor-checks-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -10636,7 +11536,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:08d5d685e4fdaaedf081020229844f4a58c9fd00244e4c37eb5b3fd78f4feb61
-      lastVerified: '2026-03-11T00:48:55.891Z'
+      lastVerified: '2026-05-17T10:02:45.270Z'
     claude-md:
       path: .aiox-core/core/doctor/checks/claude-md.js
       layer: L1
@@ -10645,17 +11545,18 @@ entities:
       keywords:
         - claude
         - md
-      usedBy: []
+      usedBy:
+        - doctor-checks-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:88162c90d0b671c1a924fd6e18aeeb0fb229d19fb4204c12551feafbdef5d01d
-      lastVerified: '2026-03-11T00:48:55.891Z'
+      lastVerified: '2026-05-17T10:02:45.271Z'
     code-intel:
       path: .aiox-core/core/doctor/checks/code-intel.js
       layer: L1
@@ -10673,8 +11574,7 @@ entities:
         - github-devops-pre-push-quality-gate
         - plan-create-context
         - plan-create-implementation
-        - code-intel-source
-        - metrics-source
+        - doctor-checks-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -10684,7 +11584,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ed69815b54a686ef1076964f1eb667059712d35487fc2f1785a9897f59436fb
-      lastVerified: '2026-03-11T00:48:55.891Z'
+      lastVerified: '2026-05-17T10:02:45.271Z'
     commands-count:
       path: .aiox-core/core/doctor/checks/commands-count.js
       layer: L1
@@ -10693,17 +11593,18 @@ entities:
       keywords:
         - commands
         - count
-      usedBy: []
+      usedBy:
+        - doctor-checks-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:eb3be16a561337ed64883ba578df1cb74790fcb6edee47bfd309d2480e66fbee
-      lastVerified: '2026-03-11T00:48:55.891Z'
+      lastVerified: '2026-05-17T10:02:45.271Z'
     core-config:
       path: .aiox-core/core/doctor/checks/core-config.js
       layer: L1
@@ -10712,17 +11613,18 @@ entities:
       keywords:
         - core
         - config
-      usedBy: []
+      usedBy:
+        - doctor-checks-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:53ddc48091f64805c100d08fb8cac5d1b4d74e844c8cfcde122f881a428b650b
-      lastVerified: '2026-03-11T00:48:55.891Z'
+      lastVerified: '2026-05-17T10:02:45.271Z'
     entity-registry:
       path: .aiox-core/core/doctor/checks/entity-registry.js
       layer: L1
@@ -10741,7 +11643,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bed5f0881102fecf77e7a4f990a1363b840422701f736e806c1c69908acae0aa
-      lastVerified: '2026-03-11T00:48:55.891Z'
+      lastVerified: '2026-05-17T10:02:45.272Z'
     git-hooks:
       path: .aiox-core/core/doctor/checks/git-hooks.js
       layer: L1
@@ -10750,17 +11652,18 @@ entities:
       keywords:
         - git
         - hooks
-      usedBy: []
+      usedBy:
+        - doctor-checks-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:3fe9411a64265c581952f40044b70cc21b324773f54e4b902e4ce390c976fa2f
-      lastVerified: '2026-03-11T00:48:55.891Z'
+      lastVerified: '2026-05-17T10:02:45.272Z'
     graph-dashboard:
       path: .aiox-core/core/doctor/checks/graph-dashboard.js
       layer: L1
@@ -10769,17 +11672,18 @@ entities:
       keywords:
         - graph
         - dashboard
-      usedBy: []
+      usedBy:
+        - doctor-checks-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:4c4a16ab33117169aac7e4e29d841eec4f28a076f6d93fb9d872749831a14a17
-      lastVerified: '2026-03-11T00:48:55.891Z'
+      lastVerified: '2026-05-17T10:02:45.272Z'
     hooks-claude-count:
       path: .aiox-core/core/doctor/checks/hooks-claude-count.js
       layer: L1
@@ -10789,17 +11693,18 @@ entities:
         - hooks
         - claude
         - count
-      usedBy: []
+      usedBy:
+        - doctor-checks-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:026ddf0248819b89b1147e0876a2934e38e0113d3c6380d68a752d432060e7ec
-      lastVerified: '2026-03-11T00:48:55.892Z'
+      lastVerified: '2026-05-17T10:02:45.272Z'
     ide-sync:
       path: .aiox-core/core/doctor/checks/ide-sync.js
       layer: L1
@@ -10808,17 +11713,52 @@ entities:
       keywords:
         - ide
         - sync
-      usedBy: []
+      usedBy:
+        - doctor-checks-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:0941feb55b6dc5d3afde7e4e9ef11afbc1d9781197c9e52630056fab1c1ebea2
-      lastVerified: '2026-03-11T00:48:55.892Z'
+      checksum: sha256:4ddd037b4ad18c4201ca1428a1044efd313e9d2721cd399aebd3c5043fd4e2d1
+      lastVerified: '2026-05-17T10:02:45.272Z'
+    doctor-checks-index:
+      path: .aiox-core/core/doctor/checks/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/doctor/checks/index.js
+      keywords:
+        - index
+      usedBy:
+        - doctor-index
+      dependencies:
+        - settings-json
+        - rules-files
+        - agent-memory
+        - entity-registry
+        - git-hooks
+        - core-config
+        - claude-md
+        - ide-sync
+        - graph-dashboard
+        - code-intel
+        - node-version
+        - npm-packages
+        - skills-count
+        - commands-count
+        - hooks-claude-count
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:c4034f86b66895c1ab9a8be4148577d5b886c21f31e05d32cbf8e4970e88f204
+      lastVerified: '2026-05-17T10:02:45.273Z'
     node-version:
       path: .aiox-core/core/doctor/checks/node-version.js
       layer: L1
@@ -10827,17 +11767,19 @@ entities:
       keywords:
         - node
         - version
-      usedBy: []
+      usedBy:
+        - doctor-checks-index
+        - health-check-checks-project-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:9e8bd100affa46131ac495c1e60ce87c88bbe879d459601a502589824d1aeac1
-      lastVerified: '2026-03-11T00:48:55.892Z'
+      lastVerified: '2026-05-17T10:02:45.273Z'
     npm-packages:
       path: .aiox-core/core/doctor/checks/npm-packages.js
       layer: L1
@@ -10846,17 +11788,18 @@ entities:
       keywords:
         - npm
         - packages
-      usedBy: []
+      usedBy:
+        - doctor-checks-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:6c54cb15dc3492ec50b4edc4733ecc5c41d5a00536aed87a5a5d815f472ee9f7
-      lastVerified: '2026-03-11T00:48:55.892Z'
+      lastVerified: '2026-05-17T10:02:45.273Z'
     rules-files:
       path: .aiox-core/core/doctor/checks/rules-files.js
       layer: L1
@@ -10867,6 +11810,7 @@ entities:
         - files
       usedBy:
         - fix-handler
+        - doctor-checks-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -10875,8 +11819,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:3996e6343a224021fa684d7930dc99b66469c59cb15d416b0c024a770d722ab6
-      lastVerified: '2026-03-11T00:48:55.893Z'
+      checksum: sha256:ec58342215cede634f50c5b3164155c4f27fd8070af176ec0e02e6deec6fb218
+      lastVerified: '2026-05-17T10:02:45.273Z'
     settings-json:
       path: .aiox-core/core/doctor/checks/settings-json.js
       layer: L1
@@ -10885,17 +11829,18 @@ entities:
       keywords:
         - settings
         - json
-      usedBy: []
+      usedBy:
+        - doctor-checks-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:bd26841b966fcfa003eca6f85416d4f877b9dcfea0e4017df9f2a97c14c33fbb
-      lastVerified: '2026-03-11T00:48:55.893Z'
+      lastVerified: '2026-05-17T10:02:45.273Z'
     skills-count:
       path: .aiox-core/core/doctor/checks/skills-count.js
       layer: L1
@@ -10904,17 +11849,18 @@ entities:
       keywords:
         - skills
         - count
-      usedBy: []
+      usedBy:
+        - doctor-checks-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:0b6a19fca1765904c31a33caeeefacbe76df4641154f2f93a8300b4cacce34b8
-      lastVerified: '2026-03-11T00:48:55.893Z'
+      checksum: sha256:811d904bde6d2ba4940f19cbe6a29cc12c5df6908ac95cb37bcb7add687fe4cc
+      lastVerified: '2026-05-17T10:02:45.273Z'
     json:
       path: .aiox-core/core/doctor/formatters/json.js
       layer: L1
@@ -10922,17 +11868,19 @@ entities:
       purpose: Entity at .aiox-core/core/doctor/formatters/json.js
       keywords:
         - json
-      usedBy: []
+      usedBy:
+        - doctor-index
+        - health-check-reporters-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:ea3f28f168f48ca3002661210932846f0e82c3dd9261d5e9115036f67e5a1ea4
-      lastVerified: '2026-03-11T00:48:55.893Z'
+      lastVerified: '2026-05-17T10:02:45.274Z'
     text:
       path: .aiox-core/core/doctor/formatters/text.js
       layer: L1
@@ -10940,17 +11888,18 @@ entities:
       purpose: ${pass} PASS | ${warn} WARN | ${fail} FAIL | ${info} INFO`);
       keywords:
         - text
-      usedBy: []
+      usedBy:
+        - doctor-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:bd582b33c2d915516798627351c46d6d8edb56f655bb91037dfdbac159de77eb
-      lastVerified: '2026-03-11T00:48:55.893Z'
+      lastVerified: '2026-05-17T10:02:45.274Z'
     code-intel-source:
       path: .aiox-core/core/graph-dashboard/data-sources/code-intel-source.js
       layer: L1
@@ -10962,8 +11911,9 @@ entities:
         - source
       usedBy:
         - cli
+        - graph-dashboard-index
       dependencies:
-        - code-intel
+        - code-intel-index
         - registry-loader
       externalDeps: []
       plannedDeps: []
@@ -10972,8 +11922,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:e508d6cbadcd2358fa7756dcaceefbaa510bd89155e036e2cbd386585408ff8f
-      lastVerified: '2026-03-11T00:48:55.893Z'
+      checksum: sha256:2b0534f57a8f6ca2ff5942e42faf147f1be84773b3af33c9e506ee8f318b558c
+      lastVerified: '2026-05-17T10:02:45.274Z'
     metrics-source:
       path: .aiox-core/core/graph-dashboard/data-sources/metrics-source.js
       layer: L1
@@ -10985,7 +11935,7 @@ entities:
       usedBy:
         - cli
       dependencies:
-        - code-intel
+        - code-intel-index
       externalDeps: []
       plannedDeps: []
       lifecycle: production
@@ -10994,7 +11944,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b1e4027f82350760b67ea8f58e04a5e739f87f010838487043e29dab7301ae9e
-      lastVerified: '2026-03-11T00:48:55.893Z'
+      lastVerified: '2026-05-17T10:02:45.274Z'
     registry-source:
       path: .aiox-core/core/graph-dashboard/data-sources/registry-source.js
       layer: L1
@@ -11015,7 +11965,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:32d2a4bd5b102823d5933e5f9a648ae7e647cb1918092063161fed80d32b844b
-      lastVerified: '2026-03-11T00:48:55.893Z'
+      lastVerified: '2026-05-17T10:02:45.274Z'
     dot-formatter:
       path: .aiox-core/core/graph-dashboard/formatters/dot-formatter.js
       layer: L1
@@ -11035,7 +11985,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c369343f2b617a730951eb137d5ba74087bfd9f5dddbbf439e1fc2f87117d7a
-      lastVerified: '2026-03-11T00:48:55.893Z'
+      lastVerified: '2026-05-17T10:02:45.274Z'
     html-formatter:
       path: .aiox-core/core/graph-dashboard/formatters/html-formatter.js
       layer: L1
@@ -11055,7 +12005,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:81bfd3d61234cf17a0d7e25fbcdb86ddddc3f911e25a95f21604f7fe1d8d6a84
-      lastVerified: '2026-03-11T00:48:55.894Z'
+      lastVerified: '2026-05-17T10:02:45.275Z'
     json-formatter:
       path: .aiox-core/core/graph-dashboard/formatters/json-formatter.js
       layer: L1
@@ -11075,7 +12025,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0544ec384f716130a5141edc7ad6733dccd82b86e37fc1606f1120b0037c3f8d
-      lastVerified: '2026-03-11T00:48:55.894Z'
+      lastVerified: '2026-05-17T10:02:45.275Z'
     mermaid-formatter:
       path: .aiox-core/core/graph-dashboard/formatters/mermaid-formatter.js
       layer: L1
@@ -11095,7 +12045,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a6a5361cb7cdce2632d348ad32c659a3c383471fd338e76d578cc83c0888b2d7
-      lastVerified: '2026-03-11T00:48:55.894Z'
+      lastVerified: '2026-05-17T10:02:45.276Z'
     stats-renderer:
       path: .aiox-core/core/graph-dashboard/renderers/stats-renderer.js
       layer: L1
@@ -11115,7 +12065,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:375f904e8592a546f594f63b2c717db03db500e7070372db6de5524ac74ba474
-      lastVerified: '2026-03-11T00:48:55.894Z'
+      lastVerified: '2026-05-17T10:02:45.276Z'
     status-renderer:
       path: .aiox-core/core/graph-dashboard/renderers/status-renderer.js
       layer: L1
@@ -11135,7 +12085,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8e971ae267a570fac96782ee2d1ddb7787cc1efde9e17a2f23c9261ae0286acb
-      lastVerified: '2026-03-11T00:48:55.894Z'
+      lastVerified: '2026-05-17T10:02:45.276Z'
     tree-renderer:
       path: .aiox-core/core/graph-dashboard/renderers/tree-renderer.js
       layer: L1
@@ -11146,6 +12096,7 @@ entities:
         - renderer
       usedBy:
         - cli
+        - graph-dashboard-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -11155,7 +12106,30 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:067bb5aefdfff0442a6132b89cec9ac61e84c9a9295097209a71c839978cef10
-      lastVerified: '2026-03-11T00:48:55.894Z'
+      lastVerified: '2026-05-17T10:02:45.276Z'
+    health-check-checks-index:
+      path: .aiox-core/core/health-check/checks/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/health-check/checks/index.js
+      keywords:
+        - index
+      usedBy: []
+      dependencies:
+        - health-check-checks-project-index
+        - health-check-checks-local-index
+        - health-check-checks-repository-index
+        - health-check-checks-deployment-index
+        - health-check-checks-services-index
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: experimental
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:d0713cca1b852d1b5a93d0c8e7d3c0fd3f3f05dde858ba1d5e5f9e053f41ae13
+      lastVerified: '2026-05-17T10:02:45.276Z'
     backup-manager:
       path: .aiox-core/core/health-check/healers/backup-manager.js
       layer: L1
@@ -11174,7 +12148,28 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2827c219b84ef9a133a057c7b15b752a7681807711de47c0807b87b16973ffb1
-      lastVerified: '2026-03-11T00:48:55.894Z'
+      lastVerified: '2026-05-17T10:02:45.276Z'
+    health-check-healers-index:
+      path: .aiox-core/core/health-check/healers/index.js
+      layer: L1
+      type: module
+      purpose: healer.promptDescription || checkResult.recommendation,
+      keywords:
+        - index
+      usedBy:
+        - health-check-index
+      dependencies:
+        - backup-manager
+        - base-check
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:09bb735207abb8ed6edbaa82247567d47f77fe3f09920e6b64c719338a9dd9e8
+      lastVerified: '2026-05-17T10:02:45.277Z'
     console:
       path: .aiox-core/core/health-check/reporters/console.js
       layer: L1
@@ -11182,6 +12177,48 @@ entities:
       purpose: Entity at .aiox-core/core/health-check/reporters/console.js
       keywords:
         - console
+      usedBy:
+        - health-check-reporters-index
+      dependencies:
+        - base-check
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:573f28a6c9c2a4087ccd349398f47351aa9a752c92a1f2e4a3c3f396682d5516
+      lastVerified: '2026-05-17T10:02:45.277Z'
+    health-check-reporters-index:
+      path: .aiox-core/core/health-check/reporters/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/health-check/reporters/index.js
+      keywords:
+        - index
+      usedBy:
+        - health-check-index
+      dependencies:
+        - markdown
+        - json
+        - console
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:5e32e3e0fa9e152bf2ffbcdbc80cbd046722eff75745ef571b21d55de760f9a2
+      lastVerified: '2026-05-17T10:02:45.277Z'
+    health-check-reporters-json:
+      path: .aiox-core/core/health-check/reporters/json.js
+      layer: L1
+      type: module
+      purpose: data.summary,
+      keywords:
+        - json
       usedBy: []
       dependencies:
         - base-check
@@ -11192,8 +12229,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:573f28a6c9c2a4087ccd349398f47351aa9a752c92a1f2e4a3c3f396682d5516
-      lastVerified: '2026-03-11T00:48:55.894Z'
+      checksum: sha256:56b97bb379b7f9e35cd0796ae51c17d990429b0b17f4a34f4350c65333b40b12
+      lastVerified: '2026-05-17T10:02:45.277Z'
     markdown:
       path: .aiox-core/core/health-check/reporters/markdown.js
       layer: L1
@@ -11201,18 +12238,19 @@ entities:
       purpose: r.message,
       keywords:
         - markdown
-      usedBy: []
+      usedBy:
+        - health-check-reporters-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:9bc17bd3bc540f60bd3ea102586cd1e04b8b7ae10e8980fad75f185eec29ad51
-      lastVerified: '2026-03-11T00:48:55.895Z'
+      lastVerified: '2026-05-17T10:02:45.277Z'
     g1-epic-creation:
       path: .aiox-core/core/ids/gates/g1-epic-creation.js
       layer: L1
@@ -11222,17 +12260,18 @@ entities:
         - g1
         - epic
         - creation
-      usedBy: []
+      usedBy:
+        - ids-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:ba7c342b176f38f2c80cb141fe820b9a963a1966e33fef3a4ec568363b011c5f
-      lastVerified: '2026-03-11T00:48:55.895Z'
+      lastVerified: '2026-05-17T10:02:45.277Z'
     g2-story-creation:
       path: .aiox-core/core/ids/gates/g2-story-creation.js
       layer: L1
@@ -11242,17 +12281,18 @@ entities:
         - g2
         - story
         - creation
-      usedBy: []
+      usedBy:
+        - ids-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:cb6312358a3d1c92a0094d25861e0747d0c1d63ffb08c82d8ed0a115a73ca1c5
-      lastVerified: '2026-03-11T00:48:55.895Z'
+      lastVerified: '2026-05-17T10:02:45.277Z'
     g3-story-validation:
       path: .aiox-core/core/ids/gates/g3-story-validation.js
       layer: L1
@@ -11262,17 +12302,18 @@ entities:
         - g3
         - story
         - validation
-      usedBy: []
+      usedBy:
+        - ids-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:7b24912d9e80c5ca52d11950b133df6782b1c0c0914127ccef0dc8384026b4ae
-      lastVerified: '2026-03-11T00:48:55.895Z'
+      lastVerified: '2026-05-17T10:02:45.278Z'
     g4-dev-context:
       path: .aiox-core/core/ids/gates/g4-dev-context.js
       layer: L1
@@ -11282,17 +12323,39 @@ entities:
         - g4
         - dev
         - context
-      usedBy: []
+      usedBy:
+        - ids-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:a0fdd59eb0c3a8a59862397b1af5af84971ce051929ae9d32361b7ca99a444fb
-      lastVerified: '2026-03-11T00:48:55.895Z'
+      lastVerified: '2026-05-17T10:02:45.278Z'
+    g5-semantic-handshake:
+      path: .aiox-core/core/ids/gates/g5-semantic-handshake.js
+      layer: L1
+      type: module
+      purpose: Preserve intent integrity between planning and implementation by
+      keywords:
+        - g5
+        - semantic
+        - handshake
+      usedBy:
+        - ids-index
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:a008c60a4afc98f03dc41219989f7306884254d802b0958282a29462c9fd0f72
+      lastVerified: '2026-05-17T10:02:45.278Z'
     active-modules.verify:
       path: .aiox-core/core/memory/__tests__/active-modules.verify.js
       layer: L1
@@ -11314,7 +12377,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:895ec75f6a303edf4cffa0ab7adbb8a4876f62626cc0d7178420efd5758f21a9
-      lastVerified: '2026-03-11T00:48:55.895Z'
+      lastVerified: '2026-05-17T10:02:45.280Z'
     epic-3-executor:
       path: .aiox-core/core/orchestration/executors/epic-3-executor.js
       layer: L1
@@ -11323,18 +12386,19 @@ entities:
       keywords:
         - epic
         - executor
-      usedBy: []
+      usedBy:
+        - orchestration-executors-index
       dependencies:
         - epic-executor
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:1cadb0544660cead45f940839a0bec51f6a8ef143b7ab1dc006b89c4abb0c1c0
-      lastVerified: '2026-03-11T00:48:55.895Z'
+      lastVerified: '2026-05-17T10:02:45.280Z'
     epic-4-executor:
       path: .aiox-core/core/orchestration/executors/epic-4-executor.js
       layer: L1
@@ -11346,20 +12410,21 @@ entities:
         - 'generated:'
         - ${new
         - date().toisostring()}
-      usedBy: []
+      usedBy:
+        - orchestration-executors-index
       dependencies:
         - epic-executor
         - plan-tracker
         - subtask-verifier
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:b2f8944114839f9b02a0b46d037fa64e2d1584d3aab6ff74537e32a16b6a793d
-      lastVerified: '2026-03-11T00:48:55.895Z'
+      lastVerified: '2026-05-17T10:02:45.280Z'
     epic-5-executor:
       path: .aiox-core/core/orchestration/executors/epic-5-executor.js
       layer: L1
@@ -11368,20 +12433,21 @@ entities:
       keywords:
         - epic
         - executor
-      usedBy: []
+      usedBy:
+        - orchestration-executors-index
       dependencies:
         - epic-executor
         - stuck-detector
         - rollback-manager
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:d334dc728dec74fdb744f14d83f9fd2b7dabc46bcaa0d2dfae482cc131e0107b
-      lastVerified: '2026-03-11T00:48:55.895Z'
+      lastVerified: '2026-05-17T10:02:45.280Z'
     epic-6-executor:
       path: .aiox-core/core/orchestration/executors/epic-6-executor.js
       layer: L1
@@ -11390,19 +12456,20 @@ entities:
       keywords:
         - epic
         - executor
-      usedBy: []
+      usedBy:
+        - orchestration-executors-index
       dependencies:
         - epic-executor
         - qa-loop-orchestrator
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:1bbc14e8236f87c074db46833345a724ee5056a28b97fbb2528d4eedd350ab12
-      lastVerified: '2026-03-11T00:48:55.896Z'
+      lastVerified: '2026-05-17T10:02:45.280Z'
     epic-executor:
       path: .aiox-core/core/orchestration/executors/epic-executor.js
       layer: L1
@@ -11416,6 +12483,7 @@ entities:
         - epic-4-executor
         - epic-5-executor
         - epic-6-executor
+        - orchestration-executors-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -11425,7 +12493,31 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f2b20cd8cc4f3473bfcc7afdc0bc20e21665bab92274433ede58eabc4691a6b9
-      lastVerified: '2026-03-11T00:48:55.896Z'
+      lastVerified: '2026-05-17T10:02:45.280Z'
+    orchestration-executors-index:
+      path: .aiox-core/core/orchestration/executors/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/orchestration/executors/index.js
+      keywords:
+        - index
+      usedBy:
+        - master-orchestrator
+      dependencies:
+        - epic-executor
+        - epic-3-executor
+        - epic-4-executor
+        - epic-5-executor
+        - epic-6-executor
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:21f66b6d59c67079bfd6f30dcb675bab60d8a3b6283c24246497d641beed1f57
+      lastVerified: '2026-05-17T10:02:45.281Z'
     permission-mode.test:
       path: .aiox-core/core/permissions/__tests__/permission-mode.test.js
       layer: L1
@@ -11447,7 +12539,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8c8a48c75933a7bf3cf4588f8e4af3911cbb6b67fb07fa526a79bada8949ce2c
-      lastVerified: '2026-03-11T00:48:55.896Z'
+      lastVerified: '2026-05-17T10:02:45.281Z'
     context-builder:
       path: .aiox-core/core/synapse/context/context-builder.js
       layer: L1
@@ -11458,17 +12550,16 @@ entities:
         - builder
       usedBy:
         - synapse-engine
-        - synapse-context-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: orphan
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:121cd0a1df8a44098831cd4335536e8facf4e65b8aec48f4ce9c2d432dc6252a
-      lastVerified: '2026-03-11T00:48:55.897Z'
+      lastVerified: '2026-05-17T10:02:45.281Z'
     context-tracker:
       path: .aiox-core/core/synapse/context/context-tracker.js
       layer: L1
@@ -11478,9 +12569,8 @@ entities:
         - context
         - tracker
       usedBy:
-        - pipeline-collector
         - synapse-engine
-        - synapse-context-index
+        - pipeline-collector
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -11489,8 +12579,67 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:48e94db7b1778dedecc8eae829139579ad7778ff47668597ebe766610696553f
-      lastVerified: '2026-03-11T00:48:55.897Z'
+      checksum: sha256:5a54a15fbbbd4b6095e7e78297cb87e4a123a7c1d714a7c7916272ef6fd680f1
+      lastVerified: '2026-05-17T10:02:45.281Z'
+    hierarchical-context-manager:
+      path: .aiox-core/core/synapse/context/hierarchical-context-manager.js
+      layer: L1
+      type: module
+      purpose: this._longTermSummaries.map(message => message.content).join('\n\n'),
+      keywords:
+        - hierarchical
+        - context
+        - manager
+      usedBy: []
+      dependencies:
+        - tokens
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: experimental
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:34f5b9e64c46880138ad684d64e7006f63c16211a219afa81a2c1b6236748af5
+      lastVerified: '2026-05-17T10:02:45.282Z'
+    synapse-context-index:
+      path: .aiox-core/core/synapse/context/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/synapse/context/index.js
+      keywords:
+        - index
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:6475a5730451d8754cc6c7ab4c1ef4decca98e093c69045661eae17da5897e07
+      lastVerified: '2026-05-17T10:02:45.282Z'
+    semantic-handshake-engine:
+      path: .aiox-core/core/synapse/context/semantic-handshake-engine.js
+      layer: L1
+      type: module
+      purpose: '''Must use PostgreSQL adapter, not SQLite or another local database.'','
+      keywords:
+        - semantic
+        - handshake
+        - engine
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:be5f2f7300902a2916f6758b46636b96f083c11e1b831f5835bf97859a4b80a6
+      lastVerified: '2026-05-17T10:02:45.282Z'
     report-formatter:
       path: .aiox-core/core/synapse/diagnostics/report-formatter.js
       layer: L1
@@ -11510,7 +12659,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e6d26c1cd9910d8311306111cc3fef3a4bb1c4bd6b1ef0e4bb8f407da9baf7f1
-      lastVerified: '2026-03-11T00:48:55.897Z'
+      lastVerified: '2026-05-17T10:02:45.282Z'
     synapse-diagnostics:
       path: .aiox-core/core/synapse/diagnostics/synapse-diagnostics.js
       layer: L1
@@ -11536,7 +12685,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de9dffce0e380637027cbd64b062d3eeffc37e42a84a337e5758fbef39fe3a00
-      lastVerified: '2026-03-11T00:48:55.897Z'
+      lastVerified: '2026-05-17T10:02:45.286Z'
     domain-loader:
       path: .aiox-core/core/synapse/domain/domain-loader.js
       layer: L1
@@ -11564,7 +12713,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:af788f9da956b89eef1e5eb4ef4efdf05ca758c8969a2c375f568119495ebc05
-      lastVerified: '2026-03-11T00:48:55.897Z'
+      lastVerified: '2026-05-17T10:02:45.287Z'
     l0-constitution:
       path: .aiox-core/core/synapse/layers/l0-constitution.js
       layer: L1
@@ -11585,7 +12734,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2123a6a44915aaac2a6bbd26c67c285c9d1e12b50fe42a8ada668306b07d1c4a
-      lastVerified: '2026-03-11T00:48:55.897Z'
+      lastVerified: '2026-05-17T10:02:45.287Z'
     l1-global:
       path: .aiox-core/core/synapse/layers/l1-global.js
       layer: L1
@@ -11606,7 +12755,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:21f6969e6d64e9a85c876be6799db4ca7d090f0009057f4a06ead8da12392d45
-      lastVerified: '2026-03-11T00:48:55.897Z'
+      lastVerified: '2026-05-17T10:02:45.287Z'
     l2-agent:
       path: .aiox-core/core/synapse/layers/l2-agent.js
       layer: L1
@@ -11627,7 +12776,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a8677dc58ae7927c5292a4b52883bbc905c8112573b8b8631f0b8bc01ea2b6e6
-      lastVerified: '2026-03-11T00:48:55.897Z'
+      lastVerified: '2026-05-17T10:02:45.287Z'
     l3-workflow:
       path: .aiox-core/core/synapse/layers/l3-workflow.js
       layer: L1
@@ -11648,7 +12797,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:496cbd71d7dac9c1daa534ffac45c622d0c032f334fedf493e9322a565b2b181
-      lastVerified: '2026-03-11T00:48:55.897Z'
+      lastVerified: '2026-05-17T10:02:45.288Z'
     l4-task:
       path: .aiox-core/core/synapse/layers/l4-task.js
       layer: L1
@@ -11668,7 +12817,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:30df70c04b16e3aff95899211ef6ae3d9f0a8097ebdc7de92599fc6cb792e5f0
-      lastVerified: '2026-03-11T00:48:55.897Z'
+      lastVerified: '2026-05-17T10:02:45.288Z'
     l5-squad:
       path: .aiox-core/core/synapse/layers/l5-squad.js
       layer: L1
@@ -11689,7 +12838,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fabc2bcb01543ef7d249631da02297d67e42f4d0fcf9e159b79564793ce8f7bb
-      lastVerified: '2026-03-11T00:48:55.897Z'
+      lastVerified: '2026-05-17T10:02:45.288Z'
     l6-keyword:
       path: .aiox-core/core/synapse/layers/l6-keyword.js
       layer: L1
@@ -11710,7 +12859,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8e5405999a2ce2f3ca4e62e863cf702ba27448914241f5eb8f02760bc7477523
-      lastVerified: '2026-03-11T00:48:55.898Z'
+      lastVerified: '2026-05-17T10:02:45.288Z'
     l7-star-command:
       path: .aiox-core/core/synapse/layers/l7-star-command.js
       layer: L1
@@ -11732,7 +12881,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3b8372ac1c51830c1ef560b1012b112a3559651b0750e42f2037f7fe9e6787d6
-      lastVerified: '2026-03-11T00:48:55.898Z'
+      lastVerified: '2026-05-17T10:02:45.288Z'
     layer-processor:
       path: .aiox-core/core/synapse/layers/layer-processor.js
       layer: L1
@@ -11758,8 +12907,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:73cb0e5b4bada80d8e256009004679e483792077fac4358c6466cd77136f79fa
-      lastVerified: '2026-03-11T00:48:55.898Z'
+      checksum: sha256:9cdb5efb2e95780373dd0ce8dcb64791dd1471128fc6914d274c6744036842a3
+      lastVerified: '2026-05-17T10:02:45.288Z'
     memory-bridge:
       path: .aiox-core/core/synapse/memory/memory-bridge.js
       layer: L1
@@ -11775,13 +12924,13 @@ entities:
         - synapse-memory-provider
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:820875f97ceea80fc6402c0dab1706cfe58de527897b22dea68db40b0d6ec368
-      lastVerified: '2026-03-11T00:48:55.898Z'
+      lastVerified: '2026-05-17T10:02:45.288Z'
     synapse-memory-provider:
       path: .aiox-core/core/synapse/memory/synapse-memory-provider.js
       layer: L1
@@ -11804,7 +12953,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5d613d1fac7ee82c49a3f03b38735fd3cabfe87dd868494672ddfef300ea3145
-      lastVerified: '2026-03-11T00:48:55.899Z'
+      lastVerified: '2026-05-17T10:02:45.288Z'
     formatter:
       path: .aiox-core/core/synapse/output/formatter.js
       layer: L1
@@ -11818,13 +12967,32 @@ entities:
         - tokens
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:fe4f6c2f6091defb6af66dad71db0640f919b983111087f8cc5821e3d44ca864
-      lastVerified: '2026-03-11T00:48:55.899Z'
+      lastVerified: '2026-05-17T10:02:45.289Z'
+    synapse-runtime-hook-runtime:
+      path: .aiox-core/core/synapse/runtime/hook-runtime.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/synapse/runtime/hook-runtime.js
+      keywords:
+        - hook
+        - runtime
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:c8a31f8cfcc760de06c65abd3c5d23d9ffd8490f7f0ae4a674efaba73e10dd44
+      lastVerified: '2026-05-17T10:02:45.289Z'
     generate-constitution:
       path: .aiox-core/core/synapse/scripts/generate-constitution.js
       layer: L1
@@ -11843,7 +13011,27 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9010d6b34667c96602b76baa1857f0629c797d911b7c42dc11414b007e5e2b91
-      lastVerified: '2026-03-11T00:48:55.899Z'
+      lastVerified: '2026-05-17T10:02:45.289Z'
+    synapse-session-session-manager:
+      path: .aiox-core/core/synapse/session/session-manager.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/synapse/session/session-manager.js
+      keywords:
+        - session
+        - manager
+      usedBy: []
+      dependencies:
+        - atomic-write
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: experimental
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:98e8c8fa15b074b6102bcd51c6f91f101743338e8cde6de9c31d6b6eea5d6580
+      lastVerified: '2026-05-17T10:02:45.289Z'
     atomic-write:
       path: .aiox-core/core/synapse/utils/atomic-write.js
       layer: L1
@@ -11855,6 +13043,7 @@ entities:
       usedBy:
         - unified-activation-pipeline
         - context-detector
+        - synapse-session-session-manager
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -11864,7 +13053,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:efeef0fbcebb184df5b79f4ba4b4b7fe274c3ba7d1c705ce1af92628e920bd8b
-      lastVerified: '2026-03-11T00:48:55.899Z'
+      lastVerified: '2026-05-17T10:02:45.289Z'
     paths:
       path: .aiox-core/core/synapse/utils/paths.js
       layer: L1
@@ -11882,7 +13071,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bf8cf93c1a16295e7de055bee292e2778a152b6e7d6c648dbc054a4b04dffc10
-      lastVerified: '2026-03-11T00:48:55.899Z'
+      lastVerified: '2026-05-17T10:02:45.290Z'
     tokens:
       path: .aiox-core/core/synapse/utils/tokens.js
       layer: L1
@@ -11891,10 +13080,10 @@ entities:
       keywords:
         - tokens
       usedBy:
+        - hierarchical-context-manager
         - memory-bridge
         - synapse-memory-provider
         - formatter
-        - hierarchical-context-manager
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -11904,7 +13093,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3b927daec51d0a791f3fe4ef9aafc362773450e7cf50eb4b6d8ae9011d70df9a
-      lastVerified: '2026-03-11T00:48:55.899Z'
+      lastVerified: '2026-05-17T10:02:45.290Z'
     build-config:
       path: .aiox-core/core/health-check/checks/deployment/build-config.js
       layer: L1
@@ -11913,18 +13102,19 @@ entities:
       keywords:
         - build
         - config
-      usedBy: []
+      usedBy:
+        - health-check-checks-deployment-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:2be009177bf26ca7e1ac2f1f6bc973e409ba1feac83906c96cab0b70e60c1af7
-      lastVerified: '2026-03-11T00:48:55.900Z'
+      lastVerified: '2026-05-17T10:02:45.290Z'
     ci-config:
       path: .aiox-core/core/health-check/checks/deployment/ci-config.js
       layer: L1
@@ -11933,18 +13123,19 @@ entities:
       keywords:
         - ci
         - config
-      usedBy: []
+      usedBy:
+        - health-check-checks-deployment-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:ad8399d53c01cb989cc17e60a3547aec2a0c31ba62d2664ef47482ccd0c6b144
-      lastVerified: '2026-03-11T00:48:55.900Z'
+      lastVerified: '2026-05-17T10:02:45.290Z'
     deployment-readiness:
       path: .aiox-core/core/health-check/checks/deployment/deployment-readiness.js
       layer: L1
@@ -11953,18 +13144,19 @@ entities:
       keywords:
         - deployment
         - readiness
-      usedBy: []
+      usedBy:
+        - health-check-checks-deployment-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:7c4706e829968ddae47f9f372140c36fd96e3148eec5dade3e1d5b7c3b276d38
-      lastVerified: '2026-03-11T00:48:55.900Z'
+      lastVerified: '2026-05-17T10:02:45.290Z'
     docker-config:
       path: .aiox-core/core/health-check/checks/deployment/docker-config.js
       layer: L1
@@ -11973,18 +13165,19 @@ entities:
       keywords:
         - docker
         - config
-      usedBy: []
+      usedBy:
+        - health-check-checks-deployment-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:a4558144220078fcc203ae662756df4f0715ffe56d94853996f01a7100a8b11a
-      lastVerified: '2026-03-11T00:48:55.900Z'
+      lastVerified: '2026-05-17T10:02:45.290Z'
     env-file:
       path: .aiox-core/core/health-check/checks/deployment/env-file.js
       layer: L1
@@ -11993,18 +13186,44 @@ entities:
       keywords:
         - env
         - file
-      usedBy: []
+      usedBy:
+        - health-check-checks-deployment-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:2864d9210c0fcf58ac11016077ac24c23edd1dbb570ace46c1762de5f0d4ebae
-      lastVerified: '2026-03-11T00:48:55.900Z'
+      lastVerified: '2026-05-17T10:02:45.291Z'
+    health-check-checks-deployment-index:
+      path: .aiox-core/core/health-check/checks/deployment/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/health-check/checks/deployment/index.js
+      keywords:
+        - index
+      usedBy:
+        - check-registry
+        - health-check-checks-index
+      dependencies:
+        - env-file
+        - build-config
+        - ci-config
+        - docker-config
+        - deployment-readiness
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:ac2b152a971650ecac4c84d92a7769b0aa6ec761c06b11e420bd62f0b8066eef
+      lastVerified: '2026-05-17T10:02:45.291Z'
     disk-space:
       path: .aiox-core/core/health-check/checks/local/disk-space.js
       layer: L1
@@ -12013,18 +13232,19 @@ entities:
       keywords:
         - disk
         - space
-      usedBy: []
+      usedBy:
+        - health-check-checks-local-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:fa400f15c9bc1a61233472639bb44b6a5f4785fbe10690f8254e54edffb7dead
-      lastVerified: '2026-03-11T00:48:55.900Z'
+      lastVerified: '2026-05-17T10:02:45.291Z'
     environment-vars:
       path: .aiox-core/core/health-check/checks/local/environment-vars.js
       layer: L1
@@ -12033,18 +13253,19 @@ entities:
       keywords:
         - environment
         - vars
-      usedBy: []
+      usedBy:
+        - health-check-checks-local-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:4da9aefdf717e267d5a0e60408b866f49ca5f49cde0e6b1fb14050046a9458d0
-      lastVerified: '2026-03-11T00:48:55.900Z'
+      lastVerified: '2026-05-17T10:02:45.292Z'
     git-install:
       path: .aiox-core/core/health-check/checks/local/git-install.js
       layer: L1
@@ -12053,18 +13274,19 @@ entities:
       keywords:
         - git
         - install
-      usedBy: []
+      usedBy:
+        - health-check-checks-local-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:f17dd15a5696de04b6530f6eb99d1c29d2a19486c7220be42f87712cb0858df2
-      lastVerified: '2026-03-11T00:48:55.900Z'
+      lastVerified: '2026-05-17T10:02:45.292Z'
     ide-detection:
       path: .aiox-core/core/health-check/checks/local/ide-detection.js
       layer: L1
@@ -12073,18 +13295,47 @@ entities:
       keywords:
         - ide
         - detection
-      usedBy: []
+      usedBy:
+        - health-check-checks-local-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:632ccbc44b3cd4306ba2391e6cea8e91e20ccedd62bb421f46ca33cd7daa7230
-      lastVerified: '2026-03-11T00:48:55.900Z'
+      lastVerified: '2026-05-17T10:02:45.292Z'
+    health-check-checks-local-index:
+      path: .aiox-core/core/health-check/checks/local/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/health-check/checks/local/index.js
+      keywords:
+        - index
+      usedBy:
+        - check-registry
+        - health-check-checks-index
+      dependencies:
+        - environment-vars
+        - git-install
+        - npm-install
+        - ide-detection
+        - shell-environment
+        - disk-space
+        - memory
+        - network
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:9f98eecb00f844f22448489f993f84c045847e3ef579c8bcf7f15a7bd56b167b
+      lastVerified: '2026-05-17T10:02:45.293Z'
     memory:
       path: .aiox-core/core/health-check/checks/local/memory.js
       layer: L1
@@ -12093,6 +13344,7 @@ entities:
       keywords:
         - memory
       usedBy:
+        - health-check-checks-local-index
         - component-metadata
       dependencies:
         - base-check
@@ -12104,7 +13356,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e959adc1f7f41ab5054bb8786967722d0364700b8e5139f94f5181a0d3dfc819
-      lastVerified: '2026-03-11T00:48:55.900Z'
+      lastVerified: '2026-05-17T10:02:45.293Z'
     network:
       path: .aiox-core/core/health-check/checks/local/network.js
       layer: L1
@@ -12112,18 +13364,19 @@ entities:
       purpose: '''Verifies network connectivity for development tools'','
       keywords:
         - network
-      usedBy: []
+      usedBy:
+        - health-check-checks-local-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:77915bfd3f27b8f02c3eb8bb4d8c37f1e34541766633dde3b0d509b223435c98
-      lastVerified: '2026-03-11T00:48:55.900Z'
+      lastVerified: '2026-05-17T10:02:45.293Z'
     npm-install:
       path: .aiox-core/core/health-check/checks/local/npm-install.js
       layer: L1
@@ -12132,18 +13385,19 @@ entities:
       keywords:
         - npm
         - install
-      usedBy: []
+      usedBy:
+        - health-check-checks-local-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:592a7ed7468d4f5dc28c5261a363035545b84d4b32c2601bd52075e02f0cbdc2
-      lastVerified: '2026-03-11T00:48:55.900Z'
+      lastVerified: '2026-05-17T10:02:45.293Z'
     shell-environment:
       path: .aiox-core/core/health-check/checks/local/shell-environment.js
       layer: L1
@@ -12152,18 +13406,19 @@ entities:
       keywords:
         - shell
         - environment
-      usedBy: []
+      usedBy:
+        - health-check-checks-local-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:6c98b9d4f3636d8c229c8031ed5126fc0fe35b6b740af320e21e05aaf1b5c402
-      lastVerified: '2026-03-11T00:48:55.900Z'
+      lastVerified: '2026-05-17T10:02:45.293Z'
     agent-config:
       path: .aiox-core/core/health-check/checks/project/agent-config.js
       layer: L1
@@ -12172,18 +13427,19 @@ entities:
       keywords:
         - agent
         - config
-      usedBy: []
+      usedBy:
+        - health-check-checks-project-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:0195e2b95c94fcea2c7fae5636664e24657e182a0b3d8e95ce4ccf7b15809de2
-      lastVerified: '2026-03-11T00:48:55.900Z'
+      lastVerified: '2026-05-17T10:02:45.294Z'
     aiox-directory:
       path: .aiox-core/core/health-check/checks/project/aiox-directory.js
       layer: L1
@@ -12192,18 +13448,19 @@ entities:
       keywords:
         - aiox
         - directory
-      usedBy: []
+      usedBy:
+        - health-check-checks-project-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:332d298d2ac7eb89ca6f3471f3a0970175f80c9a8735582af2ad5eb3331a8523
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.294Z'
     dependencies:
       path: .aiox-core/core/health-check/checks/project/dependencies.js
       layer: L1
@@ -12211,18 +13468,19 @@ entities:
       purpose: '''Verifies required dependencies are installed'','
       keywords:
         - dependencies
-      usedBy: []
+      usedBy:
+        - health-check-checks-project-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:70feccca72c7eacd5740ec9b194a80d24f997f5300487633eba9a272cbf749df
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.294Z'
     framework-config:
       path: .aiox-core/core/health-check/checks/project/framework-config.js
       layer: L1
@@ -12231,6 +13489,55 @@ entities:
       keywords:
         - framework
         - config
+      usedBy:
+        - health-check-checks-project-index
+      dependencies:
+        - base-check
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:6ca4088a1b5399d47bc6bd04a4867b807b7003e7a91e35ddafcfcc3996f171fc
+      lastVerified: '2026-05-17T10:02:45.294Z'
+    health-check-checks-project-index:
+      path: .aiox-core/core/health-check/checks/project/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/health-check/checks/project/index.js
+      keywords:
+        - index
+      usedBy:
+        - check-registry
+        - health-check-checks-index
+      dependencies:
+        - package-json
+        - dependencies
+        - framework-config
+        - node-version
+        - aiox-directory
+        - agent-config
+        - task-definitions
+        - workflow-dependencies
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:69a081967556f8325572c25615f19e30abf18d7c0c73a195953587dff34e8dfa
+      lastVerified: '2026-05-17T10:02:45.294Z'
+    health-check-checks-project-node-version:
+      path: .aiox-core/core/health-check/checks/project/node-version.js
+      layer: L1
+      type: module
+      purpose: '''Verifies Node.js version meets minimum requirements'','
+      keywords:
+        - node
+        - version
       usedBy: []
       dependencies:
         - base-check
@@ -12241,8 +13548,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:6ca4088a1b5399d47bc6bd04a4867b807b7003e7a91e35ddafcfcc3996f171fc
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      checksum: sha256:9bcebbd153d89b3f04d58850f48f2c2bcd9648286db656832197b429b7fc3391
+      lastVerified: '2026-05-17T10:02:45.294Z'
     package-json:
       path: .aiox-core/core/health-check/checks/project/package-json.js
       layer: L1
@@ -12251,18 +13558,19 @@ entities:
       keywords:
         - package
         - json
-      usedBy: []
+      usedBy:
+        - health-check-checks-project-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:ba15da8cc0aaec18e7320db8c4942e04d3c159beb8605fa58a5939d6b77debe3
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.294Z'
     task-definitions:
       path: .aiox-core/core/health-check/checks/project/task-definitions.js
       layer: L1
@@ -12271,18 +13579,19 @@ entities:
       keywords:
         - task
         - definitions
-      usedBy: []
+      usedBy:
+        - health-check-checks-project-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:87c6edf9210856e065cd8c491a14b8a016aad429dbae7b0f814ac8b9b3989770
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.295Z'
     workflow-dependencies:
       path: .aiox-core/core/health-check/checks/project/workflow-dependencies.js
       layer: L1
@@ -12291,18 +13600,19 @@ entities:
       keywords:
         - workflow
         - dependencies
-      usedBy: []
+      usedBy:
+        - health-check-checks-project-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:0eb04100b5c5a56b44b09ab7ca03426e01513c4eb109cc989603484329bc49d9
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.295Z'
     branch-protection:
       path: .aiox-core/core/health-check/checks/repository/branch-protection.js
       layer: L1
@@ -12311,18 +13621,19 @@ entities:
       keywords:
         - branch
         - protection
-      usedBy: []
+      usedBy:
+        - health-check-checks-repository-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:4ee18e46c088005e2f39399dbd80a4fc3e8251baf1c9cbff698d7a941af8416f
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.295Z'
     commit-history:
       path: .aiox-core/core/health-check/checks/repository/commit-history.js
       layer: L1
@@ -12331,18 +13642,19 @@ entities:
       keywords:
         - commit
         - history
-      usedBy: []
+      usedBy:
+        - health-check-checks-repository-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:ae9d221803f518b0167d71a1c9c2ea5f2392c83d6279e87fbfb3dea95f5845ba
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.295Z'
     conflicts:
       path: .aiox-core/core/health-check/checks/repository/conflicts.js
       layer: L1
@@ -12350,18 +13662,19 @@ entities:
       purpose: '''Checks for unresolved merge conflicts'','
       keywords:
         - conflicts
-      usedBy: []
+      usedBy:
+        - health-check-checks-repository-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:6e9eb41c2a560a8cdc9154475be65ab1a110017d28c15a991af9dca5ebf9515e
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.295Z'
     git-repo:
       path: .aiox-core/core/health-check/checks/repository/git-repo.js
       layer: L1
@@ -12370,18 +13683,19 @@ entities:
       keywords:
         - git
         - repo
-      usedBy: []
+      usedBy:
+        - health-check-checks-repository-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:80e1a09561f744772c40575f3f4c0d3a1847fbdf9825fbf616631c5edc67a833
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.296Z'
     git-status:
       path: .aiox-core/core/health-check/checks/repository/git-status.js
       layer: L1
@@ -12390,18 +13704,19 @@ entities:
       keywords:
         - git
         - status
-      usedBy: []
+      usedBy:
+        - health-check-checks-repository-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:aad6379855e89558b43584e8812f04e6a2f771331bbebee116a451f9f4b177d1
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.296Z'
     gitignore:
       path: .aiox-core/core/health-check/checks/repository/gitignore.js
       layer: L1
@@ -12409,18 +13724,47 @@ entities:
       purpose: '''Verifies .gitignore has required patterns'','
       keywords:
         - gitignore
-      usedBy: []
+      usedBy:
+        - health-check-checks-repository-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:bec3b6a29ed336920a55d21f888ce29a4589a421d8a6695d40954ddd49eb4106
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.296Z'
+    health-check-checks-repository-index:
+      path: .aiox-core/core/health-check/checks/repository/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/health-check/checks/repository/index.js
+      keywords:
+        - index
+      usedBy:
+        - check-registry
+        - health-check-checks-index
+      dependencies:
+        - git-repo
+        - git-status
+        - branch-protection
+        - commit-history
+        - lockfile-integrity
+        - gitignore
+        - conflicts
+        - large-files
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:f34fdabfde45775c0906fffd02ac1bed1ac03fe6deec119883ca681c2daff85c
+      lastVerified: '2026-05-17T10:02:45.296Z'
     large-files:
       path: .aiox-core/core/health-check/checks/repository/large-files.js
       layer: L1
@@ -12429,18 +13773,19 @@ entities:
       keywords:
         - large
         - files
-      usedBy: []
+      usedBy:
+        - health-check-checks-repository-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:8b1405280dd929c3ba5a47cf0a52bc7fd1f7efbc1ba3e8e4fdcbbcd56fe2a76e
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.296Z'
     lockfile-integrity:
       path: .aiox-core/core/health-check/checks/repository/lockfile-integrity.js
       layer: L1
@@ -12449,18 +13794,19 @@ entities:
       keywords:
         - lockfile
         - integrity
-      usedBy: []
+      usedBy:
+        - health-check-checks-repository-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:6b2d42f1d228f64079929c4d6cdeb9f5ed7217bb390ecfe2e00727c6f59527e0
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.297Z'
     api-endpoints:
       path: .aiox-core/core/health-check/checks/services/api-endpoints.js
       layer: L1
@@ -12469,18 +13815,19 @@ entities:
       keywords:
         - api
         - endpoints
-      usedBy: []
+      usedBy:
+        - health-check-checks-services-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:2233d5af1610d5553353e21e720c9cb0ecfbb968ab605d14896705458ae7ca55
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.297Z'
     claude-code:
       path: .aiox-core/core/health-check/checks/services/claude-code.js
       layer: L1
@@ -12500,7 +13847,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:69af55e5ad7e941e5e6d0a9e3aab7a4e6c2aaec491aa5955fd6c23be432b5ab7
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.297Z'
     gemini-cli:
       path: .aiox-core/core/health-check/checks/services/gemini-cli.js
       layer: L1
@@ -12509,18 +13856,19 @@ entities:
       keywords:
         - gemini
         - cli
-      usedBy: []
+      usedBy:
+        - health-check-checks-services-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:1c37af5d3cd598c44bce4d37c9d90b3c72167841882d6ea3563cc55e2bfa147e
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.297Z'
     github-cli:
       path: .aiox-core/core/health-check/checks/services/github-cli.js
       layer: L1
@@ -12540,7 +13888,32 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b94fa0d8917a8506ce80620d390e9344935a700f87bf8034c3c24d12256cd85a
-      lastVerified: '2026-03-11T00:48:55.901Z'
+      lastVerified: '2026-05-17T10:02:45.297Z'
+    health-check-checks-services-index:
+      path: .aiox-core/core/health-check/checks/services/index.js
+      layer: L1
+      type: module
+      purpose: Entity at .aiox-core/core/health-check/checks/services/index.js
+      keywords:
+        - index
+      usedBy:
+        - check-registry
+        - health-check-checks-index
+      dependencies:
+        - mcp-integration
+        - github-cli
+        - claude-code
+        - gemini-cli
+        - api-endpoints
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:979198ad95353636e18153b3f7e7ed1e49e2bf04af653d95b3058b9735332667
+      lastVerified: '2026-05-17T10:02:45.297Z'
     mcp-integration:
       path: .aiox-core/core/health-check/checks/services/mcp-integration.js
       layer: L1
@@ -12549,18 +13922,19 @@ entities:
       keywords:
         - mcp
         - integration
-      usedBy: []
+      usedBy:
+        - health-check-checks-services-index
       dependencies:
         - base-check
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.4
         constraints: []
         extensionPoints: []
       checksum: sha256:139b29b91e4f2d0abf50b08a272a688036132abba8f71adca9b26c3fb8eb671e
-      lastVerified: '2026-03-11T00:48:55.902Z'
+      lastVerified: '2026-05-17T10:02:45.298Z'
     consistency-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/consistency-collector.js
       layer: L1
@@ -12580,7 +13954,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:65f4255f87c9900400649dc8b9aedaac4851b5939d93e127778bd93cee99db12
-      lastVerified: '2026-03-11T00:48:55.902Z'
+      lastVerified: '2026-05-17T10:02:45.298Z'
     hook-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/hook-collector.js
       layer: L1
@@ -12600,7 +13974,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c2cfa1b760bcb05decf5ad05f9159140cbe0cdc6b0f91581790e44d83dc6b660
-      lastVerified: '2026-03-11T00:48:55.902Z'
+      lastVerified: '2026-05-17T10:02:45.298Z'
     manifest-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/manifest-collector.js
       layer: L1
@@ -12621,7 +13995,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3dc895eb94485320ecbaca3a1d29e3776cfb691dd7dcc71cf44b34af30e8ebb6
-      lastVerified: '2026-03-11T00:48:55.902Z'
+      lastVerified: '2026-05-17T10:02:45.299Z'
     output-analyzer:
       path: .aiox-core/core/synapse/diagnostics/collectors/output-analyzer.js
       layer: L1
@@ -12641,7 +14015,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e6846b1aba0a6cba17c297a871861d4f8199d7500220bff296a6a3291e32493e
-      lastVerified: '2026-03-11T00:48:55.902Z'
+      lastVerified: '2026-05-17T10:02:45.299Z'
     pipeline-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/pipeline-collector.js
       layer: L1
@@ -12662,7 +14036,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8655b6240e2f54b70def1a8c2fae00d40e2615cb95fd7ca0d64c2e0a6dfe3b73
-      lastVerified: '2026-03-11T00:48:55.902Z'
+      lastVerified: '2026-05-17T10:02:45.299Z'
     quality-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/quality-collector.js
       layer: L1
@@ -12682,7 +14056,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:30ae299eab6d569d09afe3530a5b2f1ff35ef75366a1ab56a9e2a57d39d3611c
-      lastVerified: '2026-03-11T00:48:55.903Z'
+      lastVerified: '2026-05-17T10:02:45.299Z'
     relevance-matrix:
       path: .aiox-core/core/synapse/diagnostics/collectors/relevance-matrix.js
       layer: L1
@@ -12702,7 +14076,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f92c4f7061dc82eed4310a27b69eade33d3015f9beb1bed688601a2dccbad22e
-      lastVerified: '2026-03-11T00:48:55.903Z'
+      lastVerified: '2026-05-17T10:02:45.300Z'
     safe-read-json:
       path: .aiox-core/core/synapse/diagnostics/collectors/safe-read-json.js
       layer: L1
@@ -12727,7 +14101,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dc7bcd13779207ad67b1c3929b7e1e0ccfa3563f3458c20cad28cb1922e9a74c
-      lastVerified: '2026-03-11T00:48:55.903Z'
+      lastVerified: '2026-05-17T10:02:45.300Z'
     session-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/session-collector.js
       layer: L1
@@ -12747,7 +14121,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a116d884d6947ddc8e5f3def012d93696576c584c4fde1639b8d895924fc09ea
-      lastVerified: '2026-03-11T00:48:55.903Z'
+      lastVerified: '2026-05-17T10:02:45.300Z'
     timing-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/timing-collector.js
       layer: L1
@@ -12767,7 +14141,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2523ce93f863a28f798d992c4f2fab041c91a09413b3186fd290e6035b391587
-      lastVerified: '2026-03-11T00:48:55.903Z'
+      lastVerified: '2026-05-17T10:02:45.300Z'
     uap-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/uap-collector.js
       layer: L1
@@ -12787,252 +14161,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dd025894f8f0d3bd22a147dbc0debef8b83e96f3c59483653404b3cd5a01d5aa
-      lastVerified: '2026-03-11T00:48:55.903Z'
-    pro-updater:
-      path: .aiox-core/core/pro/pro-updater.js
-      layer: L1
-      type: module
-      purpose: Entity at .aiox-core/core/pro/pro-updater.js
-      keywords:
-        - pro
-        - updater
-      usedBy: []
-      dependencies: []
-      adaptability:
-        score: 0.4
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:30ea78b8ab088e695936ae662057697410856751f463eeb649e00b67dcc31531
-      lastVerified: '2026-05-08T21:44:50.553Z'
-      externalDeps: []
-      plannedDeps: []
-      lifecycle: orphan
-    aiox-error:
-      path: .aiox-core/core/errors/aiox-error.js
-      layer: L1
-      type: module
-      purpose: Entity at .aiox-core/core/errors/aiox-error.js
-      keywords:
-        - aiox
-        - error
-      usedBy:
-        - errors-index
-      dependencies:
-        - constants
-        - error-registry
-        - serializer
-        - utils
-      adaptability:
-        score: 0.4
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:6734641df389f921f1d139c129ec007d15b3a08114a15fe9faf792ed1036d0c8
-      lastVerified: '2026-05-08T10:11:41.092Z'
-    constants:
-      path: .aiox-core/core/errors/constants.js
-      layer: L1
-      type: module
-      purpose: Entity at .aiox-core/core/errors/constants.js
-      keywords:
-        - constants
-      usedBy:
-        - aiox-error
-        - error-registry
-        - errors-index
-        - serializer
-      dependencies: []
-      adaptability:
-        score: 0.4
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:9f6fa0b1a9b8538d321674ac43628f42452ce2ac770d0433c1ab84b55b1e56dd
-      lastVerified: '2026-05-08T10:11:41.094Z'
-    error-registry:
-      path: .aiox-core/core/errors/error-registry.js
-      layer: L1
-      type: module
-      purpose: Entity at .aiox-core/core/errors/error-registry.js
-      keywords:
-        - error
-        - registry
-      usedBy:
-        - aiox-error
-        - errors-index
-      dependencies:
-        - constants
-        - utils
-      adaptability:
-        score: 0.4
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:7ba8dffa725860a285618593b8ed47b05c4fa488fdedf1282c2e214881c370bc
-      lastVerified: '2026-05-08T10:11:41.094Z'
-    errors-index:
-      path: .aiox-core/core/errors/index.js
-      layer: L1
-      type: module
-      purpose: Entity at .aiox-core/core/errors/index.js
-      keywords:
-        - index
-      usedBy:
-        - build-state-manager
-        - synapse-engine
-      dependencies:
-        - constants
-        - error-registry
-        - aiox-error
-        - serializer
-        - utils
-      adaptability:
-        score: 0.4
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:462d0aed6f57f2e4b9d51bcb20467451473c927e0d182b5c3ad43f352f44122c
-      lastVerified: '2026-05-08T10:11:41.095Z'
-    serializer:
-      path: .aiox-core/core/errors/serializer.js
-      layer: L1
-      type: module
-      purpose: Entity at .aiox-core/core/errors/serializer.js
-      keywords:
-        - serializer
-      usedBy:
-        - aiox-error
-        - errors-index
-      dependencies:
-        - constants
-        - utils
-      adaptability:
-        score: 0.4
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:7144adaf3a245afd732aef16e2cdb61f08246badb6b90ac1a7f4b73705ff3ce8
-      lastVerified: '2026-05-08T10:11:41.096Z'
-    utils:
-      path: .aiox-core/core/errors/utils.js
-      layer: L1
-      type: module
-      purpose: Entity at .aiox-core/core/errors/utils.js
-      keywords:
-        - utils
-      usedBy:
-        - aiox-error
-        - error-registry
-        - errors-index
-        - serializer
-      dependencies: []
-      adaptability:
-        score: 0.4
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:24b8ff80e98efc2b562843262490b7ac537ee77565715b644f212652192ced62
-      lastVerified: '2026-05-08T10:11:41.096Z'
-    synapse-engine:
-      path: .aiox-core/core/synapse/engine.js
-      layer: L1
-      type: module
-      purpose: Entity at .aiox-core/core/synapse/engine.js
-      keywords:
-        - engine
-      usedBy: []
-      dependencies:
-        - errors-index
-        - context-tracker
-        - context-builder
-        - formatter
-        - memory-bridge
-      adaptability:
-        score: 0.4
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:1b65523b2fec6a44ab380298c4d98f0569209dec8b50be3922479ffcd6548df0
-      lastVerified: '2026-05-08T14:34:39.788Z'
-      externalDeps: []
-      plannedDeps: []
-      lifecycle: experimental
-    hierarchical-context-manager:
-      path: .aiox-core/core/synapse/context/hierarchical-context-manager.js
-      layer: L1
-      type: module
-      purpose: this._longTermSummaries.map(message => message.content).join('\n\n'),
-      keywords:
-        - hierarchical
-        - context
-        - manager
-      usedBy:
-        - synapse-context-index
-      dependencies:
-        - tokens
-      externalDeps: []
-      plannedDeps: []
-      lifecycle: production
-      adaptability:
-        score: 0.4
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:34f5b9e64c46880138ad684d64e7006f63c16211a219afa81a2c1b6236748af5
-      lastVerified: '2026-05-08T19:13:43.506Z'
-    synapse-context-index:
-      path: .aiox-core/core/synapse/context/index.js
-      layer: L1
-      type: module
-      purpose: Exports SYNAPSE context runtime helpers and the hierarchical context manager
-      keywords:
-        - index
-      usedBy: []
-      dependencies:
-        - context-tracker
-        - context-builder
-        - hierarchical-context-manager
-      externalDeps: []
-      plannedDeps: []
-      lifecycle: experimental
-      adaptability:
-        score: 0.4
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:a67e843cf61e823e0c1b73efdb2d67d268a798fc0c25505a199c1da130d4fe36
-      lastVerified: '2026-05-08T19:10:54.503Z'
-    agent-immortality:
-      path: .aiox-core/core/resilience/agent-immortality.js
-      layer: L1
-      type: module
-      purpose: truncate(summary, options.maxLegacyChars ?? DEFAULT_CONFIG.maxLegacyChars),
-      keywords:
-        - agent
-        - immortality
-      usedBy:
-        - resilience-index
-      dependencies: []
-      externalDeps: []
-      plannedDeps: []
-      lifecycle: production
-      adaptability:
-        score: 0.4
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:d1612c672e91a802924c4a61d8beade66d5740487ca0a244950a2c8249a70962
-      lastVerified: '2026-05-09T07:56:57.020Z'
-    resilience-index:
-      path: .aiox-core/core/resilience/index.js
-      layer: L1
-      type: module
-      purpose: Entity at .aiox-core/core/resilience/index.js
-      keywords:
-        - index
-      usedBy:
-        - index
-      dependencies:
-        - agent-immortality
-      externalDeps: []
-      plannedDeps: []
-      lifecycle: production
-      adaptability:
-        score: 0.4
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:5acbb55fbbf25fc052c0ee2eac5f35d30228144e9f426083b89aabc9e54d084f
-      lastVerified: '2026-05-09T07:56:57.021Z'
+      lastVerified: '2026-05-17T10:02:45.300Z'
   agents:
     aiox-master:
       path: .aiox-core/development/agents/aiox-master.md
@@ -13046,6 +14175,7 @@ entities:
       usedBy:
         - environment-bootstrap
         - ids-governor
+        - project-status
         - run-workflow-engine
         - run-workflow
         - sync-registry-intel
@@ -13058,7 +14188,6 @@ entities:
         - create-agent
         - create-deep-research-prompt
         - create-doc
-        - create-next-story
         - create-task
         - create-workflow
         - deprecate-component
@@ -13110,8 +14239,8 @@ entities:
         score: 0.3
         constraints: []
         extensionPoints: []
-      checksum: sha256:17cd10f6c2ac4fcd96d944283f239c760e2829d2de4e68098f618783ec5ae351
-      lastVerified: '2026-03-11T00:48:55.908Z'
+      checksum: sha256:66175a22e6982e5c0f4123f84af8388eb0cfc81124b8e9ec8f44d502c4ca6cf8
+      lastVerified: '2026-05-17T10:02:45.307Z'
     analyst:
       path: .aiox-core/development/agents/analyst.md
       layer: L2
@@ -13163,7 +14292,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:35150d764c6dc74bc02b61a4d613c9278e87ffb209403db23991339fdda4f8e2
-      lastVerified: '2026-03-11T00:48:55.909Z'
+      lastVerified: '2026-05-17T10:02:45.308Z'
     architect:
       path: .aiox-core/development/agents/architect.md
       layer: L2
@@ -13237,7 +14366,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b89e95048df940056570ecb6589f18a9a6114b96ca1b9fde130fb7bdb2ded8f
-      lastVerified: '2026-03-11T00:48:55.910Z'
+      lastVerified: '2026-05-17T10:02:45.309Z'
     data-engineer:
       path: .aiox-core/development/agents/data-engineer.md
       layer: L2
@@ -13303,8 +14432,8 @@ entities:
         score: 0.3
         constraints: []
         extensionPoints: []
-      checksum: sha256:61ca7c661e2634aa45583b21fb3fc34213bae89803d92e1e5f08759a04c230a0
-      lastVerified: '2026-03-11T00:48:55.912Z'
+      checksum: sha256:41c791fbdf43f700f2e78418c8af18197d1135741bc7845d03013f726b125f6f
+      lastVerified: '2026-05-17T10:02:45.311Z'
     dev:
       path: .aiox-core/development/agents/dev.md
       layer: L2
@@ -13325,6 +14454,7 @@ entities:
         - create-next-story
         - create-service
         - create-suite
+        - delegate-to-external-executor
         - dev-backlog-debt
         - dev-develop-story
         - execute-checklist
@@ -13417,7 +14547,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:eaaec824273f02b9ccbe6768d9e9147a5ad0d7faa9483b9730b1f02a71ef2769
-      lastVerified: '2026-03-11T00:48:55.913Z'
+      lastVerified: '2026-05-17T10:02:45.313Z'
     devops:
       path: .aiox-core/development/agents/devops.md
       layer: L2
@@ -13429,6 +14559,14 @@ entities:
         - analyze-project-structure
         - brownfield-create-epic
         - create-worktree
+        - devops-pro-access-grant
+        - devops-pro-activate
+        - devops-pro-check-access
+        - devops-pro-request-reset
+        - devops-pro-resend-verification
+        - devops-pro-reset-password
+        - devops-pro-validate-login
+        - devops-pro-verify-status
         - environment-bootstrap
         - execute-epic-plan
         - github-devops-pre-push-quality-gate
@@ -13467,6 +14605,14 @@ entities:
         - check-docs-links
         - triage-github-issues
         - resolve-github-issue
+        - devops-pro-access-grant
+        - devops-pro-check-access
+        - devops-pro-request-reset
+        - devops-pro-resend-verification
+        - devops-pro-reset-password
+        - devops-pro-validate-login
+        - devops-pro-verify-status
+        - devops-pro-activate
         - create-worktree
         - list-worktrees
         - remove-worktree
@@ -13493,8 +14639,8 @@ entities:
         score: 0.3
         constraints: []
         extensionPoints: []
-      checksum: sha256:a41d02fe38b086211f4c1985b8da5e4624e21767466325032aeb9b4899f8c6b0
-      lastVerified: '2026-03-11T00:48:55.914Z'
+      checksum: sha256:260b04cc608c1ddcd9ed2cf210e5d22f045002a4c0059f8220abcd3dc67a1cd8
+      lastVerified: '2026-05-17T10:02:45.316Z'
     pm:
       path: .aiox-core/development/agents/pm.md
       layer: L2
@@ -13554,7 +14700,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8c81fd9b6df9b98fa3d3654062464498396ddb4eaf0b6dc3a644ae4227982f4b
-      lastVerified: '2026-03-11T00:48:55.915Z'
+      lastVerified: '2026-05-17T10:02:45.317Z'
     po:
       path: .aiox-core/development/agents/po.md
       layer: L2
@@ -13573,11 +14719,13 @@ entities:
         - po-backlog-add
         - po-close-story
         - po-stories-index
+        - project-status
         - qa-backlog-add-followup
         - qa-fix-issues
         - qa-gate
         - release-management
         - story-checkpoint
+        - validate-next-story
         - design-story-tmpl
         - antigravity-rules
         - claude-rules
@@ -13615,8 +14763,8 @@ entities:
         score: 0.3
         constraints: []
         extensionPoints: []
-      checksum: sha256:f9c3ddcdbf602890802327aada808a58486a2de56acb974412c5f860dc8c9c4b
-      lastVerified: '2026-03-11T00:48:55.916Z'
+      checksum: sha256:f0090329fd2c2871d3b46d0b2ea1bb9ff3fe48c589fc25ed3d90cf2032621cfd
+      lastVerified: '2026-05-17T10:02:45.318Z'
     qa:
       path: .aiox-core/development/agents/qa.md
       layer: L2
@@ -13701,8 +14849,8 @@ entities:
         score: 0.3
         constraints: []
         extensionPoints: []
-      checksum: sha256:6dcefe468f9e4c854080a23ec6d91c78aacd54a5f504bf77af03a6f6221753c4
-      lastVerified: '2026-03-11T00:48:55.917Z'
+      checksum: sha256:cf4a8f473067a9d2909072215bce7b13917c779442e6f858681bd8b9f0b0c3c0
+      lastVerified: '2026-05-17T10:02:45.319Z'
     sm:
       path: .aiox-core/development/agents/sm.md
       layer: L2
@@ -13714,6 +14862,7 @@ entities:
         - brownfield-create-story
         - dev-develop-story
         - po-close-story
+        - project-status
         - validate-next-story
         - design-story-tmpl
         - antigravity-rules
@@ -13743,8 +14892,8 @@ entities:
         score: 0.3
         constraints: []
         extensionPoints: []
-      checksum: sha256:0176d251fd2c7b6368f1ad4ca71000085f660b038a71b3b2cf502516119c3661
-      lastVerified: '2026-03-11T00:48:55.918Z'
+      checksum: sha256:b09334044d3ba581f5403d5d15e0d35c25e580634e712f24bb5a1bc73c9d1cf3
+      lastVerified: '2026-05-17T10:02:45.321Z'
     squad-creator:
       path: .aiox-core/development/agents/squad-creator.md
       layer: L2
@@ -13783,7 +14932,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9ae479d628a74fdf8372da4e5a306fdc93235bce8f4957b44ad9adc76643f8e1
-      lastVerified: '2026-03-11T00:48:55.918Z'
+      lastVerified: '2026-05-17T10:02:45.321Z'
     ux-design-expert:
       path: .aiox-core/development/agents/ux-design-expert.md
       layer: L2
@@ -13853,8 +15002,8 @@ entities:
         score: 0.3
         constraints: []
         extensionPoints: []
-      checksum: sha256:5ca4ec06aaf8525668303f8bdef9c5bc868b1f084db905e8b7636c974c2faa94
-      lastVerified: '2026-03-11T00:48:55.919Z'
+      checksum: sha256:b6a552405cf1a1eab76e307a505e8b431bffa30ab9681a16169b1427373b8a99
+      lastVerified: '2026-05-17T10:02:45.323Z'
     MEMORY:
       path: .aiox-core/development/agents/analyst/MEMORY.md
       layer: L3
@@ -13875,7 +15024,196 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b8b52820ba1929ba12403fc437868dd9e8a9c2532abe99296ad05864618693b0
-      lastVerified: '2026-03-11T00:48:55.919Z'
+      lastVerified: '2026-05-17T10:02:45.324Z'
+    architect-MEMORY:
+      path: .aiox-core/development/agents/architect/MEMORY.md
+      layer: L3
+      type: agent
+      purpose: Architect Agent Memory (Aria)
+      keywords:
+        - memory
+        - architect
+        - agent
+        - (aria)
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.3
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:ee99a68876311e0dc67e0b77ff11f8fa2154f0803f27f4aa89db36df50753d3b
+      lastVerified: '2026-05-17T10:02:45.324Z'
+    data-engineer-MEMORY:
+      path: .aiox-core/development/agents/data-engineer/MEMORY.md
+      layer: L3
+      type: agent
+      purpose: Data Engineer Agent Memory (Dara)
+      keywords:
+        - memory
+        - data
+        - engineer
+        - agent
+        - (dara)
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.3
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:20024028651bf2078bf4e58e38aaa84191521ef9b5c11b044eb152a026ec8412
+      lastVerified: '2026-05-17T10:02:45.324Z'
+    dev-MEMORY:
+      path: .aiox-core/development/agents/dev/MEMORY.md
+      layer: L3
+      type: agent
+      purpose: Dev Agent Memory (Dex)
+      keywords:
+        - memory
+        - dev
+        - agent
+        - (dex)
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.3
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:7c6197418798fa00617f63f93ea6e87dbbbc1bebdb1fb92276433cb7990fd7c0
+      lastVerified: '2026-05-17T10:02:45.325Z'
+    devops-MEMORY:
+      path: .aiox-core/development/agents/devops/MEMORY.md
+      layer: L3
+      type: agent
+      purpose: DevOps Agent Memory (Gage)
+      keywords:
+        - memory
+        - devops
+        - agent
+        - (gage)
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.3
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:eb2ee887047c94db3441126cd0198cac44cec779026d7842a3a1c7eba936027f
+      lastVerified: '2026-05-17T10:02:45.327Z'
+    pm-MEMORY:
+      path: .aiox-core/development/agents/pm/MEMORY.md
+      layer: L3
+      type: agent
+      purpose: PM Agent Memory (Morgan)
+      keywords:
+        - memory
+        - agent
+        - (morgan)
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.3
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:6a8a5661a32cdf440a21531004ad64767da700b70ff8483faddfb7bcde937f2b
+      lastVerified: '2026-05-17T10:02:45.327Z'
+    po-MEMORY:
+      path: .aiox-core/development/agents/po/MEMORY.md
+      layer: L3
+      type: agent
+      purpose: PO Agent Memory (Pax)
+      keywords:
+        - memory
+        - agent
+        - (pax)
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.3
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:4295cbf549671ec6a267bef05871d66fffeb6b898ada166ab1663f7d03632354
+      lastVerified: '2026-05-17T10:02:45.327Z'
+    qa-MEMORY:
+      path: .aiox-core/development/agents/qa/MEMORY.md
+      layer: L3
+      type: agent
+      purpose: QA Agent Memory (Quinn)
+      keywords:
+        - memory
+        - agent
+        - (quinn)
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.3
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:eec482f057d09635940e9a46bdd6cbb677af12dc4deed64bf71196d551b93abf
+      lastVerified: '2026-05-17T10:02:45.327Z'
+    sm-MEMORY:
+      path: .aiox-core/development/agents/sm/MEMORY.md
+      layer: L3
+      type: agent
+      purpose: Scrum Master Agent Memory (River)
+      keywords:
+        - memory
+        - scrum
+        - master
+        - agent
+        - (river)
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.3
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:4abaa92d85f4574a79a308f098e9ae719c28f72101e746f2a574ad92e120dcf4
+      lastVerified: '2026-05-17T10:02:45.328Z'
+    ux-MEMORY:
+      path: .aiox-core/development/agents/ux/MEMORY.md
+      layer: L3
+      type: agent
+      purpose: UX Design Expert Agent Memory (Uma)
+      keywords:
+        - memory
+        - design
+        - expert
+        - agent
+        - (uma)
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.3
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:39e36c9af4aa959fb547152bed812954c33a4c6c8d1a5aababd49052f229fde6
+      lastVerified: '2026-05-17T10:02:45.328Z'
   checklists:
     agent-quality-gate:
       path: .aiox-core/development/checklists/agent-quality-gate.md
@@ -13897,7 +15235,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:46395b5c10794ca98321e4baaaaa1737485bec3f6bc3a616cf948478c0a1c644
-      lastVerified: '2026-03-11T00:48:55.920Z'
+      lastVerified: '2026-05-17T10:02:45.329Z'
     brownfield-compatibility-checklist:
       path: .aiox-core/development/checklists/brownfield-compatibility-checklist.md
       layer: L2
@@ -13919,7 +15257,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c5ff5d7cd45395e8766bf5c941ece8b0d5557758ecead7bef3ac3e08abee899
-      lastVerified: '2026-03-11T00:48:55.920Z'
+      lastVerified: '2026-05-17T10:02:45.329Z'
     issue-triage-checklist:
       path: .aiox-core/development/checklists/issue-triage-checklist.md
       layer: L2
@@ -13939,7 +15277,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c6dbaae38c0e3030dbffebcbcf95e5e766e0294a7a678531531cbd7ad6e54e2b
-      lastVerified: '2026-03-11T00:48:55.920Z'
+      lastVerified: '2026-05-17T10:02:45.329Z'
     memory-audit-checklist:
       path: .aiox-core/development/checklists/memory-audit-checklist.md
       layer: L2
@@ -13961,7 +15299,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bb3ca4ea56d0294a7acc1e9f5bd690ee70c676c28950b8a7c3c25bef8e428f7e
-      lastVerified: '2026-03-11T00:48:55.920Z'
+      lastVerified: '2026-05-17T10:02:45.329Z'
     self-critique-checklist:
       path: .aiox-core/development/checklists/self-critique-checklist.md
       layer: L2
@@ -13984,7 +15322,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:158f21a6be7a7cbc90de0302678490887c2f88b1d79d925f77a8a2209d2ae003
-      lastVerified: '2026-03-11T00:48:55.920Z'
+      lastVerified: '2026-05-17T10:02:45.329Z'
   data:
     agent-config-requirements:
       path: .aiox-core/data/agent-config-requirements.yaml
@@ -14005,7 +15343,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:68e87b5777d1872c4fed6644dd3c7e3c3e8fd590df7d2b58c36d541cf8e38dd3
-      lastVerified: '2026-03-11T00:48:55.921Z'
+      lastVerified: '2026-05-17T10:02:45.331Z'
     aiox-kb:
       path: .aiox-core/data/aiox-kb.md
       layer: L3
@@ -14025,8 +15363,8 @@ entities:
         score: 0.5
         constraints: []
         extensionPoints: []
-      checksum: sha256:72c569d40b3c79a6235d571d901b87972dd72253b885b03b95b254f2dea05832
-      lastVerified: '2026-03-11T00:48:55.921Z'
+      checksum: sha256:958065f2d734189edf2868aae322114b16546502e213b9a948547af4e8c178f9
+      lastVerified: '2026-05-17T10:02:45.331Z'
     entity-registry:
       path: .aiox-core/data/entity-registry.yaml
       layer: L3
@@ -14035,18 +15373,19 @@ entities:
       keywords:
         - entity
         - registry
-      usedBy: []
+      usedBy:
+        - doctor-checks-index
       dependencies:
         - analyst
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.5
         constraints: []
         extensionPoints: []
-      checksum: sha256:3007a2fe2f6d6d95e9d65c3ab1ff91dbd45ce8a493217bf0040de851ed63c8d0
-      lastVerified: '2026-03-11T00:48:55.923Z'
+      checksum: sha256:84acf809f112cb726710a9878904db6b9d5c0eb487a2e578de25ede0c2177c5e
+      lastVerified: '2026-05-17T10:02:45.334Z'
     learned-patterns:
       path: .aiox-core/data/learned-patterns.yaml
       layer: L3
@@ -14065,7 +15404,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
-      lastVerified: '2026-03-11T00:48:55.923Z'
+      lastVerified: '2026-05-17T10:02:45.334Z'
     mcp-tool-examples:
       path: .aiox-core/data/mcp-tool-examples.yaml
       layer: L3
@@ -14086,7 +15425,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8a38e4171d7434d79f83032d9c37f2f604d9411dbec6c3c0334d6661481745fd
-      lastVerified: '2026-03-11T00:48:55.923Z'
+      lastVerified: '2026-05-17T10:02:45.335Z'
     technical-preferences:
       path: .aiox-core/data/technical-preferences.md
       layer: L3
@@ -14108,7 +15447,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:abb9327d3ce96a3cd49e73a555da4078e81ea0c4dbfe7154420c3ec7ac1c93b7
-      lastVerified: '2026-03-11T00:48:55.923Z'
+      lastVerified: '2026-05-17T10:02:45.335Z'
     tool-registry:
       path: .aiox-core/data/tool-registry.yaml
       layer: L3
@@ -14128,7 +15467,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:64e867d0eb36c7f7ac86f4f73f1b2ff89f43f37f28a6de34389be74b9346860c
-      lastVerified: '2026-03-11T00:48:55.923Z'
+      lastVerified: '2026-05-17T10:02:45.335Z'
     workflow-chains:
       path: .aiox-core/data/workflow-chains.yaml
       layer: L3
@@ -14150,7 +15489,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1fbf1625e267eedc315cf1e08e5827c250ddc6785fb2cb139e7702def9b66268
-      lastVerified: '2026-03-11T00:48:55.923Z'
+      lastVerified: '2026-05-17T10:02:45.336Z'
     workflow-patterns:
       path: .aiox-core/data/workflow-patterns.yaml
       layer: L3
@@ -14170,7 +15509,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0e90d71ce0cc218d8710c1f195f74a24d3aa7513f5728f5e65da9220612c3617
-      lastVerified: '2026-03-11T00:48:55.924Z'
+      lastVerified: '2026-05-17T10:02:45.336Z'
     workflow-state-schema:
       path: .aiox-core/data/workflow-state-schema.yaml
       layer: L3
@@ -14190,7 +15529,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d80a645a9c48b8ab8168ddbe36279662d72de4fb5cd8953a6685e5d1bd9968db
-      lastVerified: '2026-03-11T00:48:55.924Z'
+      lastVerified: '2026-05-17T10:02:45.336Z'
     _template:
       path: .aiox-core/data/tech-presets/_template.md
       layer: L3
@@ -14210,7 +15549,33 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:68b26930b728908b6097fc91956c8c446e5cc0dbe627e3b737495ebcd7e9569b
-      lastVerified: '2026-03-11T00:48:55.924Z'
+      lastVerified: '2026-05-17T10:02:45.336Z'
+    angular-nestjs:
+      path: .aiox-core/data/tech-presets/angular-nestjs.md
+      layer: L3
+      type: data
+      purpose: >-
+        'Arquitetura otimizada para aplicações fullstack com Angular 21 (Signals, Standalone Components) no frontend e
+        NestJS (Modular, DI, Guards) no backend'
+      keywords:
+        - angular
+        - nestjs
+        - tech
+        - preset
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps:
+        - auth
+        - user
+        - jwt
+      lifecycle: experimental
+      adaptability:
+        score: 0.5
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:d7b41b5076fc8a2c4312398f41414b8515cc0563ed727e4fe354548bdd80fb77
+      lastVerified: '2026-05-17T10:02:45.337Z'
     csharp:
       path: .aiox-core/data/tech-presets/csharp.md
       layer: L3
@@ -14230,7 +15595,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4667d33407c59fd6c7b4558370893a14df6d461645fc840b2df2fb7508bd6fcf
-      lastVerified: '2026-03-11T00:48:55.924Z'
+      lastVerified: '2026-05-17T10:02:45.337Z'
     go:
       path: .aiox-core/data/tech-presets/go.md
       layer: L3
@@ -14250,7 +15615,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e0851caecbdc2cea6531359fe640427685cd6ed664dbf991ccb135917c4d1ec2
-      lastVerified: '2026-03-11T00:48:55.924Z'
+      lastVerified: '2026-05-17T10:02:45.338Z'
     java:
       path: .aiox-core/data/tech-presets/java.md
       layer: L3
@@ -14270,7 +15635,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b912e04412f63b59439f7cca119802bed95a6cb756221e3ba7aee45c3d2890fd
-      lastVerified: '2026-03-11T00:48:55.924Z'
+      lastVerified: '2026-05-17T10:02:45.338Z'
     nextjs-react:
       path: .aiox-core/data/tech-presets/nextjs-react.md
       layer: L3
@@ -14297,7 +15662,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:558ce0abd112ca39853fc5150bd850862e5fcfac74c8def80c3876b60c9f5d33
-      lastVerified: '2026-03-11T00:48:55.924Z'
+      lastVerified: '2026-05-17T10:02:45.339Z'
     php:
       path: .aiox-core/data/tech-presets/php.md
       layer: L3
@@ -14319,7 +15684,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:847dde754e7a98c4d11328768483358d2be7d2f10e43b6703403237987620077
-      lastVerified: '2026-03-11T00:48:55.924Z'
+      lastVerified: '2026-05-17T10:02:45.339Z'
     rust:
       path: .aiox-core/data/tech-presets/rust.md
       layer: L3
@@ -14339,7 +15704,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:58422e884e46660216d5389878ae2f0ab619da7d34f34ed1dff917dfd8fed7db
-      lastVerified: '2026-03-11T00:48:55.924Z'
+      lastVerified: '2026-05-17T10:02:45.339Z'
   workflows:
     auto-worktree:
       path: .aiox-core/development/workflows/auto-worktree.yaml
@@ -14362,7 +15727,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:74b0dff78c2b91eda03b9914a73cc99807645c8e0b174e576d22e0b3f5b75be3
-      lastVerified: '2026-03-11T00:48:55.925Z'
+      lastVerified: '2026-05-17T10:02:45.341Z'
     brownfield-discovery:
       path: .aiox-core/development/workflows/brownfield-discovery.yaml
       layer: L2
@@ -14387,7 +15752,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a52662b683781546d4585d456aad1cb7d41343a8c934d9a6d6441f8d3dec5385
-      lastVerified: '2026-03-11T00:48:55.927Z'
+      lastVerified: '2026-05-17T10:02:45.347Z'
     brownfield-fullstack:
       path: .aiox-core/development/workflows/brownfield-fullstack.yaml
       layer: L2
@@ -14413,7 +15778,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5200308dfa759d6ce37270f63853a6c1424d47ec552142d9ada6174aaf5c22ff
-      lastVerified: '2026-03-11T00:48:55.928Z'
+      lastVerified: '2026-05-17T10:02:45.348Z'
     brownfield-service:
       path: .aiox-core/development/workflows/brownfield-service.yaml
       layer: L2
@@ -14438,7 +15803,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6ef271e25edd0dfe4235ea5aab14dbf89509250d8471580418ce58d50a1748e8
-      lastVerified: '2026-03-11T00:48:55.928Z'
+      lastVerified: '2026-05-17T10:02:45.348Z'
     brownfield-ui:
       path: .aiox-core/development/workflows/brownfield-ui.yaml
       layer: L2
@@ -14464,7 +15829,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:553a05def42e2a884d59fdeaa1aaf07566e469e3ae30daf43543e8a934c1c67f
-      lastVerified: '2026-03-11T00:48:55.928Z'
+      lastVerified: '2026-05-17T10:02:45.349Z'
     design-system-build-quality:
       path: .aiox-core/development/workflows/design-system-build-quality.yaml
       layer: L2
@@ -14486,7 +15851,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e9aa8f3e1ae22aa0799627326a3548e78eee805e5652c12a15e84dbdbcd5ffe2
-      lastVerified: '2026-03-11T00:48:55.929Z'
+      lastVerified: '2026-05-17T10:02:45.350Z'
     development-cycle:
       path: .aiox-core/development/workflows/development-cycle.yaml
       layer: L2
@@ -14512,7 +15877,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c22f2700d6c3dcd227efec711ab206b4fa9e268768a15be86eea0405e2c82c4d
-      lastVerified: '2026-03-11T00:48:55.930Z'
+      lastVerified: '2026-05-17T10:02:45.352Z'
     epic-orchestration:
       path: .aiox-core/development/workflows/epic-orchestration.yaml
       layer: L2
@@ -14532,7 +15897,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4bb9d91027036d089ab880e46e4b256290761c4dbf17d716abe61b541161fe05
-      lastVerified: '2026-03-11T00:48:55.931Z'
+      lastVerified: '2026-05-17T10:02:45.355Z'
     greenfield-fullstack:
       path: .aiox-core/development/workflows/greenfield-fullstack.yaml
       layer: L2
@@ -14561,7 +15926,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:106b47c4205ac395118a49f5d5fb194125f5c17819780f9a598ef434352013ef
-      lastVerified: '2026-03-11T00:48:55.932Z'
+      lastVerified: '2026-05-17T10:02:45.356Z'
     greenfield-service:
       path: .aiox-core/development/workflows/greenfield-service.yaml
       layer: L2
@@ -14587,7 +15952,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b22d2ea83d2079878632f50351a21d7f2a9a8035283abd6fea701033774f9bb
-      lastVerified: '2026-03-11T00:48:55.935Z'
+      lastVerified: '2026-05-17T10:02:45.357Z'
     greenfield-ui:
       path: .aiox-core/development/workflows/greenfield-ui.yaml
       layer: L2
@@ -14614,7 +15979,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e7818aa9f7c8db4efd6d7fd631fb8ff6f1aac4202c3f6253dfd6d50dd708fc30
-      lastVerified: '2026-03-11T00:48:55.935Z'
+      lastVerified: '2026-05-17T10:02:45.358Z'
     qa-loop:
       path: .aiox-core/development/workflows/qa-loop.yaml
       layer: L2
@@ -14639,7 +16004,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:585d5e5dd2cf4d5682e8db2a816caa588ecf5ae3b332f4a5ceec9f406b5f0f09
-      lastVerified: '2026-03-11T00:48:55.937Z'
+      lastVerified: '2026-05-17T10:02:45.358Z'
     spec-pipeline:
       path: .aiox-core/development/workflows/spec-pipeline.yaml
       layer: L2
@@ -14667,7 +16032,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4604ff3e2e945fbbb45006e32d8de81c73cb38782526ca3c87924549ccc29ccf
-      lastVerified: '2026-03-11T00:48:55.938Z'
+      lastVerified: '2026-05-17T10:02:45.359Z'
     story-development-cycle:
       path: .aiox-core/development/workflows/story-development-cycle.yaml
       layer: L2
@@ -14691,7 +16056,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6125a3545e9a8550582d7d6ea640bbd5b0e4747b80e7c67ebf60ce284591220e
-      lastVerified: '2026-03-11T00:48:55.938Z'
+      lastVerified: '2026-05-17T10:02:45.360Z'
   utils:
     output-formatter:
       path: .aiox-core/core/utils/output-formatter.js
@@ -14711,7 +16076,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6fdfee469b7c108ec24a045b9b2719d836a242052abd285957a9ac732c6fc594
-      lastVerified: '2026-03-11T00:48:55.939Z'
+      lastVerified: '2026-05-17T10:02:45.361Z'
     security-utils:
       path: .aiox-core/core/utils/security-utils.js
       layer: L1
@@ -14730,7 +16095,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:00c938eda0e142b8c204b50afdd662864b5209b60a32a0e6e847e4e4cbceee09
-      lastVerified: '2026-03-11T00:48:55.939Z'
+      lastVerified: '2026-05-17T10:02:45.361Z'
     yaml-validator:
       path: .aiox-core/core/utils/yaml-validator.js
       layer: L1
@@ -14748,8 +16113,8 @@ entities:
         score: 0.6
         constraints: []
         extensionPoints: []
-      checksum: sha256:41e3715845262c2e49f58745a773e81f4feaaa2325e54bcb0226e4bf08f709dd
-      lastVerified: '2026-03-11T00:48:55.939Z'
+      checksum: sha256:05084596198634dd2a670a752d5c451edfe268e16e3bae511db52184f895366f
+      lastVerified: '2026-05-17T10:02:45.361Z'
   tools: {}
   infra-scripts:
     aiox-validator:
@@ -14770,7 +16135,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5a91cc8b54ccd58955dbbb5925f878d9e507dc2a9358f642c62f7ee84a6156a0
-      lastVerified: '2026-03-11T00:48:55.940Z'
+      lastVerified: '2026-05-17T10:02:45.363Z'
     approach-manager:
       path: .aiox-core/infrastructure/scripts/approach-manager.js
       layer: L2
@@ -14790,7 +16155,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:22ee604ca42094f5b7939ec129c52cb1fc362ae70688cc1ef7a921c956ab38d2
-      lastVerified: '2026-03-11T00:48:55.941Z'
+      lastVerified: '2026-05-17T10:02:45.364Z'
     approval-workflow:
       path: .aiox-core/infrastructure/scripts/approval-workflow.js
       layer: L2
@@ -14810,7 +16175,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4d744a8d08cadf09bf368a1457c1bd3bc68ccef0885c324b2527222da816544b
-      lastVerified: '2026-03-11T00:48:55.941Z'
+      lastVerified: '2026-05-17T10:02:45.364Z'
     asset-inventory:
       path: .aiox-core/infrastructure/scripts/asset-inventory.js
       layer: L2
@@ -14830,7 +16195,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:25ad926a05af465389b6fb92f7c9c79c453c54047b4ebe9629ee1c153a6b3373
-      lastVerified: '2026-03-11T00:48:55.941Z'
+      lastVerified: '2026-05-17T10:02:45.365Z'
     atomic-layer-classifier:
       path: .aiox-core/infrastructure/scripts/atomic-layer-classifier.js
       layer: L2
@@ -14850,7 +16215,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ecdb368d80a69c8da7cc507aff0b18bd2e58d8bd94b9fb0ba1e074595a19e884
-      lastVerified: '2026-03-11T00:48:55.941Z'
+      lastVerified: '2026-05-17T10:02:45.365Z'
     backup-manager:
       path: .aiox-core/infrastructure/scripts/backup-manager.js
       layer: L2
@@ -14861,6 +16226,7 @@ entities:
         - manager
       usedBy:
         - improve-self
+        - health-check-healers-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -14870,7 +16236,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e7d0173f107c0576f443a7f4bc83387cdbb625518ce5749ca9059ffbf3070f44
-      lastVerified: '2026-03-11T00:48:55.941Z'
+      lastVerified: '2026-05-17T10:02:45.365Z'
     batch-creator:
       path: .aiox-core/infrastructure/scripts/batch-creator.js
       layer: L2
@@ -14893,7 +16259,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b91ca0e5d8af3d47658bc5bd754e72e654e68446c17c5e50e45ebd581535fe7d
-      lastVerified: '2026-03-11T00:48:55.941Z'
+      lastVerified: '2026-05-17T10:02:45.366Z'
     branch-manager:
       path: .aiox-core/infrastructure/scripts/branch-manager.js
       layer: L2
@@ -14913,7 +16279,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:49f3a7a7aa36347c3e3dbc998847913c829216c71a1c659bf7a55d67a940d1c3
-      lastVerified: '2026-03-11T00:48:55.941Z'
+      lastVerified: '2026-05-17T10:02:45.366Z'
     capability-analyzer:
       path: .aiox-core/infrastructure/scripts/capability-analyzer.js
       layer: L2
@@ -14934,7 +16300,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:92f55a27e60fd6aba2a0203f1c28aa12d6f70200097ec44d849db2653f758a17
-      lastVerified: '2026-03-11T00:48:55.941Z'
+      lastVerified: '2026-05-17T10:02:45.366Z'
     changelog-generator:
       path: .aiox-core/infrastructure/scripts/changelog-generator.js
       layer: L2
@@ -14953,7 +16319,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c2d6b203d39fe2ef8d6b7108beb59a03da0986f9331c22ce539d9857c7cc3612
-      lastVerified: '2026-03-11T00:48:55.942Z'
+      lastVerified: '2026-05-17T10:02:45.367Z'
     cicd-discovery:
       path: .aiox-core/infrastructure/scripts/cicd-discovery.js
       layer: L2
@@ -14972,7 +16338,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:04b5efa659f9d3baa998ca4b09f7fc6ec4800d0b165ecf118a8f10df93642228
-      lastVerified: '2026-03-11T00:48:55.942Z'
+      lastVerified: '2026-05-17T10:02:45.367Z'
     clickup-helpers:
       path: .aiox-core/infrastructure/scripts/clickup-helpers.js
       layer: L2
@@ -14994,7 +16360,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:043ceb5b712903e6b78be83c997575e8de64d5815dccef88355c20d8153af9a6
-      lastVerified: '2026-03-11T00:48:55.942Z'
+      lastVerified: '2026-05-17T10:02:45.368Z'
     code-quality-improver:
       path: .aiox-core/infrastructure/scripts/code-quality-improver.js
       layer: L2
@@ -15015,7 +16381,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:765dd10a367656b330a659b2245ef2eb9a947905fee71555198837743fc1483f
-      lastVerified: '2026-03-11T00:48:55.942Z'
+      lastVerified: '2026-05-17T10:02:45.368Z'
     codebase-mapper:
       path: .aiox-core/infrastructure/scripts/codebase-mapper.js
       layer: L2
@@ -15035,7 +16401,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b72ae317c81c01ed1d6d518d64cf18fdecb9d408ab45dba6ad45cb39c6e3a1d
-      lastVerified: '2026-03-11T00:48:55.943Z'
+      lastVerified: '2026-05-17T10:02:45.369Z'
     collect-tool-usage:
       path: .aiox-core/infrastructure/scripts/collect-tool-usage.js
       layer: L2
@@ -15055,7 +16421,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8a739b79182dc41e28b7e02aeb9ec1dde5ec49f3ca534399acc59711b3b92bbf
-      lastVerified: '2026-03-11T00:48:55.943Z'
+      lastVerified: '2026-05-17T10:02:45.370Z'
     commit-message-generator:
       path: .aiox-core/infrastructure/scripts/commit-message-generator.js
       layer: L2
@@ -15077,7 +16443,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:611b0f27acd02e49aff7a2d91b48823dc4a2d788440fff2f32bf500a1bc84132
-      lastVerified: '2026-03-11T00:48:55.943Z'
+      lastVerified: '2026-05-17T10:02:45.370Z'
     component-generator:
       path: .aiox-core/infrastructure/scripts/component-generator.js
       layer: L2
@@ -15119,7 +16485,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c74da9a766aeca878568a0e70f78141e7a772322d428f99e90fcd7b9a5fd7edc
-      lastVerified: '2026-03-11T00:48:55.943Z'
+      lastVerified: '2026-05-17T10:02:45.371Z'
     component-metadata:
       path: .aiox-core/infrastructure/scripts/component-metadata.js
       layer: L2
@@ -15141,7 +16507,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0ad8034533561b13187072eaa611510117463bacbaff12f9ae48008128560000
-      lastVerified: '2026-03-11T00:48:55.943Z'
+      lastVerified: '2026-05-17T10:02:45.371Z'
     component-search:
       path: .aiox-core/infrastructure/scripts/component-search.js
       layer: L2
@@ -15162,7 +16528,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:08feb4672de885f140527e460614cbc90d90544753581f36afeec71ee8614703
-      lastVerified: '2026-03-11T00:48:55.944Z'
+      lastVerified: '2026-05-17T10:02:45.372Z'
     config-cache:
       path: .aiox-core/infrastructure/scripts/config-cache.js
       layer: L2
@@ -15184,8 +16550,8 @@ entities:
         score: 0.7
         constraints: []
         extensionPoints: []
-      checksum: sha256:6264ae77eef1e98de62d9f6478becadf6a6692ca88027666dbf5a1e2399c844a
-      lastVerified: '2026-03-11T00:48:55.944Z'
+      checksum: sha256:363383dbf90df90d69b8ba769db4f9749b0ae91b4fe95ee15be633941906f8a2
+      lastVerified: '2026-05-17T10:02:45.372Z'
     config-loader:
       path: .aiox-core/infrastructure/scripts/config-loader.js
       layer: L2
@@ -15207,7 +16573,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8f9489f7c57e775bfbb750761d9714505d5df3938b664cbbdf6701f9e18e240b
-      lastVerified: '2026-03-11T00:48:55.944Z'
+      lastVerified: '2026-05-17T10:02:45.372Z'
     conflict-resolver:
       path: .aiox-core/infrastructure/scripts/conflict-resolver.js
       layer: L2
@@ -15227,7 +16593,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3d2794a66f16fcea95b096386dc9c2dcd31e5938d862030e7ac1f38c00a2c0bd
-      lastVerified: '2026-03-11T00:48:55.944Z'
+      lastVerified: '2026-05-17T10:02:45.372Z'
     coverage-analyzer:
       path: .aiox-core/infrastructure/scripts/coverage-analyzer.js
       layer: L2
@@ -15247,7 +16613,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:95e70563eadf720ce4c6aa6349ace311cf34c63bc5044f71565f328a2dc9a706
-      lastVerified: '2026-03-11T00:48:55.944Z'
+      lastVerified: '2026-05-17T10:02:45.373Z'
     dashboard-status-writer:
       path: .aiox-core/infrastructure/scripts/dashboard-status-writer.js
       layer: L2
@@ -15267,7 +16633,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a01bc8e74ce40206bbb49453af46896388754f412961b6f6585927a382338f01
-      lastVerified: '2026-03-11T00:48:55.944Z'
+      lastVerified: '2026-05-17T10:02:45.373Z'
     dependency-analyzer:
       path: .aiox-core/infrastructure/scripts/dependency-analyzer.js
       layer: L2
@@ -15288,7 +16654,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:af326d5d70a097cc255171d8f30b1d99a302b07d96d94528cfaad3f97bdea479
-      lastVerified: '2026-03-11T00:48:55.944Z'
+      lastVerified: '2026-05-17T10:02:45.374Z'
     dependency-impact-analyzer:
       path: .aiox-core/infrastructure/scripts/dependency-impact-analyzer.js
       layer: L2
@@ -15313,7 +16679,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3c9d87250845f7def63a2230d4af43ed2d6ae84cfba6b6d72a5b9e285a66f5ed
-      lastVerified: '2026-03-11T00:48:55.944Z'
+      lastVerified: '2026-05-17T10:02:45.374Z'
     diff-generator:
       path: .aiox-core/infrastructure/scripts/diff-generator.js
       layer: L2
@@ -15334,7 +16700,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:569387c1dd8ee00d0ebc34b9f463438150ed9c96af2e5728fde83c36626211cf
-      lastVerified: '2026-03-11T00:48:55.944Z'
+      lastVerified: '2026-05-17T10:02:45.375Z'
     documentation-synchronizer:
       path: .aiox-core/infrastructure/scripts/documentation-synchronizer.js
       layer: L2
@@ -15354,7 +16720,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:94fc482ef0182608a3433824d02cb24fe0d7ab4aaa256853b9b79e603bf28e9e
-      lastVerified: '2026-03-11T00:48:55.945Z'
+      lastVerified: '2026-05-17T10:02:45.375Z'
     framework-analyzer:
       path: .aiox-core/infrastructure/scripts/framework-analyzer.js
       layer: L2
@@ -15376,7 +16742,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8bd86d50f5a3f050191a49e22e8348bbefa72e3df396313064239a2f1a4a9856
-      lastVerified: '2026-03-11T00:48:55.945Z'
+      lastVerified: '2026-05-17T10:02:45.376Z'
     generate-optimization-report:
       path: .aiox-core/infrastructure/scripts/generate-optimization-report.js
       layer: L2
@@ -15396,7 +16762,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b57357bc4120529381b811fd7c1aab901d3b67dd765d043eefc61bb22f5b8df1
-      lastVerified: '2026-03-11T00:48:55.945Z'
+      lastVerified: '2026-05-17T10:02:45.376Z'
     generate-settings-json:
       path: .aiox-core/infrastructure/scripts/generate-settings-json.js
       layer: L2
@@ -15415,8 +16781,8 @@ entities:
         score: 0.7
         constraints: []
         extensionPoints: []
-      checksum: sha256:bb4c6f664eb06622fd78eb455c0a74ee29ecee5fe47b4a7fcb2de8a89119ff5a
-      lastVerified: '2026-03-11T00:48:55.945Z'
+      checksum: sha256:dc5b8803825ed749080925d7c17ece39b33a7faf3b02d08a445e8cc7408048a1
+      lastVerified: '2026-05-17T10:02:45.376Z'
     git-config-detector:
       path: .aiox-core/infrastructure/scripts/git-config-detector.js
       layer: L2
@@ -15438,7 +16804,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:52ed96d98fc6f9e83671d7d27f78dcff4f2475f3b8e339dc31922f6b2814ad78
-      lastVerified: '2026-03-11T00:48:55.945Z'
+      lastVerified: '2026-05-17T10:02:45.376Z'
     git-wrapper:
       path: .aiox-core/infrastructure/scripts/git-wrapper.js
       layer: L2
@@ -15459,7 +16825,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7130442ca72ba89e397be77000b44e2431b92a8af44d1fac63c869807641e587
-      lastVerified: '2026-03-11T00:48:55.945Z'
+      lastVerified: '2026-05-17T10:02:45.376Z'
     gotchas-documenter:
       path: .aiox-core/infrastructure/scripts/gotchas-documenter.js
       layer: L2
@@ -15479,7 +16845,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ef42171b57775622977a9221db8a7d994a33f3acaa0a72c2908d13943d45d796
-      lastVerified: '2026-03-11T00:48:55.945Z'
+      lastVerified: '2026-05-17T10:02:45.377Z'
     improvement-engine:
       path: .aiox-core/infrastructure/scripts/improvement-engine.js
       layer: L2
@@ -15499,7 +16865,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4fed61115f4148eb6b8c42ebd9d5b05732695ab1b4343e2466383baf4883d58d
-      lastVerified: '2026-03-11T00:48:55.946Z'
+      lastVerified: '2026-05-17T10:02:45.377Z'
     improvement-validator:
       path: .aiox-core/infrastructure/scripts/improvement-validator.js
       layer: L2
@@ -15521,7 +16887,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b63362e7ac1c4dbf17655be6609cab666f9f1970821da79609890f76a906c02b
-      lastVerified: '2026-03-11T00:48:55.946Z'
+      lastVerified: '2026-05-17T10:02:45.377Z'
     migrate-agent:
       path: .aiox-core/infrastructure/scripts/migrate-agent.js
       layer: L2
@@ -15541,7 +16907,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0b7330c4a7dccfe028aea2d99e4d3c2f3acface55b79c32bd51ab3bc00e33a86
-      lastVerified: '2026-03-11T00:48:55.946Z'
+      lastVerified: '2026-05-17T10:02:45.378Z'
     modification-risk-assessment:
       path: .aiox-core/infrastructure/scripts/modification-risk-assessment.js
       layer: L2
@@ -15562,7 +16928,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:974dfb83d3bfbb56f4a02385d8edb735c0acab62acb8a1a4e7c69f5ecf10c810
-      lastVerified: '2026-03-11T00:48:55.946Z'
+      lastVerified: '2026-05-17T10:02:45.378Z'
     modification-validator:
       path: .aiox-core/infrastructure/scripts/modification-validator.js
       layer: L2
@@ -15586,7 +16952,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0853fbe9e628510a0e6f8b95ac3c467d49df5cd7b15637f374928c1d3f9e2b87
-      lastVerified: '2026-03-11T00:48:55.946Z'
+      lastVerified: '2026-05-17T10:02:45.379Z'
     output-formatter:
       path: .aiox-core/infrastructure/scripts/output-formatter.js
       layer: L2
@@ -15608,7 +16974,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6f28092d0dabf3b0b486ef06a1836d47c3247a3c331ed6cfbcd597d45496ddb6
-      lastVerified: '2026-03-11T00:48:55.946Z'
+      lastVerified: '2026-05-17T10:02:45.379Z'
     path-analyzer:
       path: .aiox-core/infrastructure/scripts/path-analyzer.js
       layer: L2
@@ -15628,7 +16994,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:47250c416f8090278b4a81de7be4a3f2592f4a20b6afc9c9e30c9cafd292e166
-      lastVerified: '2026-03-11T00:48:55.947Z'
+      lastVerified: '2026-05-17T10:02:45.379Z'
     pattern-extractor:
       path: .aiox-core/infrastructure/scripts/pattern-extractor.js
       layer: L2
@@ -15649,7 +17015,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9edc6aabdb32431466c5c8db9da883bc0a5f4457cfc74ccc6c10ed687f8e1e52
-      lastVerified: '2026-03-11T00:48:55.947Z'
+      lastVerified: '2026-05-17T10:02:45.380Z'
     performance-analyzer:
       path: .aiox-core/infrastructure/scripts/performance-analyzer.js
       layer: L2
@@ -15669,7 +17035,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6d925acfbaf3cedae2b17ec262f8436c2d38d7eacd4513acfa0a6b3ebb600337
-      lastVerified: '2026-03-11T00:48:55.947Z'
+      lastVerified: '2026-05-17T10:02:45.380Z'
     performance-and-error-resolver:
       path: .aiox-core/infrastructure/scripts/performance-and-error-resolver.js
       layer: L2
@@ -15690,7 +17056,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de4246a4f01f6da08c8de8a3595505ad8837524db39458f4e6c163cb671b6097
-      lastVerified: '2026-03-11T00:48:55.948Z'
+      lastVerified: '2026-05-17T10:02:45.381Z'
     performance-optimizer:
       path: .aiox-core/infrastructure/scripts/performance-optimizer.js
       layer: L2
@@ -15710,7 +17076,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:80be8b0599b24f3f21f27ac5e53a4f3ecbb69c7b928ba101c6d1912fb19f7156
-      lastVerified: '2026-03-11T00:48:55.948Z'
+      lastVerified: '2026-05-17T10:02:45.381Z'
     performance-tracker:
       path: .aiox-core/infrastructure/scripts/performance-tracker.js
       layer: L2
@@ -15730,7 +17096,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3c98129cc1597bb637634f566f3440a47c31820e66580a65ebebca5d5771ee6f
-      lastVerified: '2026-03-11T00:48:55.948Z'
+      lastVerified: '2026-05-17T10:02:45.382Z'
     plan-tracker:
       path: .aiox-core/infrastructure/scripts/plan-tracker.js
       layer: L2
@@ -15752,7 +17118,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:12bdcdb1b05e1d36686c7ae3cd4c080e592fe41b0807d64ee08ed089d4e257da
-      lastVerified: '2026-03-11T00:48:55.948Z'
+      lastVerified: '2026-05-17T10:02:45.382Z'
     pm-adapter-factory:
       path: .aiox-core/infrastructure/scripts/pm-adapter-factory.js
       layer: L2
@@ -15779,7 +17145,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:72ceafb9cf559d619951f95d62a7fd645c95258eca27248985fbb2afb20aa257
-      lastVerified: '2026-03-11T00:48:55.948Z'
+      lastVerified: '2026-05-17T10:02:45.383Z'
     pm-adapter:
       path: .aiox-core/infrastructure/scripts/pm-adapter.js
       layer: L2
@@ -15798,7 +17164,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d8383516f70e1641be210dd4b033541fb6bfafd39fd5976361b8e322cdcb1058
-      lastVerified: '2026-03-11T00:48:55.948Z'
+      lastVerified: '2026-05-17T10:02:45.383Z'
     pr-review-ai:
       path: .aiox-core/infrastructure/scripts/pr-review-ai.js
       layer: L2
@@ -15818,7 +17184,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8872f4ddc23184ea3305cae682741a6a02c1efc170afaa20793c3a9951b374fc
-      lastVerified: '2026-03-11T00:48:55.949Z'
+      lastVerified: '2026-05-17T10:02:45.383Z'
     project-status-loader:
       path: .aiox-core/infrastructure/scripts/project-status-loader.js
       layer: L2
@@ -15842,7 +17208,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:33d753efad0658a702b08f9422406423a9aceac4c88479622fc660c8e0c8eccb
-      lastVerified: '2026-03-11T00:48:55.949Z'
+      lastVerified: '2026-05-17T10:02:45.384Z'
     qa-loop-orchestrator:
       path: .aiox-core/infrastructure/scripts/qa-loop-orchestrator.js
       layer: L2
@@ -15863,7 +17229,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cadd573d7667f6aecd77940ec48c9c8af5e09685877002625faa14a68f5568c2
-      lastVerified: '2026-03-11T00:48:55.949Z'
+      lastVerified: '2026-05-17T10:02:45.385Z'
     qa-report-generator:
       path: .aiox-core/infrastructure/scripts/qa-report-generator.js
       layer: L2
@@ -15883,7 +17249,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:23756fafc80bc0b6a6926a7436cf6653df02be1d28a68cf6628f203f778ce201
-      lastVerified: '2026-03-11T00:48:55.949Z'
+      lastVerified: '2026-05-17T10:02:45.385Z'
     recovery-tracker:
       path: .aiox-core/infrastructure/scripts/recovery-tracker.js
       layer: L2
@@ -15906,7 +17272,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:09eb60cdd5b6a42a93b5f7450448899bf83e704ecec7d56ea27b560f063e2d1a
-      lastVerified: '2026-03-11T00:48:55.950Z'
+      lastVerified: '2026-05-17T10:02:45.386Z'
     refactoring-suggester:
       path: .aiox-core/infrastructure/scripts/refactoring-suggester.js
       layer: L2
@@ -15926,7 +17292,30 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:118d4cdbc64cf3238065f2fb98958305ae81e1384bc68f5a6c7b768f1232cd1e
-      lastVerified: '2026-03-11T00:48:55.950Z'
+      lastVerified: '2026-05-17T10:02:45.386Z'
+    repair-agent-references:
+      path: .aiox-core/infrastructure/scripts/repair-agent-references.js
+      layer: L2
+      type: script
+      purpose: Entity at .aiox-core/infrastructure/scripts/repair-agent-references.js
+      keywords:
+        - repair
+        - agent
+        - references
+      usedBy: []
+      dependencies:
+        - agent-parser
+        - index
+        - validate
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: experimental
+      adaptability:
+        score: 0.7
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:63b5f580b783d5098c3ab3d8da11af9871306b3a1fc0f986f25c813eb4c4dd75
+      lastVerified: '2026-05-17T10:02:45.387Z'
     repository-detector:
       path: .aiox-core/infrastructure/scripts/repository-detector.js
       layer: L2
@@ -15948,7 +17337,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:10ffca7f57d24d3729c71a9104a154500a3c72328d67884e26e38d22199af332
-      lastVerified: '2026-03-11T00:48:55.950Z'
+      lastVerified: '2026-05-17T10:02:45.387Z'
     rollback-manager:
       path: .aiox-core/infrastructure/scripts/rollback-manager.js
       layer: L2
@@ -15970,7 +17359,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fe14a4c0b55f35c30f76daf12712fb97308171683bf81d2566e0d01838d57a6e
-      lastVerified: '2026-03-11T00:48:55.950Z'
+      lastVerified: '2026-05-17T10:02:45.387Z'
     sandbox-tester:
       path: .aiox-core/infrastructure/scripts/sandbox-tester.js
       layer: L2
@@ -15990,7 +17379,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:019af2e23de70d7dacb49faf031ba0c1f5553ecebe52f361bab74bfca73ba609
-      lastVerified: '2026-03-11T00:48:55.950Z'
+      lastVerified: '2026-05-17T10:02:45.388Z'
     security-checker:
       path: .aiox-core/infrastructure/scripts/security-checker.js
       layer: L2
@@ -16014,7 +17403,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d14d9376e3044e61eba40c03931a05dc518f7b8a10618d4f8c9c8a4b300e71fc
-      lastVerified: '2026-03-11T00:48:55.950Z'
+      lastVerified: '2026-05-17T10:02:45.388Z'
     spot-check-validator:
       path: .aiox-core/infrastructure/scripts/spot-check-validator.js
       layer: L2
@@ -16034,7 +17423,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4bf2d20ded322312aef98291d2a23913da565e1622bc97366c476793c6792c81
-      lastVerified: '2026-03-11T00:48:55.950Z'
+      lastVerified: '2026-05-17T10:02:45.388Z'
     status-mapper:
       path: .aiox-core/infrastructure/scripts/status-mapper.js
       layer: L2
@@ -16054,7 +17443,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6ce6d7324350997b3e1b112aabfbbd0612ebde753ca9ed03e494869b3bb57b1f
-      lastVerified: '2026-03-11T00:48:55.950Z'
+      lastVerified: '2026-05-17T10:02:45.388Z'
     story-worktree-hooks:
       path: .aiox-core/infrastructure/scripts/story-worktree-hooks.js
       layer: L2
@@ -16075,7 +17464,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3e719f61633200d116260931d93925197c7d2d5d857492f87974c6aae160e1a4
-      lastVerified: '2026-03-11T00:48:55.951Z'
+      lastVerified: '2026-05-17T10:02:45.389Z'
     stuck-detector:
       path: .aiox-core/infrastructure/scripts/stuck-detector.js
       layer: L2
@@ -16098,7 +17487,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d1afb4d6d17c06075d43e2327d4f84fce1a4e57a46374b0250a3028c211b1c66
-      lastVerified: '2026-03-11T00:48:55.951Z'
+      lastVerified: '2026-05-17T10:02:45.389Z'
     subtask-verifier:
       path: .aiox-core/infrastructure/scripts/subtask-verifier.js
       layer: L2
@@ -16118,7 +17507,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ceb0450fa12fa48f0255bb4565858eb1a97b28c30b98d36cb61d52d72e08b054
-      lastVerified: '2026-03-11T00:48:55.951Z'
+      lastVerified: '2026-05-17T10:02:45.389Z'
     template-engine:
       path: .aiox-core/infrastructure/scripts/template-engine.js
       layer: L2
@@ -16139,7 +17528,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec62a12ff9ad140d32fcbdfc9b5eef636101b75f0835469f1193fee8db0a7d55
-      lastVerified: '2026-03-11T00:48:55.951Z'
+      lastVerified: '2026-05-17T10:02:45.390Z'
     template-validator:
       path: .aiox-core/infrastructure/scripts/template-validator.js
       layer: L2
@@ -16160,7 +17549,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de989116d2f895b58e10355b8853e7b96af6fde151d2612616f18842b9cc56c4
-      lastVerified: '2026-03-11T00:48:55.951Z'
+      lastVerified: '2026-05-17T10:02:45.390Z'
     test-discovery:
       path: .aiox-core/infrastructure/scripts/test-discovery.js
       layer: L2
@@ -16179,7 +17568,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:04038aa49ae515697084fcdacaf0ef8bc36029fc114f5a1206065d7928870449
-      lastVerified: '2026-03-11T00:48:55.952Z'
+      lastVerified: '2026-05-17T10:02:45.390Z'
     test-generator:
       path: .aiox-core/infrastructure/scripts/test-generator.js
       layer: L2
@@ -16199,7 +17588,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f3146896fbcbc99563cc015b828f097167642e24c919c7c9bf6bbfee9ea87cc1
-      lastVerified: '2026-03-11T00:48:55.952Z'
+      lastVerified: '2026-05-17T10:02:45.391Z'
     test-quality-assessment:
       path: .aiox-core/infrastructure/scripts/test-quality-assessment.js
       layer: L2
@@ -16220,7 +17609,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:08c49331641c0fb1873e37fd14a41d88cec7b40f4b16267ae26b4cadc4d292b6
-      lastVerified: '2026-03-11T00:48:55.952Z'
+      lastVerified: '2026-05-17T10:02:45.391Z'
     test-utilities-fast:
       path: .aiox-core/infrastructure/scripts/test-utilities-fast.js
       layer: L2
@@ -16240,7 +17629,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:70d87a74dac153c65d622afa4d62816e41d8d81eee6d42e1c0e498999bec7c40
-      lastVerified: '2026-03-11T00:48:55.952Z'
+      lastVerified: '2026-05-17T10:02:45.392Z'
     test-utilities:
       path: .aiox-core/infrastructure/scripts/test-utilities.js
       layer: L2
@@ -16259,7 +17648,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2df35a1706b1389809226fde3c4e0bc72e4d5cebacab3cb98beaa70768049061
-      lastVerified: '2026-03-11T00:48:55.952Z'
+      lastVerified: '2026-05-17T10:02:45.392Z'
     tool-resolver:
       path: .aiox-core/infrastructure/scripts/tool-resolver.js
       layer: L2
@@ -16281,7 +17670,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2fa44e4a940d4c33570fd9b4495b5c39792c52ca91b98c4be2fb55cb974ad095
-      lastVerified: '2026-03-11T00:48:55.953Z'
+      lastVerified: '2026-05-17T10:02:45.392Z'
     transaction-manager:
       path: .aiox-core/infrastructure/scripts/transaction-manager.js
       layer: L2
@@ -16304,7 +17693,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bed375a4d72928ecfa670626c3e504194c4bf4439eab399fc5b31c919e873e86
-      lastVerified: '2026-03-11T00:48:55.953Z'
+      lastVerified: '2026-05-17T10:02:45.392Z'
     usage-analytics:
       path: .aiox-core/infrastructure/scripts/usage-analytics.js
       layer: L2
@@ -16324,7 +17713,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5328370f603d7601e7e69b2c19646fad8557394068955fc029b9bc4f70d66bfe
-      lastVerified: '2026-03-11T00:48:55.953Z'
+      lastVerified: '2026-05-17T10:02:45.393Z'
     validate-agents:
       path: .aiox-core/infrastructure/scripts/validate-agents.js
       layer: L2
@@ -16344,7 +17733,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5f5f89a1fcf02ba340772ed30ade56fc346114d7a4d43e6d69af40858c64b180
-      lastVerified: '2026-03-11T00:48:55.953Z'
+      lastVerified: '2026-05-17T10:02:45.393Z'
     validate-claude-integration:
       path: .aiox-core/infrastructure/scripts/validate-claude-integration.js
       layer: L2
@@ -16364,8 +17753,8 @@ entities:
         score: 0.7
         constraints: []
         extensionPoints: []
-      checksum: sha256:3b4e996c2597966fad966d1b2beaecdbda003f6529c41687dfe419d62a319ec6
-      lastVerified: '2026-03-11T00:48:55.953Z'
+      checksum: sha256:0174d5e5e38eb8aa5aaa0a44d87f0f8dda623a24f318855c1e50e9d04f7596d6
+      lastVerified: '2026-05-17T10:02:45.393Z'
     validate-codex-integration:
       path: .aiox-core/infrastructure/scripts/validate-codex-integration.js
       layer: L2
@@ -16386,7 +17775,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0f45a49898528d708ef17871bf6abae4f60483ef8520ce30a9bd4f5e507c585f
-      lastVerified: '2026-03-11T00:48:55.954Z'
+      lastVerified: '2026-05-17T10:02:45.393Z'
     validate-gemini-integration:
       path: .aiox-core/infrastructure/scripts/validate-gemini-integration.js
       layer: L2
@@ -16407,7 +17796,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:57a31b8a4b8c129189afaad961ed0261a205c02b55028d61146a9e599c112883
-      lastVerified: '2026-03-11T00:48:55.954Z'
+      lastVerified: '2026-05-17T10:02:45.394Z'
     validate-output-pattern:
       path: .aiox-core/infrastructure/scripts/validate-output-pattern.js
       layer: L2
@@ -16427,7 +17816,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:91111d656e8d7b38a20a1bda753e663b74318f75cdab2025c7e0b84c775fc83d
-      lastVerified: '2026-03-11T00:48:55.954Z'
+      lastVerified: '2026-05-17T10:02:45.394Z'
     validate-parity:
       path: .aiox-core/infrastructure/scripts/validate-parity.js
       layer: L2
@@ -16451,7 +17840,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7f651b869bd501e97d6dccb51dab434818492bc5b02f5eaea00db808cd17cd4c
-      lastVerified: '2026-03-11T00:48:55.954Z'
+      lastVerified: '2026-05-17T10:02:45.394Z'
     validate-paths:
       path: .aiox-core/infrastructure/scripts/validate-paths.js
       layer: L2
@@ -16470,8 +17859,8 @@ entities:
         score: 0.7
         constraints: []
         extensionPoints: []
-      checksum: sha256:17d453afbfb15bb85ffce096e0ae95a69838b10b3d7a9538ea35664ce851159a
-      lastVerified: '2026-03-11T00:48:55.954Z'
+      checksum: sha256:fb37d099b52eda54e47dec07259687bec6049941cad37281f1de9c3f4095bfd9
+      lastVerified: '2026-05-17T10:02:45.394Z'
     validate-user-profile:
       path: .aiox-core/infrastructure/scripts/validate-user-profile.js
       layer: L2
@@ -16492,7 +17881,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a67e6385bb77d6359e91d87882c0641b1444a1f7acd1086203f20953a4f16a37
-      lastVerified: '2026-03-11T00:48:55.954Z'
+      lastVerified: '2026-05-17T10:02:45.395Z'
     visual-impact-generator:
       path: .aiox-core/infrastructure/scripts/visual-impact-generator.js
       layer: L2
@@ -16513,7 +17902,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7771eb4d93b1d371149c15adf83db205c7bf600be6d098fc4364af2886776686
-      lastVerified: '2026-03-11T00:48:55.955Z'
+      lastVerified: '2026-05-17T10:02:45.395Z'
     worktree-manager:
       path: .aiox-core/infrastructure/scripts/worktree-manager.js
       layer: L2
@@ -16541,7 +17930,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:76ac6c2638b5ddf9d8a359ac9db887b926ca0993d77220f6511c58255f0cfbd3
-      lastVerified: '2026-03-11T00:48:55.955Z'
+      lastVerified: '2026-05-17T10:02:45.396Z'
     yaml-validator:
       path: .aiox-core/infrastructure/scripts/yaml-validator.js
       layer: L2
@@ -16564,12 +17953,32 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2039ecb9a9d3f639c734c65704018efd2c4656c4995f0b0e537670f7417bf23b
-      lastVerified: '2026-03-11T00:48:55.955Z'
+      lastVerified: '2026-05-17T10:02:45.396Z'
+    bootstrap:
+      path: .aiox-core/infrastructure/scripts/codex-skills-sync/bootstrap.js
+      layer: L2
+      type: script
+      purpose: '* - Generate `.codex/skills/aiox-*` for each core AIOX agent in'
+      keywords:
+        - bootstrap
+        - ${title}
+        - activator
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.7
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:56f4518586591d809cda89183e1af3b05c4e4c7369df992e7fdd7214ea5c6072
+      lastVerified: '2026-05-17T10:02:45.397Z'
     index:
       path: .aiox-core/infrastructure/scripts/codex-skills-sync/index.js
       layer: L2
       type: script
-      purpose: ${description}
+      purpose: Sync local Codex skills for core AIOX agents.
       keywords:
         - index
         - aiox
@@ -16582,6 +17991,7 @@ entities:
         - planning-helper
         - qa-helper
         - story-helper
+        - repair-agent-references
         - validate
       dependencies:
         - agent-parser
@@ -16592,8 +18002,8 @@ entities:
         score: 0.7
         constraints: []
         extensionPoints: []
-      checksum: sha256:a7a3c97374c34a900acad13498f61f8a40517574480354218e349d1e1d3931a4
-      lastVerified: '2026-03-11T00:48:55.955Z'
+      checksum: sha256:2dc8637ba0095921e3cb5e99791dc05da61a12e375407b05f199696bcce7ea61
+      lastVerified: '2026-05-17T10:02:45.397Z'
     validate:
       path: .aiox-core/infrastructure/scripts/codex-skills-sync/validate.js
       layer: L2
@@ -16602,6 +18012,7 @@ entities:
       keywords:
         - validate
       usedBy:
+        - repair-agent-references
         - validate-parity
       dependencies:
         - agent-parser
@@ -16613,8 +18024,8 @@ entities:
         score: 0.7
         constraints: []
         extensionPoints: []
-      checksum: sha256:5b8cb91ddcfda2b6b66328c12129e71665e4e1cb6f13b1792746e9d761d1ebcf
-      lastVerified: '2026-05-07T21:02:02.645Z'
+      checksum: sha256:6c8f98f49e433fc3aa648034457d5273a2ca667b8c7e492157a89ed6d0582c96
+      lastVerified: '2026-05-17T10:02:45.397Z'
     brownfield-analyzer:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/brownfield-analyzer.js
       layer: L2
@@ -16625,6 +18036,7 @@ entities:
         - analyzer
       usedBy:
         - analyze-brownfield
+        - documentation-integrity-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -16634,7 +18046,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a5d1a200767592554778f12cfd3594b89dd11d25e1668e81876c34753753df04
-      lastVerified: '2026-03-11T00:48:55.955Z'
+      lastVerified: '2026-05-17T10:02:45.398Z'
     config-generator:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/config-generator.js
       layer: L2
@@ -16645,6 +18057,7 @@ entities:
         - generator
       usedBy:
         - setup-project-docs
+        - documentation-integrity-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -16654,7 +18067,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bed3eb82140bf4ed547ec1f5c8992cbcd3ce8587a8814f7bef0962c7788965ee
-      lastVerified: '2026-03-11T00:48:55.955Z'
+      lastVerified: '2026-05-17T10:02:45.398Z'
     deployment-config-loader:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/deployment-config-loader.js
       layer: L2
@@ -16666,6 +18079,7 @@ entities:
         - loader
       usedBy:
         - setup-project-docs
+        - documentation-integrity-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -16675,7 +18089,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c58e84348a50a7587de3068fe7dcf69a22478cd4e96a5c44d9b9f7f814c64925
-      lastVerified: '2026-03-11T00:48:55.955Z'
+      lastVerified: '2026-05-17T10:02:45.398Z'
     doc-generator:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/doc-generator.js
       layer: L2
@@ -16686,6 +18100,7 @@ entities:
         - generator
       usedBy:
         - setup-project-docs
+        - documentation-integrity-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -16695,7 +18110,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6e58a80fc61b5af4780e98ac5c0c7070b1ed6281a776303d7550ad717b933afb
-      lastVerified: '2026-03-11T00:48:55.956Z'
+      lastVerified: '2026-05-17T10:02:45.398Z'
     gitignore-generator:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/gitignore-generator.js
       layer: L2
@@ -16707,6 +18122,7 @@ entities:
         - '========================================'
       usedBy:
         - setup-project-docs
+        - documentation-integrity-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -16716,7 +18132,31 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fc79c0c5311f3043a07a9e08480a70c8a1328ac6e00679a5141de8226c5dd4ca
-      lastVerified: '2026-03-11T00:48:55.956Z'
+      lastVerified: '2026-05-17T10:02:45.399Z'
+    documentation-integrity-index:
+      path: .aiox-core/infrastructure/scripts/documentation-integrity/index.js
+      layer: L2
+      type: script
+      purpose: Entity at .aiox-core/infrastructure/scripts/documentation-integrity/index.js
+      keywords:
+        - index
+      usedBy: []
+      dependencies:
+        - mode-detector
+        - doc-generator
+        - config-generator
+        - deployment-config-loader
+        - gitignore-generator
+        - brownfield-analyzer
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: experimental
+      adaptability:
+        score: 0.7
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:8e51de74ca904fccc4650df494e6a202766b57cba1883d3a1b5ef90d2831d7f7
+      lastVerified: '2026-05-17T10:02:45.399Z'
     mode-detector:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/mode-detector.js
       layer: L2
@@ -16728,6 +18168,7 @@ entities:
       usedBy:
         - analyze-brownfield
         - setup-project-docs
+        - documentation-integrity-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -16737,7 +18178,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:955af283f28d088d844b6e3f388b48caf265d746ff499599973196cb07612730
-      lastVerified: '2026-03-11T00:48:55.956Z'
+      lastVerified: '2026-05-17T10:02:45.399Z'
     post-commit:
       path: .aiox-core/infrastructure/scripts/git-hooks/post-commit.js
       layer: L2
@@ -16756,7 +18197,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a7eea0e43a254804a09fc09a94c9c44d8da0b285ce5dc2ea6149d426732fd917
-      lastVerified: '2026-03-11T00:48:55.956Z'
+      lastVerified: '2026-05-17T10:02:45.400Z'
     agent-parser:
       path: .aiox-core/infrastructure/scripts/ide-sync/agent-parser.js
       layer: L2
@@ -16766,8 +18207,10 @@ entities:
         - agent
         - parser
       usedBy:
+        - repair-agent-references
         - index
         - validate
+        - ide-sync-index
         - antigravity
         - cursor
         - github-copilot
@@ -16779,8 +18222,8 @@ entities:
         score: 0.7
         constraints: []
         extensionPoints: []
-      checksum: sha256:b4dceac261653d85d791b6cd8b010ebfaa75cab179477b193a2448482b4aa4d4
-      lastVerified: '2026-03-11T00:48:55.956Z'
+      checksum: sha256:f1ed4d0e6dda1a616efb0cb31157fe36063cf9481c19ee7b4bada26cb12e0e80
+      lastVerified: '2026-05-17T10:02:45.400Z'
     gemini-commands:
       path: .aiox-core/infrastructure/scripts/ide-sync/gemini-commands.js
       layer: L2
@@ -16789,27 +18232,8 @@ entities:
       keywords:
         - gemini
         - commands
-      usedBy: []
-      dependencies: []
-      externalDeps: []
-      plannedDeps: []
-      lifecycle: orphan
-      adaptability:
-        score: 0.7
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:ba02b21af0d485b14d6e248b6d5644090646dc792f78eac515d17b88680d8549
-      lastVerified: '2026-03-11T00:48:55.956Z'
-    redirect-generator:
-      path: .aiox-core/infrastructure/scripts/ide-sync/redirect-generator.js
-      layer: L2
-      type: script
-      purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/redirect-generator.js
-      keywords:
-        - redirect
-        - generator
       usedBy:
-        - validator
+        - ide-sync-index
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -16818,18 +18242,25 @@ entities:
         score: 0.7
         constraints: []
         extensionPoints: []
-      checksum: sha256:89ead2308414418e83fb66f591abddabd7137d87b57adca129fa57d119780b2a
-      lastVerified: '2026-03-11T00:48:55.956Z'
-    validator:
-      path: .aiox-core/infrastructure/scripts/ide-sync/validator.js
+      checksum: sha256:ba02b21af0d485b14d6e248b6d5644090646dc792f78eac515d17b88680d8549
+      lastVerified: '2026-05-17T10:02:45.400Z'
+    ide-sync-index:
+      path: .aiox-core/infrastructure/scripts/ide-sync/index.js
       layer: L2
       type: script
-      purpose: '{'
+      purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/index.js
       keywords:
-        - validator
+        - index
       usedBy: []
       dependencies:
+        - agent-parser
         - redirect-generator
+        - validator
+        - gemini-commands
+        - claude-code
+        - cursor
+        - antigravity
+        - github-copilot
       externalDeps: []
       plannedDeps: []
       lifecycle: experimental
@@ -16837,8 +18268,50 @@ entities:
         score: 0.7
         constraints: []
         extensionPoints: []
-      checksum: sha256:356c78125db7f88d14f4e521808e96593d729291c3d7a1c36cb02f78b4aef8fc
-      lastVerified: '2026-03-11T00:48:55.956Z'
+      checksum: sha256:2ea2fe3a070010da33be2fed3d75c305d3414cf515c1bf5fbafb334e0a7da5fa
+      lastVerified: '2026-05-17T10:02:45.401Z'
+    redirect-generator:
+      path: .aiox-core/infrastructure/scripts/ide-sync/redirect-generator.js
+      layer: L2
+      type: script
+      purpose: '''AIOX redirect from @${safeOldId} to @${safeNewId}'''
+      keywords:
+        - redirect
+        - generator
+      usedBy:
+        - ide-sync-index
+        - validator
+      dependencies:
+        - cursor
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.7
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:5bebf478e331716b4fb42d624076eb2570c90c4aa829427c700995d6b9ec361e
+      lastVerified: '2026-05-17T10:02:45.401Z'
+    validator:
+      path: .aiox-core/infrastructure/scripts/ide-sync/validator.js
+      layer: L2
+      type: script
+      purpose: '{'
+      keywords:
+        - validator
+      usedBy:
+        - ide-sync-index
+      dependencies:
+        - redirect-generator
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.7
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:768eba65a0f8ff937c34f6f43fe1b4dc990f2d406e592bc1cda0f8ab5b4f7e0b
+      lastVerified: '2026-05-17T10:02:45.401Z'
     install-llm-routing:
       path: .aiox-core/infrastructure/scripts/llm-routing/install-llm-routing.js
       layer: L2
@@ -16859,7 +18332,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c9faab7f6149a8046abe5c9a026055c5f386cfef700136b76e5fa579e60bed8
-      lastVerified: '2026-03-11T00:48:55.956Z'
+      lastVerified: '2026-05-17T10:02:45.401Z'
     antigravity:
       path: .aiox-core/infrastructure/scripts/ide-sync/transformers/antigravity.js
       layer: L2
@@ -16867,26 +18340,96 @@ entities:
       purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/transformers/antigravity.js
       keywords:
         - antigravity
-      usedBy: []
+      usedBy:
+        - ide-sync-index
       dependencies:
         - agent-parser
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: production
       adaptability:
         score: 0.7
         constraints: []
         extensionPoints: []
       checksum: sha256:e00910c008c8547a1943f79c676d0a4c0d014b638fc15c8a68e2574d6949744b
-      lastVerified: '2026-03-11T00:48:55.956Z'
+      lastVerified: '2026-05-17T10:02:45.402Z'
     claude-code:
       path: .aiox-core/infrastructure/scripts/ide-sync/transformers/claude-code.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/transformers/claude-code.js
+      purpose: ${quoteYamlString(description)}
       keywords:
         - claude
         - code
+      usedBy:
+        - health-check-checks-services-index
+        - ide-sync-index
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.7
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:364ef939d1392397d13942dfc2360a3a75ff8edd77cd0ba88fc29622d5f75fd5
+      lastVerified: '2026-05-17T10:02:45.402Z'
+    cursor:
+      path: .aiox-core/infrastructure/scripts/ide-sync/transformers/cursor.js
+      layer: L2
+      type: script
+      purpose: '''${description}'''
+      keywords:
+        - cursor
+        - ${name}
+        - (@${agentdata.id})
+      usedBy:
+        - ide-sync-index
+        - redirect-generator
+      dependencies:
+        - agent-parser
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.7
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:9a38f664747ea71472585d4f8c3e52b844dc75a39a526f5873e6bf97370a4723
+      lastVerified: '2026-05-17T10:02:45.402Z'
+    github-copilot:
+      path: .aiox-core/infrastructure/scripts/ide-sync/transformers/github-copilot.js
+      layer: L2
+      type: script
+      purpose: '''${description}''`,'
+      keywords:
+        - github
+        - copilot
+      usedBy:
+        - ide-sync-index
+      dependencies:
+        - agent-parser
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: production
+      adaptability:
+        score: 0.7
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:6d365be4a55e2f5ced316a0efbfa50fb925562f3e145d47a86c57a2c685343ac
+      lastVerified: '2026-05-17T10:02:45.402Z'
+    kimi:
+      path: .aiox-core/infrastructure/scripts/ide-sync/transformers/kimi.js
+      layer: L2
+      type: script
+      purpose: ${JSON.stringify(description)}
+      keywords:
+        - kimi
+        - ${icon}
+        - '@${id}'
+        - ${name}${archetype
+        - '!=='
+        - '''specialist'''
       usedBy: []
       dependencies: []
       externalDeps: []
@@ -16896,47 +18439,26 @@ entities:
         score: 0.7
         constraints: []
         extensionPoints: []
-      checksum: sha256:82eea7091a8bdc89f9067dd420b535574c9bdb2dee8c616eda99758069328a84
-      lastVerified: '2026-03-11T00:48:55.957Z'
-    cursor:
-      path: .aiox-core/infrastructure/scripts/ide-sync/transformers/cursor.js
+      checksum: sha256:69a6b34e81ba956242ff38cfce4063d9a0d9e32818a5f36e0246d80e41940def
+      lastVerified: '2026-05-17T10:02:45.403Z'
+    llm-routing-usage-tracker-index:
+      path: .aiox-core/infrastructure/scripts/llm-routing/usage-tracker/index.js
       layer: L2
       type: script
-      purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/transformers/cursor.js
+      purpose: Entity at .aiox-core/infrastructure/scripts/llm-routing/usage-tracker/index.js
       keywords:
-        - cursor
+        - index
       usedBy: []
-      dependencies:
-        - agent-parser
+      dependencies: []
       externalDeps: []
       plannedDeps: []
-      lifecycle: experimental
+      lifecycle: orphan
       adaptability:
         score: 0.7
         constraints: []
         extensionPoints: []
-      checksum: sha256:c24d24e4bec477c3b75340aeac08c5a4a2780001eec9c25e6b00d4f0af53d4f0
-      lastVerified: '2026-03-11T00:48:55.957Z'
-    github-copilot:
-      path: .aiox-core/infrastructure/scripts/ide-sync/transformers/github-copilot.js
-      layer: L2
-      type: script
-      purpose: '''${description}''`,'
-      keywords:
-        - github
-        - copilot
-      usedBy: []
-      dependencies:
-        - agent-parser
-      externalDeps: []
-      plannedDeps: []
-      lifecycle: experimental
-      adaptability:
-        score: 0.7
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:6d365be4a55e2f5ced316a0efbfa50fb925562f3e145d47a86c57a2c685343ac
-      lastVerified: '2026-03-11T00:48:55.957Z'
+      checksum: sha256:b49216115de498113a754f9c87fe9834f6262abaa6db3b54c87c06fbdc632905
+      lastVerified: '2026-05-17T10:02:45.403Z'
   infra-tools:
     README:
       path: .aiox-core/infrastructure/tools/README.md
@@ -16962,7 +18484,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2f8f4141b9f4a71ad51668d28fc9a12362835dd40eb45992c645f9bfe28f8a48
-      lastVerified: '2026-03-11T00:48:55.958Z'
+      lastVerified: '2026-05-17T10:02:45.405Z'
     github-cli:
       path: .aiox-core/infrastructure/tools/cli/github-cli.yaml
       layer: L2
@@ -16976,6 +18498,7 @@ entities:
       usedBy:
         - environment-bootstrap
         - setup-github
+        - health-check-checks-services-index
         - devops
         - po
       dependencies: []
@@ -16987,7 +18510,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:222ca6016e9487d2da13bead0af5cee6099885ea438b359ff5fa5a73c7cd4820
-      lastVerified: '2026-03-11T00:48:55.958Z'
+      lastVerified: '2026-05-17T10:02:45.405Z'
     llm-routing:
       path: .aiox-core/infrastructure/tools/cli/llm-routing.yaml
       layer: L2
@@ -17009,7 +18532,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d97183f254876933de02d9ad2c793ad7d06e37dd0c4f9da9fb68097a5d0eedb3
-      lastVerified: '2026-03-11T00:48:55.958Z'
+      lastVerified: '2026-05-17T10:02:45.405Z'
     railway-cli:
       path: .aiox-core/infrastructure/tools/cli/railway-cli.yaml
       layer: L2
@@ -17030,7 +18553,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cab769df07cfd0a65bfed0e7140dfde3bf3c54cd6940452d2d18e18f99a63e4a
-      lastVerified: '2026-03-11T00:48:55.958Z'
+      lastVerified: '2026-05-17T10:02:45.405Z'
     supabase-cli:
       path: .aiox-core/infrastructure/tools/cli/supabase-cli.yaml
       layer: L2
@@ -17054,7 +18577,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:659fefd3d8b182dd06fc5be560fcf386a028156386b2029cd51bbd7d3b5e6bfd
-      lastVerified: '2026-03-11T00:48:55.959Z'
+      lastVerified: '2026-05-17T10:02:45.406Z'
     ffmpeg:
       path: .aiox-core/infrastructure/tools/local/ffmpeg.yaml
       layer: L2
@@ -17073,7 +18596,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d481a548e0eb327513412c7ac39e4a92ac27a283f4b9e6c43211fed52281df44
-      lastVerified: '2026-03-11T00:48:55.959Z'
+      lastVerified: '2026-05-17T10:02:45.406Z'
     21st-dev-magic:
       path: .aiox-core/infrastructure/tools/mcp/21st-dev-magic.yaml
       layer: L2
@@ -17096,7 +18619,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5e1b575bdb51c6b5d446a2255fa068194d2010bce56c8c0dd0b2e98e3cf61f18
-      lastVerified: '2026-03-11T00:48:55.959Z'
+      lastVerified: '2026-05-17T10:02:45.406Z'
     browser:
       path: .aiox-core/infrastructure/tools/mcp/browser.yaml
       layer: L2
@@ -17117,7 +18640,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c28206d92a6127d299ca60955cd6f6d03c940ac8b221f1e9fc620dd7efd7b471
-      lastVerified: '2026-03-11T00:48:55.959Z'
+      lastVerified: '2026-05-17T10:02:45.406Z'
     clickup:
       path: .aiox-core/infrastructure/tools/mcp/clickup.yaml
       layer: L2
@@ -17136,7 +18659,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:aa7c34786e8e332a3486b136f40ec997dcc2a7e408bbc99a8899b0653baac6ee
-      lastVerified: '2026-03-11T00:48:55.959Z'
+      lastVerified: '2026-05-17T10:02:45.407Z'
     context7:
       path: .aiox-core/infrastructure/tools/mcp/context7.yaml
       layer: L2
@@ -17162,7 +18685,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:321e0e23a787c36260efdbb1a3953235fa7dc57e77b211610ffaf33bc21fca02
-      lastVerified: '2026-03-11T00:48:55.959Z'
+      lastVerified: '2026-05-17T10:02:45.407Z'
     desktop-commander:
       path: .aiox-core/infrastructure/tools/mcp/desktop-commander.yaml
       layer: L2
@@ -17181,7 +18704,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec1a5db7def48d1762e68d4477ad0574bbb54a6783256870f5451c666ebdc213
-      lastVerified: '2026-03-11T00:48:55.959Z'
+      lastVerified: '2026-05-17T10:02:45.407Z'
     exa:
       path: .aiox-core/infrastructure/tools/mcp/exa.yaml
       layer: L2
@@ -17203,7 +18726,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:02576ff68b8de8a2d4e6aaffaeade78d5c208b95380feeacb37e2105c6f83541
-      lastVerified: '2026-03-11T00:48:55.959Z'
+      lastVerified: '2026-05-17T10:02:45.407Z'
     google-workspace:
       path: .aiox-core/infrastructure/tools/mcp/google-workspace.yaml
       layer: L2
@@ -17225,7 +18748,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f017c3154e9d480f37d94c7ddd7c3d24766b4fa7e0ee9e722600e85da75734b4
-      lastVerified: '2026-03-11T00:48:55.959Z'
+      lastVerified: '2026-05-17T10:02:45.407Z'
     n8n:
       path: .aiox-core/infrastructure/tools/mcp/n8n.yaml
       layer: L2
@@ -17244,7 +18767,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f9d9536ec47f9911e634083c3ac15cb920214ea0f052e78d4c6a27a17e9ec408
-      lastVerified: '2026-03-11T00:48:55.959Z'
+      lastVerified: '2026-05-17T10:02:45.408Z'
     supabase:
       path: .aiox-core/infrastructure/tools/mcp/supabase.yaml
       layer: L2
@@ -17266,7 +18789,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:350bd31537dfef9c3df55bd477434ccbe644cdf0dd3408bf5a8a6d0c5ba78aa2
-      lastVerified: '2026-03-11T00:48:55.960Z'
+      lastVerified: '2026-05-17T10:02:45.408Z'
   product-checklists:
     accessibility-wcag-checklist:
       path: .aiox-core/product/checklists/accessibility-wcag-checklist.md
@@ -17288,7 +18811,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:56126182b25e9b7bdde43f75315e33167eb49b1f9a9cb0e9a37bc068af40aeab
-      lastVerified: '2026-03-11T00:48:55.960Z'
+      lastVerified: '2026-05-17T10:02:45.409Z'
     architect-checklist:
       path: .aiox-core/product/checklists/architect-checklist.md
       layer: L2
@@ -17311,7 +18834,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ecbcc8e6b34f813bc73ebcc28482c045ef12c6b17808ee6f70a808eee1818911
-      lastVerified: '2026-03-11T00:48:55.960Z'
+      lastVerified: '2026-05-17T10:02:45.410Z'
     change-checklist:
       path: .aiox-core/product/checklists/change-checklist.md
       layer: L2
@@ -17344,7 +18867,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:edaa126d5db726fce3a422be6441928b1177fe13e5e8defe2d2cb8959acd1439
-      lastVerified: '2026-03-11T00:48:55.960Z'
+      lastVerified: '2026-05-17T10:02:45.410Z'
     component-quality-checklist:
       path: .aiox-core/product/checklists/component-quality-checklist.md
       layer: L2
@@ -17365,7 +18888,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec4e34a3fc4a071d346a8ba473f521d2a38e5eb07d1656fee6ff108e5cd7b62f
-      lastVerified: '2026-03-11T00:48:55.960Z'
+      lastVerified: '2026-05-17T10:02:45.410Z'
     database-design-checklist:
       path: .aiox-core/product/checklists/database-design-checklist.md
       layer: L2
@@ -17386,7 +18909,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6d3cf038f0320db0e6daf9dba61e4c29269ed73c793df5618e155ebd07b6c200
-      lastVerified: '2026-03-11T00:48:55.960Z'
+      lastVerified: '2026-05-17T10:02:45.411Z'
     dba-predeploy-checklist:
       path: .aiox-core/product/checklists/dba-predeploy-checklist.md
       layer: L2
@@ -17408,7 +18931,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:482136936a2414600b59d4d694526c008287e3376ed73c9a93de78d7d7bd3285
-      lastVerified: '2026-03-11T00:48:55.961Z'
+      lastVerified: '2026-05-17T10:02:45.411Z'
     dba-rollback-checklist:
       path: .aiox-core/product/checklists/dba-rollback-checklist.md
       layer: L2
@@ -17429,7 +18952,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:060847cba7ef223591c2c1830c65994fd6cf8135625d6953a3a5b874301129c5
-      lastVerified: '2026-03-11T00:48:55.961Z'
+      lastVerified: '2026-05-17T10:02:45.411Z'
     migration-readiness-checklist:
       path: .aiox-core/product/checklists/migration-readiness-checklist.md
       layer: L2
@@ -17450,7 +18973,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6231576966f24b30c00fe7cc836359e10c870c266a30e5d88c6b3349ad2f1d17
-      lastVerified: '2026-03-11T00:48:55.961Z'
+      lastVerified: '2026-05-17T10:02:45.411Z'
     pattern-audit-checklist:
       path: .aiox-core/product/checklists/pattern-audit-checklist.md
       layer: L2
@@ -17471,7 +18994,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2eb28cb0e7abd8900170123c1d080c1bbb81ccb857eeb162c644f40616b0875e
-      lastVerified: '2026-03-11T00:48:55.961Z'
+      lastVerified: '2026-05-17T10:02:45.411Z'
     pm-checklist:
       path: .aiox-core/product/checklists/pm-checklist.md
       layer: L2
@@ -17496,7 +19019,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6828efd3acf32638e31b8081ca0c6f731aa5710c8413327db5a8096b004aeb2b
-      lastVerified: '2026-03-11T00:48:55.961Z'
+      lastVerified: '2026-05-17T10:02:45.412Z'
     po-master-checklist:
       path: .aiox-core/product/checklists/po-master-checklist.md
       layer: L2
@@ -17532,7 +19055,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:506a3032f461c7ae96c338600208575be4f4823d2fe7c92fe304a4ff07cc5390
-      lastVerified: '2026-03-11T00:48:55.961Z'
+      lastVerified: '2026-05-17T10:02:45.412Z'
     pre-push-checklist:
       path: .aiox-core/product/checklists/pre-push-checklist.md
       layer: L2
@@ -17556,7 +19079,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8b96f7216101676b86b314c347fa8c6d616cde21dbc77ef8f77b8d0b5770af2a
-      lastVerified: '2026-03-11T00:48:55.961Z'
+      lastVerified: '2026-05-17T10:02:45.413Z'
     release-checklist:
       path: .aiox-core/product/checklists/release-checklist.md
       layer: L2
@@ -17577,7 +19100,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a5e66e27d115abd544834a70f3dda429bc486fbcb569870031c4f79fd8ac6187
-      lastVerified: '2026-03-11T00:48:55.961Z'
+      lastVerified: '2026-05-17T10:02:45.413Z'
     self-critique-checklist:
       path: .aiox-core/product/checklists/self-critique-checklist.md
       layer: L2
@@ -17601,7 +19124,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9f257660bb386ea315fe4ab8b259897058d279e66338801db234c25750be9c2c
-      lastVerified: '2026-03-11T00:48:55.961Z'
+      lastVerified: '2026-05-17T10:02:45.414Z'
     story-dod-checklist:
       path: .aiox-core/product/checklists/story-dod-checklist.md
       layer: L2
@@ -17626,7 +19149,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:725b60a16a41886a92794e54b9efa8359eab5f09813cd584fa9e8e1519c78dc4
-      lastVerified: '2026-03-11T00:48:55.961Z'
+      lastVerified: '2026-05-17T10:02:45.414Z'
     story-draft-checklist:
       path: .aiox-core/product/checklists/story-draft-checklist.md
       layer: L2
@@ -17651,7 +19174,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cf500e2a8a471573d25f3d73439a41fffea9f5351963c598fd2285ec909f96ce
-      lastVerified: '2026-03-11T00:48:55.962Z'
+      lastVerified: '2026-05-17T10:02:45.415Z'
   product-data:
     atomic-design-principles:
       path: .aiox-core/product/data/atomic-design-principles.md
@@ -17672,7 +19195,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:66153135e28394178c4f8f33441c45a2404587c2f07d25ad09dde54f3f5e1746
-      lastVerified: '2026-03-11T00:48:55.962Z'
+      lastVerified: '2026-05-17T10:02:45.416Z'
     brainstorming-techniques:
       path: .aiox-core/product/data/brainstorming-techniques.md
       layer: L2
@@ -17692,7 +19215,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c5a558d21eb620a8c820d8ca9807b2d12c299375764289482838f81ef63dbce
-      lastVerified: '2026-03-11T00:48:55.962Z'
+      lastVerified: '2026-05-17T10:02:45.416Z'
     consolidation-algorithms:
       path: .aiox-core/product/data/consolidation-algorithms.md
       layer: L2
@@ -17712,7 +19235,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2f2561be9e6281f6352f05e1c672954001f919c4664e3fecd6fcde24fdd4d240
-      lastVerified: '2026-03-11T00:48:55.962Z'
+      lastVerified: '2026-05-17T10:02:45.416Z'
     database-best-practices:
       path: .aiox-core/product/data/database-best-practices.md
       layer: L2
@@ -17733,7 +19256,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8331f001e903283633f0123d123546ef3d4682ed0e0f9516b4df391fe57b9b7d
-      lastVerified: '2026-03-11T00:48:55.962Z'
+      lastVerified: '2026-05-17T10:02:45.417Z'
     design-token-best-practices:
       path: .aiox-core/product/data/design-token-best-practices.md
       layer: L2
@@ -17754,7 +19277,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:10cf3c824bba452ee598e2325b8bfb2068f188d9ac3058b9e034ddf34bf4791a
-      lastVerified: '2026-03-11T00:48:55.962Z'
+      lastVerified: '2026-05-17T10:02:45.417Z'
     elicitation-methods:
       path: .aiox-core/product/data/elicitation-methods.md
       layer: L2
@@ -17774,7 +19297,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f8e46f90bd0acc1e9697086d7a2008c7794bc767e99d0037c64e6800e9d17ef4
-      lastVerified: '2026-03-11T00:48:55.962Z'
+      lastVerified: '2026-05-17T10:02:45.417Z'
     integration-patterns:
       path: .aiox-core/product/data/integration-patterns.md
       layer: L2
@@ -17794,7 +19317,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b771f999fb452dcabf835d5f5e5ae3982c48cece5941cc5a276b6f280062db43
-      lastVerified: '2026-03-11T00:48:55.962Z'
+      lastVerified: '2026-05-17T10:02:45.417Z'
     migration-safety-guide:
       path: .aiox-core/product/data/migration-safety-guide.md
       layer: L2
@@ -17815,7 +19338,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:42200ca180d4586447304dfc7f8035ccd09860b6ac34c72b63d284e57c94d2db
-      lastVerified: '2026-03-11T00:48:55.962Z'
+      lastVerified: '2026-05-17T10:02:45.418Z'
     mode-selection-best-practices:
       path: .aiox-core/product/data/mode-selection-best-practices.md
       layer: L2
@@ -17836,7 +19359,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4ed5ee7aaeadb2e3c12029b7cae9a6063f3a7b016fdd0d53f9319d461ddf3ea1
-      lastVerified: '2026-03-11T00:48:55.963Z'
+      lastVerified: '2026-05-17T10:02:45.418Z'
     postgres-tuning-guide:
       path: .aiox-core/product/data/postgres-tuning-guide.md
       layer: L2
@@ -17858,7 +19381,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4715262241ae6ba2da311865506781bd7273fa6ee1bd55e15968dfda542c2bec
-      lastVerified: '2026-03-11T00:48:55.963Z'
+      lastVerified: '2026-05-17T10:02:45.418Z'
     rls-security-patterns:
       path: .aiox-core/product/data/rls-security-patterns.md
       layer: L2
@@ -17881,7 +19404,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e3e12a06b483c1bda645e7eb361a230bdef106cc5d1140a69b443a4fc2ad70ef
-      lastVerified: '2026-03-11T00:48:55.963Z'
+      lastVerified: '2026-05-17T10:02:45.418Z'
     roi-calculation-guide:
       path: .aiox-core/product/data/roi-calculation-guide.md
       layer: L2
@@ -17901,7 +19424,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f00a3c039297b3cb6e00f68d5feb6534a27c2a0ad02afd14df50e4e0cf285aa4
-      lastVerified: '2026-03-11T00:48:55.963Z'
+      lastVerified: '2026-05-17T10:02:45.419Z'
     supabase-patterns:
       path: .aiox-core/product/data/supabase-patterns.md
       layer: L2
@@ -17921,7 +19444,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9ed119bc89f859125a0489036d747ff13b6c475a9db53946fdb7f3be02b41e0a
-      lastVerified: '2026-03-11T00:48:55.963Z'
+      lastVerified: '2026-05-17T10:02:45.419Z'
     test-levels-framework:
       path: .aiox-core/product/data/test-levels-framework.md
       layer: L2
@@ -17941,7 +19464,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b9a50f9c3b5b153280c93ea30f823f30deb2ba7aea588039b5a2bdea0b23891e
-      lastVerified: '2026-03-11T00:48:55.963Z'
+      lastVerified: '2026-05-17T10:02:45.419Z'
     test-priorities-matrix:
       path: .aiox-core/product/data/test-priorities-matrix.md
       layer: L2
@@ -17961,7 +19484,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c97c7279f23ed42ea2588814f204432a93d658d9b5a9914e34647db796a70a60
-      lastVerified: '2026-03-11T00:48:55.963Z'
+      lastVerified: '2026-05-17T10:02:45.419Z'
     wcag-compliance-guide:
       path: .aiox-core/product/data/wcag-compliance-guide.md
       layer: L2
@@ -17981,7 +19504,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8f5a97e1522da2193e2a2eae18dc68c4477acf3e2471b50b46885163cefa40e6
-      lastVerified: '2026-03-11T00:48:55.963Z'
+      lastVerified: '2026-05-17T10:02:45.419Z'
 categories:
   - id: tasks
     description: Executable task workflows for agent operations

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -7,8 +7,8 @@
 # - SHA256 hashes for change detection
 # - File types for categorization
 #
-version: 5.2.2
-generated_at: "2026-05-12T20:19:35.126Z"
+version: 5.2.6
+generated_at: "2026-05-17T10:06:35.754Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1128
 files:
@@ -1297,9 +1297,9 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:84acf809f112cb726710a9878904db6b9d5c0eb487a2e578de25ede0c2177c5e
+    hash: sha256:5dac372c022f1da390b923a2ce2c719deb2ed3916464925be788b26596f31fdf
     type: data
-    size: 529247
+    size: 574327
   - path: data/learned-patterns.yaml
     hash: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
     type: data

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to Synkra AIOX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.6] - 2026-05-17
+
+### Fixed
+
+- Pro installer no longer fails with `Installed Pro artifact did not create node_modules/@aiox-squads/pro` when `aiox install` runs in a directory that sits beneath an ancestor with a `package.json` or a declared `workspaces:` array (#742).
+  - Root cause: `npm install <tgz>` walked the directory tree and resolved to the ancestor instead of the chosen target.
+  - Fix: pass `--prefix=<targetDir> --workspaces=false --include-workspace-root=false`; create a synthetic anchor `package.json` when the target is empty and clean it up afterwards; fall back to the sha256-verified Pro source from the temp cache if the target install still fails, with an explicit user-facing warning.
+- Improved diagnostic when an installer failure does occur: the error message now reports where npm actually placed the artifact (when detectable) so students can recover quickly.
+
+### Added
+
+- `tests/installer/pro-setup-target-install.test.js` — 8 regression tests covering the four real install topologies (empty target, ancestor with `workspaces:`, ancestor with plain `package.json`, target with its own `package.json`), the synthetic anchor cleanup, the diagnostic helper, and the graceful-fallback contract.
+- `.github/workflows/installer-smoke-matrix.yml` — pre-publish CI matrix (Ubuntu/macOS/Windows × Node 18/20/22 × npm 10/11/bundled) running the regression suite plus three end-to-end smoke installs.
+
+### Notes
+
+- Students hit by the original error can update via `npx -y -p @aiox-squads/core@latest aiox install`. The fresh-directory workaround (`mkdir ~/aiox-pro && cd ~/aiox-pro`) is no longer required.
+
 ## [5.1.0] - 2026-05-06
 
 ### Changed

--- a/compat/aiox-core/package.json
+++ b/compat/aiox-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiox-core",
-  "version": "5.2.5",
+  "version": "5.2.6",
   "description": "Compatibility wrapper for @aiox-squads/core.",
   "license": "MIT",
   "bin": {
@@ -15,7 +15,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@aiox-squads/core": "5.2.5"
+    "@aiox-squads/core": "5.2.6"
   },
   "engines": {
     "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.2.4",
+  "version": "5.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aiox-squads/core",
-      "version": "5.2.4",
+      "version": "5.2.6",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -3103,9 +3103,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3120,9 +3117,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3137,9 +3131,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3154,9 +3145,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3171,9 +3159,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3188,9 +3173,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3205,9 +3187,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3222,9 +3201,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -14542,7 +14518,7 @@
     },
     "packages/installer": {
       "name": "@aiox-squads/installer",
-      "version": "3.3.4",
+      "version": "3.3.5",
       "license": "MIT",
       "dependencies": {
         "@aiox-squads/core": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.2.5",
+  "version": "5.2.6",
   "description": "Synkra AIOX: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aiox": "bin/aiox.js",

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/installer",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "description": "AIOX Installer - Automated setup wizard for AIOX projects (greenfield & brownfield)",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

Hotfix release for #742 (already merged in main as squash `20e79996`).

Bumps:
- `@aiox-squads/core`: 5.2.5 → **5.2.6**
- `aiox-core` (compat wrapper): 5.2.5 → **5.2.6** (+ dep `@aiox-squads/core`: 5.2.5 → 5.2.6)
- `@aiox-squads/installer`: 3.3.4 → **3.3.5**

## Why this exists

Cohort students hit `Pro activation failed: Installed Pro artifact did not create node_modules/@aiox-squads/pro` whenever they ran `aiox install` in a directory that sits beneath an ancestor with a `package.json` or a declared `workspaces:` array. Root cause was npm 10+ walking up to find a manifest. Fix in #742 anchors the install with `--prefix` + `--workspaces=false` and adds a graceful temp-cache fallback.

E2E validated against the real `@aiox-squads/pro@0.4.3` tgz across 5 install topologies (5/5 PASS):
1. Subpasta vazia + parent com `package.json` (cenário exato do print)
2. Subpasta de monorepo com `workspaces:`
3. Pasta fresh `~/aiox-pro` (happy path)
4. Projeto próprio com `package.json`
5. Sub-sub-subpasta com workspace 3 níveis acima

## Release mechanics

Merging this PR + pushing tag `v5.2.6` triggers `.github/workflows/npm-publish.yml`, which publishes to npmjs.org using `NPM_TOKEN_AIOX_SQUADS`. Tag push will follow immediately after merge.

## Test plan

- [x] `npm run lint` → clean
- [x] `npm run test:ci` → 8472 passed, 151 skipped, 0 failures (343 suites)
- [x] Installer regression suite → 259/259 (incl. 8 new hijack tests)
- [x] E2E with real Pro tgz → 5/5 PASS
- [x] Versions consistent across package.json, compat/aiox-core/package.json, packages/installer/package.json, package-lock.json
- [ ] After merge: tag v5.2.6, push tag, watch `npm-publish.yml` workflow, verify `npm view @aiox-squads/core version` returns 5.2.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Pro installer failing when running from directories nested under `package.json` or workspaces declarations, with improved error diagnostics.

* **Documentation**
  * Updated setup guidance with simplified one-command workaround and removed previous manual workaround.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/743?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->