### PR TITLE
fix(ids): skip unfilled placeholders in extractPurpose priority chain

### DIFF
--- a/.aiox-core/data/entity-registry.yaml
+++ b/.aiox-core/data/entity-registry.yaml
@@ -1,7 +1,7 @@
 metadata:
   version: 1.0.0
-  lastUpdated: '2026-05-17T13:08:28.431Z'
-  entityCount: 816
+  lastUpdated: '2026-05-17T14:15:04.693Z'
+  entityCount: 815
   checksumAlgorithm: sha256
   resolutionRate: 100
 entities:
@@ -16,7 +16,8 @@ entities:
         - mcp
         - server
         - task
-      usedBy: []
+      usedBy:
+        - devops
       dependencies:
         - analyst
       externalDeps: []
@@ -27,7 +28,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:badc8a9859cb313e908d4ea0f4c4d7bc1be723214e38f26d55c366689fe5e3f0
-      lastVerified: '2026-05-17T10:02:45.082Z'
+      lastVerified: '2026-05-17T14:15:04.334Z'
     advanced-elicitation:
       path: .aiox-core/development/tasks/advanced-elicitation.md
       layer: L2
@@ -52,12 +53,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:897f36c94fc1e4e40c9e5728f3c7780515b40742d6a99366a5fdb5df109f6636
-      lastVerified: '2026-05-17T10:02:45.084Z'
+      lastVerified: '2026-05-17T14:15:04.336Z'
     analyst-facilitate-brainstorming:
       path: .aiox-core/development/tasks/analyst-facilitate-brainstorming.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: No checklists needed - this task facilitates brainstorming sessions, validation is through user interaction
       keywords:
         - analyst
         - facilitate
@@ -79,7 +80,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:85bef3ab05f3e3422ff450e7d39f04f49e59fa981df2f126eeb0f8395e4a1625
-      lastVerified: '2026-05-17T10:02:45.084Z'
+      lastVerified: '2026-05-17T14:15:04.336Z'
     analyze-brownfield:
       path: .aiox-core/development/tasks/analyze-brownfield.md
       layer: L2
@@ -107,7 +108,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0d1c35b32db5ae058ee29c125b1a7ce6d39bfd37d82711aad3abe780ef99cef3
-      lastVerified: '2026-05-17T10:02:45.085Z'
+      lastVerified: '2026-05-17T14:15:04.337Z'
     analyze-cross-artifact:
       path: .aiox-core/development/tasks/analyze-cross-artifact.md
       layer: L2
@@ -133,12 +134,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ce335d997ddd6438c298b18386ab72414959f24e6176736f12ee26ea5764432b
-      lastVerified: '2026-05-17T10:02:45.086Z'
+      lastVerified: '2026-05-17T14:15:04.337Z'
     analyze-framework:
       path: .aiox-core/development/tasks/analyze-framework.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Analyze Framework'
       keywords:
         - analyze
         - framework
@@ -162,12 +163,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6f3bb2f12ad42600cb38d6a1677608772bf8cb63a1e5971c987400ebf3e1d685
-      lastVerified: '2026-05-17T10:02:45.087Z'
+      lastVerified: '2026-05-17T14:15:04.338Z'
     analyze-performance:
       path: .aiox-core/development/tasks/analyze-performance.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Analyze Performance'
       keywords:
         - analyze
         - performance
@@ -186,14 +187,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c3a78a8794d2edfbf44525e1bbe286bb957dcc0fbbee5d9b8a7876a8d0cdce4
-      lastVerified: '2026-05-17T10:02:45.087Z'
+      lastVerified: '2026-05-17T14:15:04.339Z'
     analyze-project-structure:
       path: .aiox-core/development/tasks/analyze-project-structure.md
       layer: L2
       type: task
-      purpose: >-
-        ** Analyze an existing AIOX project to understand its structure, services, patterns, and provide recommendations
-        for implementing new features. This is Phase 1 of the Incremental Feature Workflow.
+      purpose: Analyze Project Structure
       keywords:
         - analyze
         - project
@@ -218,7 +217,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0f6acf877e5fa93796418576c239ea300226c4fb6fe28639239da8cc8225a57e
-      lastVerified: '2026-05-17T10:02:45.087Z'
+      lastVerified: '2026-05-17T14:15:04.339Z'
     apply-qa-fixes:
       path: .aiox-core/development/tasks/apply-qa-fixes.md
       layer: L2
@@ -244,7 +243,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:614731439a27c15ecc02d84abf3d320c2cf18f016075c222ca1d7bfda12d6625
-      lastVerified: '2026-05-17T10:02:45.088Z'
+      lastVerified: '2026-05-17T14:15:04.340Z'
     architect-analyze-impact:
       path: .aiox-core/development/tasks/architect-analyze-impact.md
       layer: L2
@@ -261,6 +260,8 @@ entities:
         - modification-risk-assessment
         - visual-impact-generator
         - approval-workflow
+        - analyst
+        - pm
       externalDeps: []
       plannedDeps:
         - change-propagation-predictor
@@ -273,12 +274,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73ad65e2263dac7a5a3aa64736d2c803c8a532c269b83fb98a61cb5729b689db
-      lastVerified: '2026-05-17T13:08:28.424Z'
+      lastVerified: '2026-05-17T14:15:04.341Z'
     audit-codebase:
       path: .aiox-core/development/tasks/audit-codebase.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Audit Codebase for UI Pattern Redundancy
       keywords:
         - audit
         - codebase
@@ -298,12 +299,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:11a136d6e7cd6d5238a06a9298eff28d381799667612aa7668d923cc40c74ff7
-      lastVerified: '2026-05-17T10:02:45.090Z'
+      lastVerified: '2026-05-17T14:15:04.341Z'
     audit-tailwind-config:
       path: .aiox-core/development/tasks/audit-tailwind-config.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Audit Tailwind v4 Configuration & Utility Health
       keywords:
         - audit
         - tailwind
@@ -323,7 +324,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6a555a7b86f2b447b0393b9ac1a7f2be84f5705c293259c83c082b25ec849fbb
-      lastVerified: '2026-05-17T10:02:45.090Z'
+      lastVerified: '2026-05-17T14:15:04.341Z'
     audit-utilities:
       path: .aiox-core/development/tasks/audit-utilities.md
       layer: L2
@@ -348,12 +349,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1a1e4cb6be031f144d223321c6977a88108843b05b933143784ce8340198acd3
-      lastVerified: '2026-05-17T10:02:45.090Z'
+      lastVerified: '2026-05-17T14:15:04.342Z'
     bootstrap-shadcn-library:
       path: .aiox-core/development/tasks/bootstrap-shadcn-library.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Bootstrap Shadcn/Radix Component Library
       keywords:
         - bootstrap
         - shadcn
@@ -374,7 +375,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3fe06f13e2ff550bab6b74cf2105f5902800e568fd7afc982dd3987c5579e769
-      lastVerified: '2026-05-17T10:02:45.091Z'
+      lastVerified: '2026-05-17T14:15:04.342Z'
     brownfield-create-epic:
       path: .aiox-core/development/tasks/brownfield-create-epic.md
       layer: L2
@@ -413,7 +414,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:554a403bdd14fdc0aa6236818d47b273e275f73b39971c3918e74978e28d9b68
-      lastVerified: '2026-05-17T10:02:45.092Z'
+      lastVerified: '2026-05-17T14:15:04.343Z'
     brownfield-create-story:
       path: .aiox-core/development/tasks/brownfield-create-story.md
       layer: L2
@@ -443,7 +444,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:29ba1fe81cda46bdece3e698cc797370c63df56903e38ca71523352b98e08dd2
-      lastVerified: '2026-05-17T10:02:45.092Z'
+      lastVerified: '2026-05-17T14:15:04.343Z'
     build-autonomous:
       path: .aiox-core/development/tasks/build-autonomous.md
       layer: L2
@@ -469,12 +470,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:90ea4c17a6a131082df1546fbe1f30817b951bba7a8b9a41a371578ce8034b39
-      lastVerified: '2026-05-17T10:02:45.092Z'
+      lastVerified: '2026-05-17T14:15:04.343Z'
     build-component:
       path: .aiox-core/development/tasks/build-component.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Build Production-Ready Component
       keywords:
         - build
         - component
@@ -494,7 +495,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:026adaf174a29692f4eef293a94f5909de9c79d25d7ed226740db1708cde4389
-      lastVerified: '2026-05-17T10:02:45.093Z'
+      lastVerified: '2026-05-17T14:15:04.344Z'
     build-resume:
       path: .aiox-core/development/tasks/build-resume.md
       layer: L2
@@ -517,7 +518,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:920b1faa39d021fd7c0013b5d2ac4f66ac6de844723821b65dfaceba41d37885
-      lastVerified: '2026-05-17T10:02:45.094Z'
+      lastVerified: '2026-05-17T14:15:04.344Z'
     build-status:
       path: .aiox-core/development/tasks/build-status.md
       layer: L2
@@ -539,7 +540,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:47a5f95ab59ff99532adf442700f4b949e32bd5bd2131998d8f271327108e4e1
-      lastVerified: '2026-05-17T10:02:45.094Z'
+      lastVerified: '2026-05-17T14:15:04.344Z'
     build:
       path: .aiox-core/development/tasks/build.md
       layer: L2
@@ -561,12 +562,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2f09d24cc0e5f9e4cf527fcb5341461a7ac30fcadf82e4f78f98be161e0ea4ec
-      lastVerified: '2026-05-17T10:02:45.094Z'
+      lastVerified: '2026-05-17T14:15:04.345Z'
     calculate-roi:
       path: .aiox-core/development/tasks/calculate-roi.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Calculate ROI and Cost Savings
       keywords:
         - calculate
         - roi
@@ -587,7 +588,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa8c2073ee845a42b30eea44e2452898ebb8e5d4fceb207c9b42984f817732cc
-      lastVerified: '2026-05-17T10:02:45.095Z'
+      lastVerified: '2026-05-17T14:15:04.345Z'
     check-docs-links:
       path: .aiox-core/development/tasks/check-docs-links.md
       layer: L2
@@ -598,7 +599,8 @@ entities:
         - docs
         - links
         - check-docs-links
-      usedBy: []
+      usedBy:
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -608,7 +610,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a7e1400d894777caa607486ff78b77ea454e4ace1c16d54308533ecc7f2c015
-      lastVerified: '2026-05-17T10:02:45.095Z'
+      lastVerified: '2026-05-17T14:15:04.345Z'
     ci-cd-configuration:
       path: .aiox-core/development/tasks/ci-cd-configuration.md
       layer: L2
@@ -623,7 +625,8 @@ entities:
         - configure
         - ci/cd
         - pipeline
-      usedBy: []
+      usedBy:
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -635,7 +638,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:115634392c1838eac80c7a5b760f43f96c92ad69c7a88d9932debed64e5ad23a
-      lastVerified: '2026-05-17T10:02:45.096Z'
+      lastVerified: '2026-05-17T14:15:04.345Z'
     cleanup-utilities:
       path: .aiox-core/development/tasks/cleanup-utilities.md
       layer: L2
@@ -663,7 +666,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8945dee3b0ea9afcab4aba1f4651be00d79ae236710a36821cf04238bee3890f
-      lastVerified: '2026-05-17T10:02:45.096Z'
+      lastVerified: '2026-05-17T14:15:04.346Z'
     cleanup-worktrees:
       path: .aiox-core/development/tasks/cleanup-worktrees.md
       layer: L2
@@ -676,6 +679,7 @@ entities:
       usedBy:
         - list-worktrees
         - remove-worktree
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -685,7 +689,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:10d9fab42ba133a03f76094829ab467d2ef53b80bcc3de39245805679cedfbbd
-      lastVerified: '2026-05-17T10:02:45.096Z'
+      lastVerified: '2026-05-17T14:15:04.346Z'
     collaborative-edit:
       path: .aiox-core/development/tasks/collaborative-edit.md
       layer: L2
@@ -713,12 +717,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9295eae7a7c8731ff06131f76dcd695d30641d714a64c164989b98d8631532d8
-      lastVerified: '2026-05-17T10:02:45.097Z'
+      lastVerified: '2026-05-17T14:15:04.346Z'
     compose-molecule:
       path: .aiox-core/development/tasks/compose-molecule.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Compose Molecule from Atoms
       keywords:
         - compose
         - molecule
@@ -740,12 +744,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:596b8a8e1a6068e02aceeb9d1164d64fe8686b492ff39d25ec8dcd67ad1f9c09
-      lastVerified: '2026-05-17T10:02:45.098Z'
+      lastVerified: '2026-05-17T14:15:04.347Z'
     consolidate-patterns:
       path: .aiox-core/development/tasks/consolidate-patterns.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Consolidate Patterns Using Intelligent Clustering
       keywords:
         - consolidate
         - patterns
@@ -766,7 +770,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c45d9337c0aac9fcea56e216e172234a4f09a09f45db311f013973f9d5efc05a
-      lastVerified: '2026-05-17T10:02:45.098Z'
+      lastVerified: '2026-05-17T14:15:04.347Z'
     correct-course:
       path: .aiox-core/development/tasks/correct-course.md
       layer: L2
@@ -794,14 +798,14 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec55430908fb25c99bd0ae0bbf8aad6b1aff36306488abb07cf6e8f2e03306cc
-      lastVerified: '2026-05-17T10:02:45.099Z'
+      lastVerified: '2026-05-17T14:15:04.347Z'
     create-agent:
       path: .aiox-core/development/tasks/create-agent.md
       layer: L2
       type: task
       purpose: >-
-        ** Create a single domain-specific agent through research, elicitation, validation, and operational
-        infrastructure
+        This task creates a single high-quality agent based on researched methodologies from an elite mind. The key
+        insight: **agents created without research are weak and generic**.
       keywords:
         - create
         - agent
@@ -818,7 +822,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:538954ecee93c0b4467d4dc00ce4315b2fac838ad298a11c6bc4e45366430e17
-      lastVerified: '2026-05-17T10:02:45.101Z'
+      lastVerified: '2026-05-17T14:15:04.348Z'
     create-brownfield-story:
       path: .aiox-core/development/tasks/create-brownfield-story.md
       layer: L2
@@ -848,7 +852,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:88dc7949dbfde53773135650a6864c2b7a36cbfe93239cee8edf8a9c082b0fcf
-      lastVerified: '2026-05-17T10:02:45.102Z'
+      lastVerified: '2026-05-17T14:15:04.348Z'
     create-deep-research-prompt:
       path: .aiox-core/development/tasks/create-deep-research-prompt.md
       layer: L2
@@ -883,12 +887,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c432fad72d00722db2525b3b68555ab02bb38e80f85e55b7354b389771ed943b
-      lastVerified: '2026-05-17T10:02:45.102Z'
+      lastVerified: '2026-05-17T14:15:04.349Z'
     create-doc:
       path: .aiox-core/development/tasks/create-doc.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Template selection determined dynamically during task execution
       keywords:
         - create
         - doc
@@ -918,7 +922,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:078b2e5ac900f5d48fc82792198e59108a32891c77ed18aa062d87db442d155e
-      lastVerified: '2026-05-17T10:02:45.103Z'
+      lastVerified: '2026-05-17T14:15:04.349Z'
     create-next-story:
       path: .aiox-core/development/tasks/create-next-story.md
       layer: L2
@@ -933,7 +937,13 @@ entities:
         - task
       usedBy:
         - sm
-      dependencies: []
+      dependencies:
+        - po-master-checklist
+        - component-generator.js
+        - dev
+        - architect
+        - qa
+        - po
       externalDeps: []
       plannedDeps:
         - tech-stack
@@ -954,7 +964,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c8ce97f47ad9b0fb316bee47eae46fe7c9fbacb897f3062eaedd8a925511afc
-      lastVerified: '2026-05-17T13:08:28.424Z'
+      lastVerified: '2026-05-17T14:15:04.350Z'
     create-service:
       path: .aiox-core/development/tasks/create-service.md
       layer: L2
@@ -979,12 +989,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dd9467f3e646ca4058f0cc524f99ae102c91750fa70f412f41f50f89d8f4b4e9
-      lastVerified: '2026-05-17T10:02:45.104Z'
+      lastVerified: '2026-05-17T14:15:04.350Z'
     create-suite:
       path: .aiox-core/development/tasks/create-suite.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'TODO: Create test-suite-checklist.md for validation (follow-up story needed)'
       keywords:
         - create
         - suite
@@ -1009,7 +1019,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0c5e7fa10bcb37d571ae3003f79fb6f98f46ed26c35234912b23b13d47091cb1
-      lastVerified: '2026-05-17T10:02:45.104Z'
+      lastVerified: '2026-05-17T14:15:04.350Z'
     create-task:
       path: .aiox-core/development/tasks/create-task.md
       layer: L2
@@ -1038,7 +1048,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2adfe4c3c8b73fbe3998444e24af796542342265b102ce52d3fc85d69d5e12af
-      lastVerified: '2026-05-17T10:02:45.104Z'
+      lastVerified: '2026-05-17T14:15:04.351Z'
     create-workflow:
       path: .aiox-core/development/tasks/create-workflow.md
       layer: L2
@@ -1067,12 +1077,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:76f47a9fa54b9690a10ddf4544c96f8d732c658550fd8487f9defd2339b8e222
-      lastVerified: '2026-05-17T10:02:45.105Z'
+      lastVerified: '2026-05-17T14:15:04.351Z'
     create-worktree:
       path: .aiox-core/development/tasks/create-worktree.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: create-worktree
       keywords:
         - create
         - worktree
@@ -1081,6 +1091,7 @@ entities:
         - list-worktrees
         - remove-worktree
         - dev
+        - devops
         - auto-worktree
       dependencies:
         - worktree-manager
@@ -1097,12 +1108,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:143b9bdf87a4eed0faac612e137965483dec1224a7579399a68b68b6bc0689b7
-      lastVerified: '2026-05-17T10:02:45.105Z'
+      lastVerified: '2026-05-17T14:15:04.351Z'
     db-analyze-hotpaths:
       path: .aiox-core/development/tasks/db-analyze-hotpaths.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Analyze Hot Query Paths'
       keywords:
         - db
         - analyze
@@ -1123,12 +1134,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0993cb6e5d0c4fb22f081060e47f303c3c745889cf7b583ea2a29ab0f3b0ac6e
-      lastVerified: '2026-05-17T10:02:45.106Z'
+      lastVerified: '2026-05-17T14:15:04.352Z'
     db-apply-migration:
       path: .aiox-core/development/tasks/db-apply-migration.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Apply Migration (with snapshot + advisory lock)'
       keywords:
         - db
         - apply
@@ -1149,12 +1160,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73ca77d0858dde76a1979d6c0dce1cd6760666ea67fdc60283da0d027d73eaa2
-      lastVerified: '2026-05-17T10:02:45.106Z'
+      lastVerified: '2026-05-17T14:15:04.352Z'
     db-bootstrap:
       path: .aiox-core/development/tasks/db-bootstrap.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Bootstrap Supabase Project'
       keywords:
         - db
         - bootstrap
@@ -1174,12 +1185,14 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b50effd8d5d63bcbb7f42a02223678306c4b10a3d7cdbd94b024e0dc716d1e69
-      lastVerified: '2026-05-17T10:02:45.106Z'
+      lastVerified: '2026-05-17T14:15:04.352Z'
     db-domain-modeling:
       path: .aiox-core/development/tasks/db-domain-modeling.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: >-
+        This task guides you through domain-driven database design, helping you translate business requirements into a
+        well-structured database schema.
       keywords:
         - db
         - domain
@@ -1199,12 +1212,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:afd2911ebdb4d4164885efb6d71cb2578da1e60ca3c37397f19261a99e5bb22b
-      lastVerified: '2026-05-17T10:02:45.107Z'
+      lastVerified: '2026-05-17T14:15:04.352Z'
     db-dry-run:
       path: .aiox-core/development/tasks/db-dry-run.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Migration Dry-Run'
       keywords:
         - db
         - dry
@@ -1225,12 +1238,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ce848fdf956175b5dd96d6864376011972d2a7512ce37519592589eca442ec2b
-      lastVerified: '2026-05-17T10:02:45.107Z'
+      lastVerified: '2026-05-17T14:15:04.353Z'
     db-env-check:
       path: .aiox-core/development/tasks/db-env-check.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: DB Env Check'
       keywords:
         - db
         - env
@@ -1249,12 +1262,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8a4674f5858ee709186690b45dd51fe5cbb28097a641f178e0e624e2a5331a44
-      lastVerified: '2026-05-17T10:02:45.108Z'
+      lastVerified: '2026-05-17T14:15:04.353Z'
     db-explain:
       path: .aiox-core/development/tasks/db-explain.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: EXPLAIN (ANALYZE, BUFFERS)'
       keywords:
         - db
         - explain
@@ -1273,12 +1286,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b96391756f45fc99b5cbd129921541060dc9ced1d1c269b820109d36fcd53530
-      lastVerified: '2026-05-17T10:02:45.109Z'
+      lastVerified: '2026-05-17T14:15:04.354Z'
     db-impersonate:
       path: .aiox-core/development/tasks/db-impersonate.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Impersonate User (RLS Testing)'
       keywords:
         - db
         - impersonate
@@ -1298,12 +1311,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:31891339b082706882c3529d5fbae5a77e566dbe94dfb2cc011a70aef6721abd
-      lastVerified: '2026-05-17T10:02:45.109Z'
+      lastVerified: '2026-05-17T14:15:04.354Z'
     db-load-csv:
       path: .aiox-core/development/tasks/db-load-csv.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Load CSV Data Safely'
       keywords:
         - db
         - load
@@ -1324,12 +1337,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a4cf24a705ad7669aef945a71dcc95b7e156e2c41ee20be9d63819818422bd23
-      lastVerified: '2026-05-17T10:02:45.109Z'
+      lastVerified: '2026-05-17T14:15:04.354Z'
     db-policy-apply:
       path: .aiox-core/development/tasks/db-policy-apply.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Apply RLS Policy Template'
       keywords:
         - db
         - policy
@@ -1350,12 +1363,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5069a7786ac2f5c032f9b4aeedaa90808bccb0ecc01456d72b11d111281c8497
-      lastVerified: '2026-05-17T10:02:45.109Z'
+      lastVerified: '2026-05-17T14:15:04.354Z'
     db-rls-audit:
       path: .aiox-core/development/tasks/db-rls-audit.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: RLS Audit'
       keywords:
         - db
         - rls
@@ -1373,12 +1386,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b25183564fe08abdb5c563a19eac526ebbe14c10397cfb27e9b2f2c53f1c189b
-      lastVerified: '2026-05-17T10:02:45.110Z'
+      lastVerified: '2026-05-17T14:15:04.354Z'
     db-rollback:
       path: .aiox-core/development/tasks/db-rollback.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Rollback Database'
       keywords:
         - db
         - rollback
@@ -1397,12 +1410,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cc8b5ccbfb8184724452bd4fbaf93a5e43b137428f7cd1c6562b8bc7c10887e2
-      lastVerified: '2026-05-17T10:02:45.110Z'
+      lastVerified: '2026-05-17T14:15:04.355Z'
     db-run-sql:
       path: .aiox-core/development/tasks/db-run-sql.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Run SQL'
       keywords:
         - db
         - run
@@ -1421,12 +1434,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:90b771db8d68c2cc3236aa371d24c2553175c4d39931fe3eb690cdd2ebaded1e
-      lastVerified: '2026-05-17T10:02:45.110Z'
+      lastVerified: '2026-05-17T14:15:04.355Z'
     db-schema-audit:
       path: .aiox-core/development/tasks/db-schema-audit.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'This task performs a thorough audit of your database schema, checking for:'
       keywords:
         - db
         - schema
@@ -1444,12 +1457,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4a70508b9d6bbe2b2e62265231682df371dc3a9295e285ef2e4356f81ed941e9
-      lastVerified: '2026-05-17T10:02:45.111Z'
+      lastVerified: '2026-05-17T14:15:04.356Z'
     db-seed:
       path: .aiox-core/development/tasks/db-seed.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Apply Seed Data'
       keywords:
         - db
         - seed
@@ -1469,12 +1482,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e3553aff9781731e75c2017a7038cbb843a6945d69fb26365300aae3fd68d97e
-      lastVerified: '2026-05-17T10:02:45.111Z'
+      lastVerified: '2026-05-17T14:15:04.356Z'
     db-smoke-test:
       path: .aiox-core/development/tasks/db-smoke-test.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: DB Smoke Test'
       keywords:
         - db
         - smoke
@@ -1493,12 +1506,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7f0672e95bedf5d5ac83f34acdd07f32d88bab743a2f210a49b6bea9bcdd04c7
-      lastVerified: '2026-05-17T10:02:45.111Z'
+      lastVerified: '2026-05-17T14:15:04.356Z'
     db-snapshot:
       path: .aiox-core/development/tasks/db-snapshot.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Create Database Snapshot'
       keywords:
         - db
         - snapshot
@@ -1518,12 +1531,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:60955c4ec4894233ef891424900d134ff4ac987ccf6fa2521f704e476865ef79
-      lastVerified: '2026-05-17T10:02:45.112Z'
+      lastVerified: '2026-05-17T14:15:04.356Z'
     db-squad-integration:
       path: .aiox-core/development/tasks/db-squad-integration.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: MMOS cognitive clones are now persisted in Supabase with full RLS, versioning, and vector search.
       keywords:
         - db
         - squad
@@ -1542,12 +1555,14 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:13ce5e3226dadffad490752064169e124e2c989514e2e7b3c249445b9ad3485c
-      lastVerified: '2026-05-17T10:02:45.112Z'
+      lastVerified: '2026-05-17T14:15:04.357Z'
     db-supabase-setup:
       path: .aiox-core/development/tasks/db-supabase-setup.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: >-
+        This task guides you through setting up a new Supabase project with optimal configuration and DB Sage
+        integration.
       keywords:
         - db
         - supabase
@@ -1567,12 +1582,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:64e02b6c69bb87d0082590484fadc0510cb88e4a6dc01b3c7015e5e6e6bcb585
-      lastVerified: '2026-05-17T10:02:45.113Z'
+      lastVerified: '2026-05-17T14:15:04.357Z'
     db-verify-order:
       path: .aiox-core/development/tasks/db-verify-order.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Verify DDL Ordering'
       keywords:
         - db
         - verify
@@ -1593,7 +1608,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:478a1f94e0e4d9da5488ce5df41538308454a64e534d587d5d8361dbd9cff701
-      lastVerified: '2026-05-17T10:02:45.113Z'
+      lastVerified: '2026-05-17T14:15:04.358Z'
     delegate-to-external-executor:
       path: .aiox-core/development/tasks/delegate-to-external-executor.md
       layer: L2
@@ -1616,7 +1631,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:68c73a78e4eeebcb551f69bc8c13f37157be253b91a3d3d80ea9bc52c5330808
-      lastVerified: '2026-05-17T10:02:45.113Z'
+      lastVerified: '2026-05-17T14:15:04.358Z'
     deprecate-component:
       path: .aiox-core/development/tasks/deprecate-component.md
       layer: L2
@@ -1647,7 +1662,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:72dfca4d222b990ed868e5fd4c0d5793848cd1a9fda6d48fb7caec93e02c59ed
-      lastVerified: '2026-05-17T10:02:45.114Z'
+      lastVerified: '2026-05-17T14:15:04.359Z'
     dev-apply-qa-fixes:
       path: .aiox-core/development/tasks/dev-apply-qa-fixes.md
       layer: L2
@@ -1672,12 +1687,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a5b993cbc89e46f3669748da0f33e5cae28af4e6552d7f492b7f640f735736ba
-      lastVerified: '2026-05-17T10:02:45.114Z'
+      lastVerified: '2026-05-17T14:15:04.359Z'
     dev-backlog-debt:
       path: .aiox-core/development/tasks/dev-backlog-debt.md
       layer: L2
       type: task
-      purpose: '** Register technical debt item to backlog'
+      purpose: 'Dev Task: Register Technical Debt'
       keywords:
         - dev
         - backlog
@@ -1701,7 +1716,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e5aa74b0fb90697be71cb5c1914d8b632d7edac0b9e42d87539a4ea1519c7ed3
-      lastVerified: '2026-05-17T10:02:45.115Z'
+      lastVerified: '2026-05-17T14:15:04.359Z'
     dev-develop-story:
       path: .aiox-core/development/tasks/dev-develop-story.md
       layer: L2
@@ -1731,7 +1746,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:be8924aa0de759ca92a177b0ea12a5b076a3095ee2a9f530b74b3de19e996954
-      lastVerified: '2026-05-17T10:02:45.116Z'
+      lastVerified: '2026-05-17T14:15:04.360Z'
     dev-improve-code-quality:
       path: .aiox-core/development/tasks/dev-improve-code-quality.md
       layer: L2
@@ -1764,7 +1779,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6cf78aed6cca48bf13cc1f677f2cde86aea591785f428f9f56733de478107e2f
-      lastVerified: '2026-05-17T10:02:45.116Z'
+      lastVerified: '2026-05-17T14:15:04.361Z'
     dev-optimize-performance:
       path: .aiox-core/development/tasks/dev-optimize-performance.md
       layer: L2
@@ -1795,7 +1810,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:acd5a1b14732f4d2526ebee2571897eb5ccb4c106d2388eb3560298ed85ce20d
-      lastVerified: '2026-05-17T10:02:45.118Z'
+      lastVerified: '2026-05-17T14:15:04.362Z'
     dev-suggest-refactoring:
       path: .aiox-core/development/tasks/dev-suggest-refactoring.md
       layer: L2
@@ -1826,7 +1841,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:51eebcbb72786df561ee0f25176ee4534166d71f2cfd4db1ea6eae7e8f3f6188
-      lastVerified: '2026-05-17T10:02:45.118Z'
+      lastVerified: '2026-05-17T14:15:04.362Z'
     dev-validate-next-story:
       path: .aiox-core/development/tasks/dev-validate-next-story.md
       layer: L2
@@ -1841,7 +1856,8 @@ entities:
         - story
         - task
       usedBy: []
-      dependencies: []
+      dependencies:
+        - po-master-checklist
       externalDeps: []
       plannedDeps:
         - task-runner.js
@@ -1853,7 +1869,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b3c533f925077c73d18d8c9b4b69783493f1c690fd562df9546f9169f82bbe14
-      lastVerified: '2026-05-17T13:08:28.425Z'
+      lastVerified: '2026-05-17T14:15:04.363Z'
     devops-pro-access-grant:
       path: .aiox-core/development/tasks/devops-pro-access-grant.md
       layer: L2
@@ -1867,7 +1883,8 @@ entities:
         - access
         - grant
         - 'task:'
-      usedBy: []
+      usedBy:
+        - devops
       dependencies:
         - devops
       externalDeps: []
@@ -1878,7 +1895,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:11d2b342a39a95acfbd5dbb7abe9c25a9511035b9ca46abac86ec40f60d6a011
-      lastVerified: '2026-05-17T10:02:45.119Z'
+      lastVerified: '2026-05-17T14:15:04.363Z'
     devops-pro-activate:
       path: .aiox-core/development/tasks/devops-pro-activate.md
       layer: L2
@@ -1889,7 +1906,8 @@ entities:
         - pro
         - activate
         - 'task:'
-      usedBy: []
+      usedBy:
+        - devops
       dependencies:
         - devops
       externalDeps: []
@@ -1900,7 +1918,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:910a62a5dc9c9780a774da3d79b1b3fe3b5834ecf7f1c074775774a8bdfebd65
-      lastVerified: '2026-05-17T10:02:45.119Z'
+      lastVerified: '2026-05-17T14:15:04.363Z'
     devops-pro-check-access:
       path: .aiox-core/development/tasks/devops-pro-check-access.md
       layer: L2
@@ -1912,7 +1930,8 @@ entities:
         - check
         - access
         - 'task:'
-      usedBy: []
+      usedBy:
+        - devops
       dependencies:
         - devops
       externalDeps: []
@@ -1923,7 +1942,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4dcff883a824899c531841bcdcda8bb5767a57fb49e8ca242a14875f41e7c694
-      lastVerified: '2026-05-17T10:02:45.119Z'
+      lastVerified: '2026-05-17T14:15:04.363Z'
     devops-pro-request-reset:
       path: .aiox-core/development/tasks/devops-pro-request-reset.md
       layer: L2
@@ -1935,7 +1954,8 @@ entities:
         - request
         - reset
         - 'task:'
-      usedBy: []
+      usedBy:
+        - devops
       dependencies:
         - devops
       externalDeps: []
@@ -1946,7 +1966,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fdb5710a9c85e39750016cb3ac3e60a69396f2edaa1fc3180f0ebbf71e2c470c
-      lastVerified: '2026-05-17T10:02:45.119Z'
+      lastVerified: '2026-05-17T14:15:04.363Z'
     devops-pro-resend-verification:
       path: .aiox-core/development/tasks/devops-pro-resend-verification.md
       layer: L2
@@ -1958,7 +1978,8 @@ entities:
         - resend
         - verification
         - 'task:'
-      usedBy: []
+      usedBy:
+        - devops
       dependencies:
         - devops
       externalDeps: []
@@ -1969,7 +1990,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e6ed30bb1bd15d1d138f09e991ec227fda48f7b2bfef6be2f7a49bcb95ab9cd4
-      lastVerified: '2026-05-17T10:02:45.119Z'
+      lastVerified: '2026-05-17T14:15:04.363Z'
     devops-pro-reset-password:
       path: .aiox-core/development/tasks/devops-pro-reset-password.md
       layer: L2
@@ -1981,7 +2002,8 @@ entities:
         - reset
         - password
         - 'task:'
-      usedBy: []
+      usedBy:
+        - devops
       dependencies:
         - devops
       externalDeps: []
@@ -1992,7 +2014,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1f48dd5d1110529cc20b91f41c3ad4ac2e4a095040f0bbc1aa2641955fb2559c
-      lastVerified: '2026-05-17T10:02:45.120Z'
+      lastVerified: '2026-05-17T14:15:04.363Z'
     devops-pro-validate-login:
       path: .aiox-core/development/tasks/devops-pro-validate-login.md
       layer: L2
@@ -2004,7 +2026,8 @@ entities:
         - validate
         - login
         - 'task:'
-      usedBy: []
+      usedBy:
+        - devops
       dependencies:
         - devops
       externalDeps: []
@@ -2015,7 +2038,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b9321e184b4a1c7e003b363a857be01f953aebd467b898891b701880243265fe
-      lastVerified: '2026-05-17T10:02:45.120Z'
+      lastVerified: '2026-05-17T14:15:04.363Z'
     devops-pro-verify-status:
       path: .aiox-core/development/tasks/devops-pro-verify-status.md
       layer: L2
@@ -2027,7 +2050,8 @@ entities:
         - verify
         - status
         - 'task:'
-      usedBy: []
+      usedBy:
+        - devops
       dependencies:
         - devops
       externalDeps: []
@@ -2038,7 +2062,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c6fff732a41370c125e5507f9284a3b567b5472a788df0cd874ad4e6c801150d
-      lastVerified: '2026-05-17T10:02:45.120Z'
+      lastVerified: '2026-05-17T14:15:04.364Z'
     document-gotchas:
       path: .aiox-core/development/tasks/document-gotchas.md
       layer: L2
@@ -2064,7 +2088,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:84858f6252bc2a85beda75971fed74e087edee3bdd537eb29f43132f0141fbf5
-      lastVerified: '2026-05-17T10:02:45.120Z'
+      lastVerified: '2026-05-17T14:15:04.364Z'
     document-project:
       path: .aiox-core/development/tasks/document-project.md
       layer: L2
@@ -2096,7 +2120,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8123a2c9105391b46857cfb3e236a912f47bfb598fb21df1cea0a12eabbf7337
-      lastVerified: '2026-05-17T10:02:45.121Z'
+      lastVerified: '2026-05-17T14:15:04.364Z'
     environment-bootstrap:
       path: .aiox-core/development/tasks/environment-bootstrap.md
       layer: L2
@@ -2110,6 +2134,7 @@ entities:
         - environment-bootstrap
       usedBy:
         - setup-github
+        - devops
       dependencies:
         - config-resolver
         - github-cli.yaml
@@ -2133,12 +2158,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:02ed701bea38ee11ad7e83a310ad55b3d84f36f37a344fda6b252fe3230d50cb
-      lastVerified: '2026-05-17T10:02:45.122Z'
+      lastVerified: '2026-05-17T14:15:04.365Z'
     execute-checklist:
       path: .aiox-core/development/tasks/execute-checklist.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: No templates needed - this task executes existing checklists, doesn't create document outputs
       keywords:
         - execute
         - checklist
@@ -2170,7 +2195,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9bd751605efd593e0708bac6e3f1c66a91ba5f33a5069c655b6d16cf6621859c
-      lastVerified: '2026-05-17T10:02:45.122Z'
+      lastVerified: '2026-05-17T14:15:04.365Z'
     execute-epic-plan:
       path: .aiox-core/development/tasks/execute-epic-plan.md
       layer: L2
@@ -2200,12 +2225,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0c3ee4e1802927fb8f21be172daeb356797033ff082fea07523025a373bea387
-      lastVerified: '2026-05-17T10:02:45.123Z'
+      lastVerified: '2026-05-17T14:15:04.366Z'
     export-design-tokens-dtcg:
       path: .aiox-core/development/tasks/export-design-tokens-dtcg.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Export Design Tokens to W3C DTCG
       keywords:
         - export
         - design
@@ -2226,12 +2251,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8819918bd7c4b6b0b0b0aadd66f5aecb2d6ca0b949206c16cb497d6d1d7a72f9
-      lastVerified: '2026-05-17T10:02:45.123Z'
+      lastVerified: '2026-05-17T14:15:04.366Z'
     extend-pattern:
       path: .aiox-core/development/tasks/extend-pattern.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Extend Existing Pattern
       keywords:
         - extend
         - pattern
@@ -2250,7 +2275,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7eaccc1d33f806bbcd2e7a90e701d6c88c00e4e98f14c14b4f705ff618ef17f8
-      lastVerified: '2026-05-17T10:02:45.124Z'
+      lastVerified: '2026-05-17T14:15:04.366Z'
     extract-patterns:
       path: .aiox-core/development/tasks/extract-patterns.md
       layer: L2
@@ -2274,12 +2299,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:aa8981c254d00a76c66c6c4f9569b0be1785f4537137ee23129049abae92f3b4
-      lastVerified: '2026-05-17T10:02:45.124Z'
+      lastVerified: '2026-05-17T14:15:04.366Z'
     extract-tokens:
       path: .aiox-core/development/tasks/extract-tokens.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Extract Design Tokens from Consolidated Patterns
       keywords:
         - extract
         - tokens
@@ -2300,7 +2325,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8266d4caf51507fe82510c04a54b6a33c7e2d1f10862e4e242f009b214edd7ee
-      lastVerified: '2026-05-17T10:02:45.124Z'
+      lastVerified: '2026-05-17T14:15:04.367Z'
     facilitate-brainstorming-session:
       path: .aiox-core/development/tasks/facilitate-brainstorming-session.md
       layer: L2
@@ -2325,7 +2350,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c351428e7aa1af079046bbf357af98668675943fd13920b98b7ecfd9f87a6081
-      lastVerified: '2026-05-17T10:02:45.125Z'
+      lastVerified: '2026-05-17T14:15:04.367Z'
     fast-path-gate:
       path: .aiox-core/development/tasks/fast-path-gate.md
       layer: L2
@@ -2347,7 +2372,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d28e2def9134ffe79e04ebcfa25de651d659471eab07367fa4c7992245f79fe2
-      lastVerified: '2026-05-17T10:02:45.125Z'
+      lastVerified: '2026-05-17T14:15:04.368Z'
     generate-ai-frontend-prompt:
       path: .aiox-core/development/tasks/generate-ai-frontend-prompt.md
       layer: L2
@@ -2379,12 +2404,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d4c2abf28b065922f1e67c95fa2a69dd792c9828c6dd31d2fc173a5361b021aa
-      lastVerified: '2026-05-17T10:02:45.125Z'
+      lastVerified: '2026-05-17T14:15:04.368Z'
     generate-documentation:
       path: .aiox-core/development/tasks/generate-documentation.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Generate Pattern Library Documentation
       keywords:
         - generate
         - documentation
@@ -2405,12 +2430,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec03841e1f72b8b55a156e03a7d6ef061f0cf942beb7d66f61d3bf6bdbaaa93b
-      lastVerified: '2026-05-17T10:02:45.125Z'
+      lastVerified: '2026-05-17T14:15:04.368Z'
     generate-migration-strategy:
       path: .aiox-core/development/tasks/generate-migration-strategy.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Generate Phased Migration Strategy
       keywords:
         - generate
         - migration
@@ -2430,12 +2455,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a944f9294553cad38c4e2a13143388a48dc330667e5b1b04dfcd1f5a2644541
-      lastVerified: '2026-05-17T10:02:45.126Z'
+      lastVerified: '2026-05-17T14:15:04.368Z'
     generate-shock-report:
       path: .aiox-core/development/tasks/generate-shock-report.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Generate Visual Shock Report
       keywords:
         - generate
         - shock
@@ -2455,12 +2480,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:04ebdca5f8bad14504f76d3e1fde4b426a4cd4ce8fe8dc4f9391f3c711bb6970
-      lastVerified: '2026-05-17T10:02:45.126Z'
+      lastVerified: '2026-05-17T14:15:04.369Z'
     github-devops-github-pr-automation:
       path: .aiox-core/development/tasks/github-devops-github-pr-automation.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: github-pr-automation.md
       keywords:
         - github
         - devops
@@ -2469,6 +2494,7 @@ entities:
         - github-pr-automation.md
       usedBy:
         - resolve-github-issue
+        - devops
       dependencies:
         - repository-detector
         - devops-helper
@@ -2487,12 +2513,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2149c952074e661e77cfe6caa1bc2cb7366c930c9782eb308a8513a54f3d1629
-      lastVerified: '2026-05-17T10:02:45.127Z'
+      lastVerified: '2026-05-17T14:15:04.369Z'
     github-devops-pre-push-quality-gate:
       path: .aiox-core/development/tasks/github-devops-pre-push-quality-gate.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: pre-push-quality-gate.md
       keywords:
         - github
         - devops
@@ -2503,6 +2529,7 @@ entities:
         - pre-push-quality-gate.md
       usedBy:
         - resolve-github-issue
+        - devops
       dependencies:
         - repository-detector
         - devops-helper
@@ -2517,19 +2544,20 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3709049cefce2dc03f54a16830114e67fa6b4cf37f0f999638d5d1521f0979d8
-      lastVerified: '2026-05-17T10:02:45.128Z'
+      lastVerified: '2026-05-17T14:15:04.370Z'
     github-devops-repository-cleanup:
       path: .aiox-core/development/tasks/github-devops-repository-cleanup.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: repository-cleanup.md
       keywords:
         - github
         - devops
         - repository
         - cleanup
         - repository-cleanup.md
-      usedBy: []
+      usedBy:
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -2542,19 +2570,20 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:34135e86820be5218daf7031f4daa115d6ef9a727c7c0cb3a6f28c59f8e694c1
-      lastVerified: '2026-05-17T10:02:45.128Z'
+      lastVerified: '2026-05-17T14:15:04.370Z'
     github-devops-version-management:
       path: .aiox-core/development/tasks/github-devops-version-management.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: version-management.md
       keywords:
         - github
         - devops
         - version
         - management
         - version-management.md
-      usedBy: []
+      usedBy:
+        - devops
       dependencies:
         - repository-detector
       externalDeps: []
@@ -2568,12 +2597,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1e217bea7df36731cfa5c3fb5a3b97399a57fef5989e59c303c3163bb3e5ecd7
-      lastVerified: '2026-05-17T10:02:45.129Z'
+      lastVerified: '2026-05-17T14:15:04.370Z'
     github-issue-triage:
       path: .aiox-core/development/tasks/github-issue-triage.md
       layer: L2
       type: task
-      purpose: '```bash'
+      purpose: GitHub Issue Triage
       keywords:
         - github
         - issue
@@ -2589,7 +2618,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:61178caa7bc647dcae5e53d3f0515d6dab0cdc927e245b2db5844dc35d9e3d6f
-      lastVerified: '2026-05-17T10:02:45.129Z'
+      lastVerified: '2026-05-17T14:15:04.371Z'
     gotcha:
       path: .aiox-core/development/tasks/gotcha.md
       layer: L2
@@ -2614,7 +2643,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a9117d8a4c85c1be044975d829c936be0037c1751ef42b0fb2d19861702aecc6
-      lastVerified: '2026-05-17T10:02:45.129Z'
+      lastVerified: '2026-05-17T14:15:04.371Z'
     gotchas:
       path: .aiox-core/development/tasks/gotchas.md
       layer: L2
@@ -2640,12 +2669,14 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ecf526697d6c55416aaea97939cd2002e8f32eaa7001d31e823d7766688d2bf5
-      lastVerified: '2026-05-17T10:02:45.129Z'
+      lastVerified: '2026-05-17T14:15:04.371Z'
     ids-governor:
       path: .aiox-core/development/tasks/ids-governor.md
       layer: L2
       type: task
-      purpose: '** Execute IDS Framework Governor commands (*ids query, *ids health, *ids stats, *ids impact)'
+      purpose: >-
+        This task handles the execution of IDS (Incremental Development System) commands through the FrameworkGovernor
+        facade. All commands are advisory and non-blocking.
       keywords:
         - ids
         - governor
@@ -2664,7 +2695,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cfb1aefffdf2db0d35cae8fdde2f5afbcea62b9b616e78a43390756c9b8e6b9c
-      lastVerified: '2026-05-17T10:02:45.130Z'
+      lastVerified: '2026-05-17T14:15:04.371Z'
     ids-health:
       path: .aiox-core/development/tasks/ids-health.md
       layer: L2
@@ -2687,7 +2718,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d5196b3741fb537707e1a99c71514e439447121df500002644dfebe43da4a70f
-      lastVerified: '2026-05-17T10:02:45.130Z'
+      lastVerified: '2026-05-17T14:15:04.371Z'
     ids-query:
       path: .aiox-core/development/tasks/ids-query.md
       layer: L2
@@ -2711,7 +2742,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c15596fdfc0bf86e4b6053313e7e91195c073d6c9066df4d626c5a3e2c13e99b
-      lastVerified: '2026-05-17T10:02:45.130Z'
+      lastVerified: '2026-05-17T14:15:04.371Z'
     improve-self:
       path: .aiox-core/development/tasks/improve-self.md
       layer: L2
@@ -2745,7 +2776,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ccabfaad3cdba01a151b313afdf0e1c41c8a981ec2140531f24500149b4a7646
-      lastVerified: '2026-05-17T10:02:45.131Z'
+      lastVerified: '2026-05-17T14:15:04.372Z'
     index-docs:
       path: .aiox-core/development/tasks/index-docs.md
       layer: L2
@@ -2776,12 +2807,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d8553b437ad8a4dc9dc37bd38939164ee0d0f76f2bb46d30a8318cf4413415f5
-      lastVerified: '2026-05-17T10:02:45.131Z'
+      lastVerified: '2026-05-17T14:15:04.372Z'
     init-project-status:
       path: .aiox-core/development/tasks/init-project-status.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: init-project-status
       keywords:
         - init
         - project
@@ -2804,12 +2835,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0c2f801d30da8f926542e8d29507886cb79ec324e717c75607b9fbb5555dc16b
-      lastVerified: '2026-05-17T10:02:45.131Z'
+      lastVerified: '2026-05-17T14:15:04.372Z'
     integrate-squad:
       path: .aiox-core/development/tasks/integrate-squad.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Integrate with Squad
       keywords:
         - integrate
         - squad
@@ -2826,7 +2857,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c1dbded4048033ea0a5f10c8bb53e045e14930d8442a1bf35c67bb16c0c8939a
-      lastVerified: '2026-05-17T10:02:45.132Z'
+      lastVerified: '2026-05-17T14:15:04.373Z'
     kb-mode-interaction:
       path: .aiox-core/development/tasks/kb-mode-interaction.md
       layer: L2
@@ -2856,7 +2887,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73ef3d164b2576f80f37bfc5bc6ea2276a59778f9bcc41a77fd288fab7f2e61f
-      lastVerified: '2026-05-17T10:02:45.132Z'
+      lastVerified: '2026-05-17T14:15:04.373Z'
     learn-patterns:
       path: .aiox-core/development/tasks/learn-patterns.md
       layer: L2
@@ -2882,7 +2913,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0042edaa7d638aa4e476607d026a406411a6b9177f3a29a25d78773ee27e9c0f
-      lastVerified: '2026-05-17T10:02:45.133Z'
+      lastVerified: '2026-05-17T14:15:04.373Z'
     list-mcps:
       path: .aiox-core/development/tasks/list-mcps.md
       layer: L2
@@ -2892,7 +2923,8 @@ entities:
         - list
         - mcps
         - list-mcps
-      usedBy: []
+      usedBy:
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -2902,7 +2934,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c2eca1a9c8d0be7c83a3e2eea59b33155bf7955f534eb0b36b27ed3852ea7dd1
-      lastVerified: '2026-05-17T10:02:45.133Z'
+      lastVerified: '2026-05-17T14:15:04.373Z'
     list-worktrees:
       path: .aiox-core/development/tasks/list-worktrees.md
       layer: L2
@@ -2916,6 +2948,7 @@ entities:
         - create-worktree
         - remove-worktree
         - dev
+        - devops
       dependencies:
         - worktree-manager
         - create-worktree
@@ -2930,12 +2963,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a29055766b289c22597532b5623e6e56dbbf6ca8d59193da6e6a0159213cb00b
-      lastVerified: '2026-05-17T10:02:45.133Z'
+      lastVerified: '2026-05-17T14:15:04.374Z'
     mcp-workflow:
       path: .aiox-core/development/tasks/mcp-workflow.md
       layer: L2
       type: task
-      purpose: What does this workflow do?
+      purpose: MCP Workflow Creation Task
       keywords:
         - mcp
         - workflow
@@ -2952,7 +2985,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c09227efc590cc68ae9d32fe010de2dd8db621a2102b36d92a6fbb30f8f27cf
-      lastVerified: '2026-05-17T10:02:45.133Z'
+      lastVerified: '2026-05-17T14:15:04.374Z'
     merge-worktree:
       path: .aiox-core/development/tasks/merge-worktree.md
       layer: L2
@@ -2964,6 +2997,7 @@ entities:
         - merge-worktree
       usedBy:
         - create-worktree
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -2973,7 +3007,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e33a96e1961bbaba60f2258f4a98b8c9d384754a07eba705732f41d61ed2d4f4
-      lastVerified: '2026-05-17T10:02:45.134Z'
+      lastVerified: '2026-05-17T14:15:04.374Z'
     modify-agent:
       path: .aiox-core/development/tasks/modify-agent.md
       layer: L2
@@ -2987,7 +3021,8 @@ entities:
         - task
       usedBy:
         - aiox-master
-      dependencies: []
+      dependencies:
+        - change-checklist
       externalDeps: []
       plannedDeps:
         - existing-task
@@ -3000,7 +3035,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:31d7d543b8994605e10fbbdce3ca52d5d6d0938832f053baa5a0ca50238f7e33
-      lastVerified: '2026-05-17T13:08:28.425Z'
+      lastVerified: '2026-05-17T14:15:04.374Z'
     modify-task:
       path: .aiox-core/development/tasks/modify-task.md
       layer: L2
@@ -3013,7 +3048,8 @@ entities:
         - task
       usedBy:
         - aiox-master
-      dependencies: []
+      dependencies:
+        - change-checklist
       externalDeps: []
       plannedDeps:
         - Node.js
@@ -3025,7 +3061,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b02ca96a6ffebac281a6f0640228c39a62d723414a50481bf6ef8ad05c92cfd3
-      lastVerified: '2026-05-17T13:08:28.425Z'
+      lastVerified: '2026-05-17T14:15:04.374Z'
     modify-workflow:
       path: .aiox-core/development/tasks/modify-workflow.md
       layer: L2
@@ -3052,7 +3088,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7cbfc3488912240b0782d116b27c5410d724c7822f94efe6cd64df954c3b4b50
-      lastVerified: '2026-05-17T10:02:45.135Z'
+      lastVerified: '2026-05-17T14:15:04.375Z'
     next:
       path: .aiox-core/development/tasks/next.md
       layer: L2
@@ -3078,7 +3114,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bc65cd39c47607cef82f4d72e21f80b69ee4d5b1c42f3ffc317d91910fbae4ae
-      lastVerified: '2026-05-17T10:02:45.135Z'
+      lastVerified: '2026-05-17T14:15:04.375Z'
     orchestrate-resume:
       path: .aiox-core/development/tasks/orchestrate-resume.md
       layer: L2
@@ -3099,7 +3135,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c15ca8e699269246cc48a581ca6a956acf6ba9b717024274836d6447cfbccc76
-      lastVerified: '2026-05-17T10:02:45.135Z'
+      lastVerified: '2026-05-17T14:15:04.375Z'
     orchestrate-status:
       path: .aiox-core/development/tasks/orchestrate-status.md
       layer: L2
@@ -3120,7 +3156,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fe47c904e6329f758c001f6cc56383ea32059ce988c3d190e8d6ebcc42376ec9
-      lastVerified: '2026-05-17T10:02:45.135Z'
+      lastVerified: '2026-05-17T14:15:04.376Z'
     orchestrate-stop:
       path: .aiox-core/development/tasks/orchestrate-stop.md
       layer: L2
@@ -3141,7 +3177,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:87f82b66a711ed468ea2f97ce5201469c2990010fed95ddbd975bb8ab49a3547
-      lastVerified: '2026-05-17T10:02:45.135Z'
+      lastVerified: '2026-05-17T14:15:04.376Z'
     orchestrate:
       path: .aiox-core/development/tasks/orchestrate.md
       layer: L2
@@ -3161,7 +3197,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ca30ad1efa28ea5c7eeebd07f944fa0202ab9522ae6c32c8a19ca9ff2d30a8ce
-      lastVerified: '2026-05-17T10:02:45.136Z'
+      lastVerified: '2026-05-17T14:15:04.376Z'
     patterns:
       path: .aiox-core/development/tasks/patterns.md
       layer: L2
@@ -3185,7 +3221,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:99dc215422f88e1dafa138e577c2c96bc65cf9657ca99b9ca00e72b3d17ec843
-      lastVerified: '2026-05-17T10:02:45.136Z'
+      lastVerified: '2026-05-17T14:15:04.376Z'
     plan-create-context:
       path: .aiox-core/development/tasks/plan-create-context.md
       layer: L2
@@ -3216,7 +3252,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2374473d1984288dc37c80c298fc564facadf0b8b886b8a98520c8b39c9bc82a
-      lastVerified: '2026-05-17T10:02:45.137Z'
+      lastVerified: '2026-05-17T14:15:04.377Z'
     plan-create-implementation:
       path: .aiox-core/development/tasks/plan-create-implementation.md
       layer: L2
@@ -3245,7 +3281,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3c186ead114afe21638b933d2e312538ed3a7bb9ee3dfee0ee0dc86fcc0025cc
-      lastVerified: '2026-05-17T10:02:45.137Z'
+      lastVerified: '2026-05-17T14:15:04.377Z'
     plan-execute-subtask:
       path: .aiox-core/development/tasks/plan-execute-subtask.md
       layer: L2
@@ -3276,12 +3312,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a6c9c283579d0b5d3f337816ed192f4dda99c3634ac55da98fa0c0d332e4d963
-      lastVerified: '2026-05-17T10:02:45.138Z'
+      lastVerified: '2026-05-17T14:15:04.378Z'
     po-backlog-add:
       path: .aiox-core/development/tasks/po-backlog-add.md
       layer: L2
       type: task
-      purpose: '** Add item to story backlog (follow-up, technical debt, or enhancement)'
+      purpose: 'PO Task: Add Backlog Item'
       keywords:
         - po
         - backlog
@@ -3303,12 +3339,14 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6f553ba9bf2638c183c4a59caa56d73baa641263080125ed0f9d87a18e9f376f
-      lastVerified: '2026-05-17T10:02:45.138Z'
+      lastVerified: '2026-05-17T14:15:04.378Z'
     po-close-story:
       path: .aiox-core/development/tasks/po-close-story.md
       layer: L2
       type: task
-      purpose: '** Close a completed story, update epic/backlog, and suggest next story'
+      purpose: >-
+        This task closes the PO story lifecycle that begins with `*validate-story-draft`. After a story is implemented,
+        tested, and merged, this task:
       keywords:
         - po
         - close
@@ -3329,7 +3367,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:df93883e8af967351586dff250f79748008f6dc2ac15b78ac85715023a8d3ba4
-      lastVerified: '2026-05-17T10:02:45.138Z'
+      lastVerified: '2026-05-17T14:15:04.378Z'
     po-manage-story-backlog:
       path: .aiox-core/development/tasks/po-manage-story-backlog.md
       layer: L2
@@ -3357,14 +3395,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ed619e87c9753428eaea969d05d046b7f26af4f825d792ffcf026dc4f475b6e5
-      lastVerified: '2026-05-17T10:02:45.139Z'
+      lastVerified: '2026-05-17T14:15:04.379Z'
     po-pull-story-from-clickup:
       path: .aiox-core/development/tasks/po-pull-story-from-clickup.md
       layer: L2
       type: task
-      purpose: >-
-        ** Pull complete story updates from ClickUp to local file, including task completions, description changes, and
-        status updates. This is the **reverse direction** of sync-story-to-clickup.
+      purpose: pull-story-from-clickup
       keywords:
         - po
         - pull
@@ -3388,12 +3424,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:27fa2887a3da901319bafd7bd714c0abb31c638554aecaf924d412d25a7072bc
-      lastVerified: '2026-05-17T10:02:45.139Z'
+      lastVerified: '2026-05-17T14:15:04.379Z'
     po-pull-story:
       path: .aiox-core/development/tasks/po-pull-story.md
       layer: L2
       type: task
-      purpose: '** Pull story updates from the configured PM tool to check for external changes.'
+      purpose: pull-story
       keywords:
         - po
         - pull
@@ -3415,12 +3451,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d6f23501d4f35011fddf5242ed739208e9ec4d767210cd961e6d48373f33a2a3
-      lastVerified: '2026-05-17T10:02:45.139Z'
+      lastVerified: '2026-05-17T14:15:04.380Z'
     po-stories-index:
       path: .aiox-core/development/tasks/po-stories-index.md
       layer: L2
       type: task
-      purpose: '** Regenerate story index from docs/stories/ directory'
+      purpose: 'PO Task: Regenerate Story Index'
       keywords:
         - po
         - stories
@@ -3443,14 +3479,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9e078929826bdec66e9cddbc9f0883568d32cc130e119e3a1da3345b54121dd3
-      lastVerified: '2026-05-17T10:02:45.140Z'
+      lastVerified: '2026-05-17T14:15:04.380Z'
     po-sync-story-to-clickup:
       path: .aiox-core/development/tasks/po-sync-story-to-clickup.md
       layer: L2
       type: task
-      purpose: >-
-        ** Manually force synchronization of a local story file to ClickUp. Use this when you've edited a story file
-        directly (via Edit tool) and need to ensure changes are reflected in ClickUp.
+      purpose: sync-story-to-clickup
       keywords:
         - po
         - sync
@@ -3474,14 +3508,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:03f25fea39d33c6f4febd1dfd467b643bef5cd3d89ceb4766282c173ce810698
-      lastVerified: '2026-05-17T10:02:45.140Z'
+      lastVerified: '2026-05-17T14:15:04.380Z'
     po-sync-story:
       path: .aiox-core/development/tasks/po-sync-story.md
       layer: L2
       type: task
-      purpose: >-
-        ** Synchronize a local story file to the configured PM tool. Works with ClickUp, GitHub Projects, Jira, or
-        local-only mode.
+      purpose: sync-story
       keywords:
         - po
         - sync
@@ -3503,7 +3535,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:67c5e1b02c0d499f12c6727d88a18407f926f440741fb5f8f6e2afa937adec2e
-      lastVerified: '2026-05-17T10:02:45.141Z'
+      lastVerified: '2026-05-17T14:15:04.381Z'
     pr-automation:
       path: .aiox-core/development/tasks/pr-automation.md
       layer: L2
@@ -3533,7 +3565,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:956147dfb7f42983b249041173b85fd75419f71b9018f9991f2b3aa7e59e3885
-      lastVerified: '2026-05-17T13:08:28.425Z'
+      lastVerified: '2026-05-17T14:15:04.381Z'
     project-status:
       path: .aiox-core/development/tasks/project-status.md
       layer: L2
@@ -3560,7 +3592,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3cb76eeb42b7e0b46a06ce0827bc68d2f507a7f4021174b1bd9e68d82463e5e6
-      lastVerified: '2026-05-17T10:02:45.141Z'
+      lastVerified: '2026-05-17T14:15:04.381Z'
     propose-modification:
       path: .aiox-core/development/tasks/propose-modification.md
       layer: L2
@@ -3590,7 +3622,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa340dc0749f40ba7f1ed12ebe107c53f212f764cf7318ee7a816d059528f69e
-      lastVerified: '2026-05-17T10:02:45.142Z'
+      lastVerified: '2026-05-17T14:15:04.382Z'
     publish-npm:
       path: .aiox-core/development/tasks/publish-npm.md
       layer: L2
@@ -3602,21 +3634,24 @@ entities:
         - publishing
         - pipeline
       usedBy: []
-      dependencies: []
+      dependencies:
+        - release-checklist
+        - devops
       externalDeps: []
-      plannedDeps: []
-      lifecycle: orphan
+      plannedDeps:
+        - release-procedure
+      lifecycle: experimental
       adaptability:
         score: 0.8
         constraints: []
         extensionPoints: []
       checksum: sha256:60ce8f90fbe932294dd103f507240413ad75bc2ea9be01a6224de65a9e282f54
-      lastVerified: '2026-05-17T12:22:53.093Z'
+      lastVerified: '2026-05-17T14:15:04.383Z'
     qa-after-creation:
       path: .aiox-core/development/tasks/qa-after-creation.md
       layer: L2
       type: task
-      purpose: '** Automatic quality assurance check after squad/component creation (includes operational completeness)'
+      purpose: 'Task: QA After Creation'
       keywords:
         - qa
         - after
@@ -3632,12 +3667,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e9f6ceff7a0bc00d4fc035e890b7f1178c6ea43f447d135774b46a00713450e6
-      lastVerified: '2026-05-17T10:02:45.143Z'
+      lastVerified: '2026-05-17T14:15:04.383Z'
     qa-backlog-add-followup:
       path: .aiox-core/development/tasks/qa-backlog-add-followup.md
       layer: L2
       type: task
-      purpose: '** Add follow-up item from QA review to backlog'
+      purpose: 'QA Task: Add Follow-up to Backlog'
       keywords:
         - qa
         - backlog
@@ -3662,12 +3697,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:167e6f253eaf69e5751c294eec6a677153996b148ce70ba242506c2812f41535
-      lastVerified: '2026-05-17T10:02:45.144Z'
+      lastVerified: '2026-05-17T14:15:04.383Z'
     qa-browser-console-check:
       path: .aiox-core/development/tasks/qa-browser-console-check.md
       layer: L2
       type: task
-      purpose: Automated console capture
+      purpose: Browser Console Check Task
       keywords:
         - qa
         - browser
@@ -3685,12 +3720,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:deddbb5aed026e5b8b4d100a84baea6f4f85b3a249e56033f6e35e7ac08e2f80
-      lastVerified: '2026-05-17T10:02:45.144Z'
+      lastVerified: '2026-05-17T14:15:04.384Z'
     qa-create-fix-request:
       path: .aiox-core/development/tasks/qa-create-fix-request.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Create Fix Request Task
       keywords:
         - qa
         - create
@@ -3714,12 +3749,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:709ed6f4c0260bf95e9801e22ef75f2b02958f967aaf6b1b6ffc4b7ee34b3e03
-      lastVerified: '2026-05-17T10:02:45.144Z'
+      lastVerified: '2026-05-17T14:15:04.384Z'
     qa-evidence-requirements:
       path: .aiox-core/development/tasks/qa-evidence-requirements.md
       layer: L2
       type: task
-      purpose: '''Screenshot, log, or reproduction steps of the bug'''
+      purpose: Evidence Requirements Task
       keywords:
         - qa
         - evidence
@@ -3737,12 +3772,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cfa30b79bf1eac27511c94de213dbae761f3fb5544da07cc38563bcbd9187569
-      lastVerified: '2026-05-17T10:02:45.145Z'
+      lastVerified: '2026-05-17T14:15:04.384Z'
     qa-false-positive-detection:
       path: .aiox-core/development/tasks/qa-false-positive-detection.md
       layer: L2
       type: task
-      purpose: '"Change looks like it fixes the bug but doesn''t actually address root cause"'
+      purpose: False Positive Detection Task
       keywords:
         - qa
         - 'false'
@@ -3761,7 +3796,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f1a816365c588e7521617fc3aa7435e6f08d1ed06f4f51cce86f9529901d86ce
-      lastVerified: '2026-05-17T10:02:45.145Z'
+      lastVerified: '2026-05-17T14:15:04.385Z'
     qa-fix-issues:
       path: .aiox-core/development/tasks/qa-fix-issues.md
       layer: L2
@@ -3791,7 +3826,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b5db49f2709dbe27bb50d68f46f48b2d1c9a6b176a6025158d8f299e552eb2c3
-      lastVerified: '2026-05-17T10:02:45.145Z'
+      lastVerified: '2026-05-17T14:15:04.385Z'
     qa-gate:
       path: .aiox-core/development/tasks/qa-gate.md
       layer: L2
@@ -3821,7 +3856,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b151ea672e7ad0e9229807f86430e4f3483395ee4beae40f2f17d7f6228aee24
-      lastVerified: '2026-05-17T10:02:45.146Z'
+      lastVerified: '2026-05-17T14:15:04.385Z'
     qa-generate-tests:
       path: .aiox-core/development/tasks/qa-generate-tests.md
       layer: L2
@@ -3856,12 +3891,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:245885950328b086ffbe9320bba2e814b3f6b5e3e5342bac904ccd814d4e8519
-      lastVerified: '2026-05-17T10:02:45.147Z'
+      lastVerified: '2026-05-17T14:15:04.386Z'
     qa-library-validation:
       path: .aiox-core/development/tasks/qa-library-validation.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Library Validation Task
       keywords:
         - qa
         - library
@@ -3879,12 +3914,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:366df913fe32f08ec4bf883c4b6f9781af22cc4bfa23ce25cfdbe56f562b013e
-      lastVerified: '2026-05-17T10:02:45.147Z'
+      lastVerified: '2026-05-17T14:15:04.387Z'
     qa-migration-validation:
       path: .aiox-core/development/tasks/qa-migration-validation.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Migration Validation Task
       keywords:
         - qa
         - migration
@@ -3901,7 +3936,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2f855a1b918066755b8b16d0db7c347b32df372996217542905713459eb29bc4
-      lastVerified: '2026-05-17T10:02:45.148Z'
+      lastVerified: '2026-05-17T14:15:04.387Z'
     qa-nfr-assess:
       path: .aiox-core/development/tasks/qa-nfr-assess.md
       layer: L2
@@ -3926,7 +3961,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f2816ad58335c6d3b68bfc18d95f58b75358f8cb2cab844c7712ef36635a5e37
-      lastVerified: '2026-05-17T10:02:45.148Z'
+      lastVerified: '2026-05-17T14:15:04.388Z'
     qa-review-build:
       path: .aiox-core/development/tasks/qa-review-build.md
       layer: L2
@@ -3956,7 +3991,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9fcc1fd52b5cd18cf0039478c817e17aacf93e09f3e06de4ed308dc36075b5d5
-      lastVerified: '2026-05-17T10:02:45.148Z'
+      lastVerified: '2026-05-17T14:15:04.388Z'
     qa-review-proposal:
       path: .aiox-core/development/tasks/qa-review-proposal.md
       layer: L2
@@ -3987,12 +4022,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:928c0c1929f9935966ba24c27e590ae98b402095f3f54de6aa209d0e5ec9220c
-      lastVerified: '2026-05-17T10:02:45.149Z'
+      lastVerified: '2026-05-17T14:15:04.389Z'
     qa-review-story:
       path: .aiox-core/development/tasks/qa-review-story.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: review-story
       keywords:
         - qa
         - review
@@ -4017,7 +4052,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cc3e189824c656ff6ed2db04bd0a2a03d6293bccbec7e9b7a321daf64b9f1563
-      lastVerified: '2026-05-17T10:02:45.150Z'
+      lastVerified: '2026-05-17T14:15:04.389Z'
     qa-risk-profile:
       path: .aiox-core/development/tasks/qa-risk-profile.md
       layer: L2
@@ -4044,12 +4079,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:69b2b6edb38330234766bef8ed3c27469843e88fb30e130837922541c717432d
-      lastVerified: '2026-05-17T10:02:45.150Z'
+      lastVerified: '2026-05-17T14:15:04.390Z'
     qa-run-tests:
       path: .aiox-core/development/tasks/qa-run-tests.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Run Tests (with Code Quality Gate)
       keywords:
         - qa
         - run
@@ -4072,12 +4107,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f40850e70ffea9aecfb266e784575e0aa0483ea390ab8aae59df3829fd5fa6d8
-      lastVerified: '2026-05-17T10:02:45.151Z'
+      lastVerified: '2026-05-17T14:15:04.390Z'
     qa-security-checklist:
       path: .aiox-core/development/tasks/qa-security-checklist.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Security Checklist Task
       keywords:
         - qa
         - security
@@ -4094,7 +4129,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e155fba83e78f55830558def7ffe03b23c65dd6c2bbe63733b3966d1df6946ab
-      lastVerified: '2026-05-17T10:02:45.151Z'
+      lastVerified: '2026-05-17T14:15:04.390Z'
     qa-test-design:
       path: .aiox-core/development/tasks/qa-test-design.md
       layer: L2
@@ -4121,7 +4156,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:00e2aac4ec1587949b4bbdbd52f84adb8dc10a06395e9f68cc339c4a6fdb7405
-      lastVerified: '2026-05-17T10:02:45.152Z'
+      lastVerified: '2026-05-17T14:15:04.391Z'
     qa-trace-requirements:
       path: .aiox-core/development/tasks/qa-trace-requirements.md
       layer: L2
@@ -4148,7 +4183,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5c4a95d42d33b16ab77606d7a2dd5b18bb78f81f3872150454f10950bc0ee047
-      lastVerified: '2026-05-17T10:02:45.152Z'
+      lastVerified: '2026-05-17T14:15:04.391Z'
     release-management:
       path: .aiox-core/development/tasks/release-management.md
       layer: L2
@@ -4160,20 +4195,21 @@ entities:
         - manage
         - software
         - releases
-      usedBy: []
-      dependencies: []
+      usedBy:
+        - devops
+      dependencies:
+        - devops
       externalDeps: []
       plannedDeps:
-        - package
         - github-devops-checklist
-        - execute-task.js
-      lifecycle: experimental
+        - release-procedure
+      lifecycle: production
       adaptability:
         score: 0.8
         constraints: []
         extensionPoints: []
       checksum: sha256:fc4dd795b0ebc886a0de09452a70764eab5958eae894da639ae2df1829c9dd50
-      lastVerified: '2026-05-17T12:22:53.093Z'
+      lastVerified: '2026-05-17T14:15:04.391Z'
     remove-mcp:
       path: .aiox-core/development/tasks/remove-mcp.md
       layer: L2
@@ -4183,7 +4219,8 @@ entities:
         - remove
         - mcp
         - remove-mcp
-      usedBy: []
+      usedBy:
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -4193,7 +4230,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3f4bf3f8d4d651109dc783e95598ab21569447295f22a7b868d3973f0848aa4c
-      lastVerified: '2026-05-17T10:02:45.153Z'
+      lastVerified: '2026-05-17T14:15:04.391Z'
     remove-worktree:
       path: .aiox-core/development/tasks/remove-worktree.md
       layer: L2
@@ -4207,6 +4244,7 @@ entities:
         - create-worktree
         - list-worktrees
         - dev
+        - devops
       dependencies:
         - worktree-manager
         - create-worktree
@@ -4221,12 +4259,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0ac9497e0a85e16f9e0a5357da43ae8571d1bf2ba98028f9968d2656df3ee36f
-      lastVerified: '2026-05-17T10:02:45.154Z'
+      lastVerified: '2026-05-17T14:15:04.392Z'
     resolve-github-issue:
       path: .aiox-core/development/tasks/resolve-github-issue.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: resolve-github-issue.md
       keywords:
         - resolve
         - github
@@ -4234,6 +4272,7 @@ entities:
         - resolve-github-issue.md
       usedBy:
         - triage-github-issues
+        - devops
       dependencies:
         - triage-github-issues
         - github-devops-pre-push-quality-gate
@@ -4247,7 +4286,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d1e8f775eee3367f0a553f3e767477bad1833e72a731a2df94cde56d5b5eda97
-      lastVerified: '2026-05-17T10:02:45.154Z'
+      lastVerified: '2026-05-17T14:15:04.392Z'
     review-contributor-pr:
       path: .aiox-core/development/tasks/review-contributor-pr.md
       layer: L2
@@ -4269,12 +4308,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dfb5f03fae16171777742b06a9e54ee25711d1d94cedc2152ef9c9331310b608
-      lastVerified: '2026-05-17T10:02:45.154Z'
+      lastVerified: '2026-05-17T14:15:04.392Z'
     run-design-system-pipeline:
       path: .aiox-core/development/tasks/run-design-system-pipeline.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Run Design System Pipeline
       keywords:
         - run
         - design
@@ -4295,7 +4334,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ff4c225b922da347b63aeb6d8aa95484c1c9281eb1e4b4c4ab0ecef0a1a54c26
-      lastVerified: '2026-05-17T10:02:45.155Z'
+      lastVerified: '2026-05-17T14:15:04.393Z'
     run-workflow-engine:
       path: .aiox-core/development/tasks/run-workflow-engine.md
       layer: L2
@@ -4325,7 +4364,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c1f10d20c25283675ca8b7f3644699c17298d7ffd2745640e252aa40bb654397
-      lastVerified: '2026-05-17T10:02:45.155Z'
+      lastVerified: '2026-05-17T14:15:04.393Z'
     run-workflow:
       path: .aiox-core/development/tasks/run-workflow.md
       layer: L2
@@ -4352,18 +4391,19 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:484bb719fc4b4584875370647c59c04bdc24b57eaaf6b99460404b57f80772b1
-      lastVerified: '2026-05-17T10:02:45.156Z'
+      lastVerified: '2026-05-17T14:15:04.394Z'
     search-mcp:
       path: .aiox-core/development/tasks/search-mcp.md
       layer: L2
       type: task
-      purpose: '{full_description}'
+      purpose: Search MCP Catalog Task
       keywords:
         - search
         - mcp
         - catalog
         - task
-      usedBy: []
+      usedBy:
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -4373,12 +4413,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c7d9239c740b250baf9d82a5aa3baf1cd0bb8c671f0889c9a6fc6c0a668ac9c
-      lastVerified: '2026-05-17T10:02:45.156Z'
+      lastVerified: '2026-05-17T14:15:04.394Z'
     security-audit:
       path: .aiox-core/development/tasks/security-audit.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Security Audit'
       keywords:
         - security
         - audit
@@ -4395,7 +4435,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8ae6068628080d67c4c981d0c6e87d6347ddcc2e363d985ef578de22e94d6ae1
-      lastVerified: '2026-05-17T10:02:45.157Z'
+      lastVerified: '2026-05-17T14:15:04.394Z'
     security-scan:
       path: .aiox-core/development/tasks/security-scan.md
       layer: L2
@@ -4418,7 +4458,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2232ced35524452c49197fb4c09099dfc61c4980f31a8cd7fda3cc1b152068ca
-      lastVerified: '2026-05-17T10:02:45.157Z'
+      lastVerified: '2026-05-17T14:15:04.395Z'
     session-resume:
       path: .aiox-core/development/tasks/session-resume.md
       layer: L2
@@ -4441,12 +4481,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0130ea9c24b5c74a7803985f485663dd373edd366c8cbaa5d0143119a4e3cc3e
-      lastVerified: '2026-05-17T10:02:45.158Z'
+      lastVerified: '2026-05-17T14:15:04.395Z'
     setup-database:
       path: .aiox-core/development/tasks/setup-database.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Setup Database'
       keywords:
         - setup
         - database
@@ -4465,12 +4505,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3240013a44d42143a63280f0a1d6a8756a2572027e39b6fe913c1ed956442a38
-      lastVerified: '2026-05-17T10:02:45.158Z'
+      lastVerified: '2026-05-17T14:15:04.395Z'
     setup-design-system:
       path: .aiox-core/development/tasks/setup-design-system.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Setup Design System Structure
       keywords:
         - setup
         - design
@@ -4490,7 +4530,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9cb43d28c66a6b7a8d36a16fc0256ea25c9bb49e214e37bce42cae4908450677
-      lastVerified: '2026-05-17T10:02:45.158Z'
+      lastVerified: '2026-05-17T14:15:04.396Z'
     setup-github:
       path: .aiox-core/development/tasks/setup-github.md
       layer: L2
@@ -4502,7 +4542,8 @@ entities:
         - setup
         - github
         - setup-github
-      usedBy: []
+      usedBy:
+        - devops
       dependencies:
         - environment-bootstrap
         - github-cli.yaml
@@ -4516,7 +4557,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:515cc5f26383c6fde61e38acb4678ead15d701ddc32c668a9b9bcfc9a02f2850
-      lastVerified: '2026-05-17T10:02:45.159Z'
+      lastVerified: '2026-05-17T14:15:04.396Z'
     setup-llm-routing:
       path: .aiox-core/development/tasks/setup-llm-routing.md
       layer: L2
@@ -4542,7 +4583,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:97334fdf1e679d9bd1deecf048f54760c3efdebf38af4daafe82094323f05865
-      lastVerified: '2026-05-17T10:02:45.160Z'
+      lastVerified: '2026-05-17T14:15:04.397Z'
     setup-mcp-docker:
       path: .aiox-core/development/tasks/setup-mcp-docker.md
       layer: L2
@@ -4555,7 +4596,8 @@ entities:
         - mcp
         - docker
         - toolkit
-      usedBy: []
+      usedBy:
+        - devops
       dependencies:
         - devops
       externalDeps: []
@@ -4567,7 +4609,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b65a663641b6667ac46848eab02ecb75da28e09e2cfa4d7d12f979c423eef999
-      lastVerified: '2026-05-17T10:02:45.160Z'
+      lastVerified: '2026-05-17T14:15:04.397Z'
     setup-project-docs:
       path: .aiox-core/development/tasks/setup-project-docs.md
       layer: L2
@@ -4599,7 +4641,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5e2969779d62d05a26fb49d5959d25224de748d2c70aaa72b6f219fb149decee
-      lastVerified: '2026-05-17T10:02:45.160Z'
+      lastVerified: '2026-05-17T14:15:04.397Z'
     shard-doc:
       path: .aiox-core/development/tasks/shard-doc.md
       layer: L2
@@ -4632,7 +4674,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:614fb73a40c4569d30e42a6a5536fbb374f2174bd709a73ad1026df595f50f52
-      lastVerified: '2026-05-17T10:02:45.161Z'
+      lastVerified: '2026-05-17T14:15:04.398Z'
     sm-create-next-story:
       path: .aiox-core/development/tasks/sm-create-next-story.md
       layer: L2
@@ -4647,7 +4689,8 @@ entities:
         - story
         - task
       usedBy: []
-      dependencies: []
+      dependencies:
+        - po-master-checklist
       externalDeps: []
       plannedDeps:
         - tech-stack
@@ -4669,7 +4712,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e5ee6bc856fba12867557c0684d566d520516b4ff0c96e9df91f260786106bd0
-      lastVerified: '2026-05-17T13:08:28.426Z'
+      lastVerified: '2026-05-17T14:15:04.398Z'
     spec-assess-complexity:
       path: .aiox-core/development/tasks/spec-assess-complexity.md
       layer: L2
@@ -4695,7 +4738,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:860d6c4641282a426840ccea8bed766c8eddeb9806e4e0a806a330f70e5b6eca
-      lastVerified: '2026-05-17T10:02:45.162Z'
+      lastVerified: '2026-05-17T14:15:04.398Z'
     spec-critique:
       path: .aiox-core/development/tasks/spec-critique.md
       layer: L2
@@ -4724,7 +4767,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d2c3615b84dff942bb1c36fe1d89d025a5c52eedf15a382e75bba6cee085e7dd
-      lastVerified: '2026-05-17T10:02:45.162Z'
+      lastVerified: '2026-05-17T14:15:04.399Z'
     spec-gather-requirements:
       path: .aiox-core/development/tasks/spec-gather-requirements.md
       layer: L2
@@ -4751,7 +4794,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b2ae9cd6da1233bd610a0a8023dcf1dfece81ab75a1cb6da6b9016e0351a7d40
-      lastVerified: '2026-05-17T10:02:45.163Z'
+      lastVerified: '2026-05-17T14:15:04.400Z'
     spec-research-dependencies:
       path: .aiox-core/development/tasks/spec-research-dependencies.md
       layer: L2
@@ -4778,7 +4821,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c13f6fed7af8e1f8e20295e697637fc6831e559ba9d67d7649786626f2619a43
-      lastVerified: '2026-05-17T10:02:45.163Z'
+      lastVerified: '2026-05-17T14:15:04.400Z'
     spec-write-spec:
       path: .aiox-core/development/tasks/spec-write-spec.md
       layer: L2
@@ -4810,7 +4853,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1ecef348cf83403243398c362629e016ff299b4e0634d7a0581b39d779a113bf
-      lastVerified: '2026-05-17T10:02:45.164Z'
+      lastVerified: '2026-05-17T14:15:04.400Z'
     squad-creator-analyze:
       path: .aiox-core/development/tasks/squad-creator-analyze.md
       layer: L2
@@ -4837,12 +4880,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8aeeae86b0afd75c4f79e8a5f1cca02b3633c9d925ee39725a66795befecc8a8
-      lastVerified: '2026-05-17T10:02:45.164Z'
+      lastVerified: '2026-05-17T14:15:04.401Z'
     squad-creator-create:
       path: .aiox-core/development/tasks/squad-creator-create.md
       layer: L2
       type: task
-      purpose: Descricao (opcional, elicitacao)
+      purpose: '*create-squad'
       keywords:
         - squad
         - creator
@@ -4865,12 +4908,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e4a8b8799837fb0ea60eb9baf3bbe57a27f1c1c7dd67ec8fd0c9d5d8a17bbce2
-      lastVerified: '2026-05-17T10:02:45.165Z'
+      lastVerified: '2026-05-17T14:15:04.401Z'
     squad-creator-design:
       path: .aiox-core/development/tasks/squad-creator-design.md
       layer: L2
       type: task
-      purpose: Human-readable summary of recommendations
+      purpose: '*design-squad'
       keywords:
         - squad
         - creator
@@ -4890,7 +4933,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b5851f22a2466107bf506707a01be7ff857b27b19d5d4ec4c5d0506cb6719e80
-      lastVerified: '2026-05-17T10:02:45.165Z'
+      lastVerified: '2026-05-17T14:15:04.401Z'
     squad-creator-download:
       path: .aiox-core/development/tasks/squad-creator-download.md
       layer: L2
@@ -4912,7 +4955,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5d75af6d41624a4c40d6734031ebc2a8f7eb4eb3ec22f10de32c92d600ddf332
-      lastVerified: '2026-05-17T10:02:45.165Z'
+      lastVerified: '2026-05-17T14:15:04.402Z'
     squad-creator-extend:
       path: .aiox-core/development/tasks/squad-creator-extend.md
       layer: L2
@@ -4941,12 +4984,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2d4a0bbe65d21aea5869b8df3a1e1d81a67e027402c4270b8dd1cc8b7c595573
-      lastVerified: '2026-05-17T10:02:45.166Z'
+      lastVerified: '2026-05-17T14:15:04.402Z'
     squad-creator-list:
       path: .aiox-core/development/tasks/squad-creator-list.md
       layer: L2
       type: task
-      purpose: Squad para automacao de X
+      purpose: '*list-squads'
       keywords:
         - squad
         - creator
@@ -4965,7 +5008,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6bc04c23b31daa2f4e8448a5c28540ed8c35903c1b2c77e3ce7b0986268c8710
-      lastVerified: '2026-05-17T10:02:45.166Z'
+      lastVerified: '2026-05-17T14:15:04.402Z'
     squad-creator-migrate:
       path: .aiox-core/development/tasks/squad-creator-migrate.md
       layer: L2
@@ -4991,12 +5034,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:69a15d3db12cc1268740378fcd411a0a011c3f441e3eea6feaaf0b95f4bf8c1e
-      lastVerified: '2026-05-17T10:02:45.166Z'
+      lastVerified: '2026-05-17T14:15:04.402Z'
     squad-creator-publish:
       path: .aiox-core/development/tasks/squad-creator-publish.md
       layer: L2
       type: task
-      purpose: '** {description}'
+      purpose: '*publish-squad'
       keywords:
         - squad
         - creator
@@ -5013,12 +5056,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9f744f0c1e70e18945bfdc22ea48a103862cdb7fffcbc36ac61d44473248b124
-      lastVerified: '2026-05-17T10:02:45.167Z'
+      lastVerified: '2026-05-17T14:15:04.402Z'
     squad-creator-sync-ide-command:
       path: .aiox-core/development/tasks/squad-creator-sync-ide-command.md
       layer: L2
       type: task
-      purpose: 'Files created:  19'
+      purpose: \*command
       keywords:
         - squad
         - creator
@@ -5036,7 +5079,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4221574f07adb5fb53c7c0c9f85656222a97e623b5e4072cee37e34b82f3f379
-      lastVerified: '2026-05-17T10:02:45.167Z'
+      lastVerified: '2026-05-17T14:15:04.403Z'
     squad-creator-sync-synkra:
       path: .aiox-core/development/tasks/squad-creator-sync-synkra.md
       layer: L2
@@ -5059,7 +5102,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dd03f844de8aa1f1caac31b7791ae96b4a221a650728fb13ff6a6245f2e5f75a
-      lastVerified: '2026-05-17T10:02:45.167Z'
+      lastVerified: '2026-05-17T14:15:04.403Z'
     squad-creator-validate:
       path: .aiox-core/development/tasks/squad-creator-validate.md
       layer: L2
@@ -5085,7 +5128,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:782cc7e67b8d061475d94eff8312d5ec23d3ea84630797d9190384d3b3fafd8e
-      lastVerified: '2026-05-17T10:02:45.167Z'
+      lastVerified: '2026-05-17T14:15:04.403Z'
     story-checkpoint:
       path: .aiox-core/development/tasks/story-checkpoint.md
       layer: L2
@@ -5111,7 +5154,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:467fabe8b0c0c7fcd1bd122fdbdc883992a54656c6774c8cea2963789873ee4a
-      lastVerified: '2026-05-17T10:02:45.168Z'
+      lastVerified: '2026-05-17T14:15:04.403Z'
     sync-documentation:
       path: .aiox-core/development/tasks/sync-documentation.md
       layer: L2
@@ -5135,7 +5178,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8be6c2123aa935ddab5e845375c28213f70476cc9dfb10fd0e444c6d40a7e4ae
-      lastVerified: '2026-05-17T10:02:45.168Z'
+      lastVerified: '2026-05-17T14:15:04.404Z'
     sync-registry-intel:
       path: .aiox-core/development/tasks/sync-registry-intel.md
       layer: L2
@@ -5159,12 +5202,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:908df7d093442ccfd15805dabbd9f16e1f34b92ddb692f408a77484bb3d69a53
-      lastVerified: '2026-05-17T10:02:45.168Z'
+      lastVerified: '2026-05-17T14:15:04.404Z'
     tailwind-upgrade:
       path: .aiox-core/development/tasks/tailwind-upgrade.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Tailwind CSS v4 Upgrade Playbook
       keywords:
         - tailwind
         - upgrade
@@ -5184,12 +5227,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa0bea0fc5513e13782bbb0bdb0564f15d7cc2d30b7954f26e52c980767d4469
-      lastVerified: '2026-05-17T10:02:45.169Z'
+      lastVerified: '2026-05-17T14:15:04.404Z'
     test-as-user:
       path: .aiox-core/development/tasks/test-as-user.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: 'Task: Test As User (RLS Testing)'
       keywords:
         - test
         - as
@@ -5211,7 +5254,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9117f1cf85c63be672b0e0f7207274ad73f384cf0299f5c32f9c2f7ad092a701
-      lastVerified: '2026-05-17T10:02:45.169Z'
+      lastVerified: '2026-05-17T14:15:04.404Z'
     test-validation-task:
       path: .aiox-core/development/tasks/test-validation-task.md
       layer: L2
@@ -5233,12 +5276,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2868bd169192b345cba423f2134d46a0d0337f9fe7135476b593e8e9b81617db
-      lastVerified: '2026-05-17T10:02:45.169Z'
+      lastVerified: '2026-05-17T14:15:04.405Z'
     triage-github-issues:
       path: .aiox-core/development/tasks/triage-github-issues.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: triage-github-issues.md
       keywords:
         - triage
         - github
@@ -5246,6 +5289,7 @@ entities:
         - triage-github-issues.md
       usedBy:
         - resolve-github-issue
+        - devops
       dependencies:
         - resolve-github-issue
         - devops
@@ -5257,12 +5301,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73e1e42f0998a701f8855de6e8666150a284e44efd41878927defa17eded4cfe
-      lastVerified: '2026-05-17T10:02:45.170Z'
+      lastVerified: '2026-05-17T14:15:04.405Z'
     undo-last:
       path: .aiox-core/development/tasks/undo-last.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: No checklists needed - rollback operation with built-in transaction validation
       keywords:
         - undo
         - last
@@ -5284,7 +5328,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c038fd862dadcf7a4ad62e347ffa66e6335bc9bbd63d2e675a810381fb257f8a
-      lastVerified: '2026-05-17T10:02:45.170Z'
+      lastVerified: '2026-05-17T14:15:04.405Z'
     update-aiox:
       path: .aiox-core/development/tasks/update-aiox.md
       layer: L2
@@ -5308,7 +5352,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a88b1f79f52aad5aaaf2c7d385314718fd5f09316f37b65553b838b2cb445f95
-      lastVerified: '2026-05-17T10:02:45.170Z'
+      lastVerified: '2026-05-17T14:15:04.405Z'
     update-manifest:
       path: .aiox-core/development/tasks/update-manifest.md
       layer: L2
@@ -5334,7 +5378,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0ef0a5ed8638d1fa00317796acbd8419ca1bbbfa0c5e42109dda3d82300d8c12
-      lastVerified: '2026-05-17T10:02:45.170Z'
+      lastVerified: '2026-05-17T14:15:04.406Z'
     update-source-tree:
       path: .aiox-core/development/tasks/update-source-tree.md
       layer: L2
@@ -5358,12 +5402,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1d7eb7cbc8fa582375edc0275e98415f110e0507cb77744954fa342592ac1c56
-      lastVerified: '2026-05-17T10:02:45.171Z'
+      lastVerified: '2026-05-17T14:15:04.406Z'
     ux-create-wireframe:
       path: .aiox-core/development/tasks/ux-create-wireframe.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Create Wireframes & Interaction Flows
       keywords:
         - ux
         - create
@@ -5383,12 +5427,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d3fe6c03050d98d0a46024c6c6aae32d4fb5e6d7b4a06b01401c54b0853469ce
-      lastVerified: '2026-05-17T10:02:45.171Z'
+      lastVerified: '2026-05-17T14:15:04.406Z'
     ux-ds-scan-artifact:
       path: .aiox-core/development/tasks/ux-ds-scan-artifact.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Design System Artifact Scanner
       keywords:
         - ux
         - ds
@@ -5411,12 +5455,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5a6eb9d40350c3cc15099f8f42beb8a15d64021916e4ec2e82142b33cecb1635
-      lastVerified: '2026-05-17T10:02:45.171Z'
+      lastVerified: '2026-05-17T14:15:04.407Z'
     ux-user-research:
       path: .aiox-core/development/tasks/ux-user-research.md
       layer: L2
       type: task
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: User Research & Needs Analysis
       keywords:
         - ux
         - user
@@ -5437,7 +5481,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0c497783693c6b49d71a99c136f3c016f94afe1fd7556eb6c050aa05a60adade
-      lastVerified: '2026-05-17T10:02:45.172Z'
+      lastVerified: '2026-05-17T14:15:04.407Z'
     validate-agents:
       path: .aiox-core/development/tasks/validate-agents.md
       layer: L2
@@ -5457,7 +5501,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b278ba27cf8171d143aba30bd2f708b9226526dae70e9b881f52b5e1e908525f
-      lastVerified: '2026-05-17T10:02:45.172Z'
+      lastVerified: '2026-05-17T14:15:04.407Z'
     validate-next-story:
       path: .aiox-core/development/tasks/validate-next-story.md
       layer: L2
@@ -5474,7 +5518,18 @@ entities:
         - po-close-story
         - dev
         - po
-      dependencies: []
+      dependencies:
+        - po-master-checklist
+        - dev
+        - data-engineer
+        - devops
+        - ux-design-expert
+        - analyst
+        - architect
+        - pm
+        - qa
+        - po
+        - sm
       externalDeps: []
       plannedDeps:
         - validation-engine.js
@@ -5485,12 +5540,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:277faba94cba30ac3773159d641fc2b8a345efd70dcfef6bae15f8a6280128ea
-      lastVerified: '2026-05-17T13:08:28.426Z'
+      lastVerified: '2026-05-17T14:15:04.407Z'
     validate-tech-preset:
       path: .aiox-core/development/tasks/validate-tech-preset.md
       layer: L2
       type: task
-      purpose: 'string # Required - when to use'
+      purpose: \*validate-tech-preset
       keywords:
         - validate
         - tech
@@ -5508,7 +5563,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:50a65289c223c1a79b0bebe4120f3f703df45d42522309e658f6d0f5c9fdb54e
-      lastVerified: '2026-05-17T10:02:45.173Z'
+      lastVerified: '2026-05-17T14:15:04.408Z'
     validate-workflow:
       path: .aiox-core/development/tasks/validate-workflow.md
       layer: L2
@@ -5533,7 +5588,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e01147feb106d803a298447e5a4988d5310e65cd5b5e291f771923d457056008
-      lastVerified: '2026-05-17T10:02:45.173Z'
+      lastVerified: '2026-05-17T14:15:04.408Z'
     verify-subtask:
       path: .aiox-core/development/tasks/verify-subtask.md
       layer: L2
@@ -5557,12 +5612,14 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4ad9d89256ed9c34f104ae951e7d3b3739f6c5611f22fcf98ab5b666b60cc39f
-      lastVerified: '2026-05-17T10:02:45.173Z'
+      lastVerified: '2026-05-17T14:15:04.408Z'
     waves:
       path: .aiox-core/development/tasks/waves.md
       layer: L2
       type: task
-      purpose: 'Task: `*waves` - Wave Analysis'
+      purpose: >-
+        Analyzes workflow task dependencies to identify waves of tasks that can execute in parallel. Shows optimization
+        opportunities and critical path.
       keywords:
         - waves
         - 'task:'
@@ -5582,7 +5639,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f5bfc1c3d03bf9fbf7c7ac859dd5c388d327abc154f6c064e33dcbae3f94dbd9
-      lastVerified: '2026-05-17T10:02:45.174Z'
+      lastVerified: '2026-05-17T14:15:04.408Z'
     yolo-toggle:
       path: .aiox-core/development/tasks/yolo-toggle.md
       layer: L2
@@ -5605,7 +5662,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4fd6b6d8b2dc0130377ab66fcdf328e48df7701fb621cf919932245886642405
-      lastVerified: '2026-05-17T10:02:45.174Z'
+      lastVerified: '2026-05-17T14:15:04.408Z'
     README:
       path: .aiox-core/development/tasks/blocks/README.md
       layer: L2
@@ -5628,7 +5685,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:484409d3b069c30a14ba28873388567f06d613e6feb9acb14537434d1db03446
-      lastVerified: '2026-05-17T10:02:45.174Z'
+      lastVerified: '2026-05-17T14:15:04.409Z'
     agent-prompt-template:
       path: .aiox-core/development/tasks/blocks/agent-prompt-template.md
       layer: L2
@@ -5652,7 +5709,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7f61c142e66622159ed2ef119ed0abbc95ed514f21749a957f1aaa3babc57b36
-      lastVerified: '2026-05-17T10:02:45.175Z'
+      lastVerified: '2026-05-17T14:15:04.409Z'
     context-loading:
       path: .aiox-core/development/tasks/blocks/context-loading.md
       layer: L2
@@ -5675,7 +5732,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:281c958fa18a2a104c41a3b4b0d0338298034e4bf4e4f5b5085d10d8f603d797
-      lastVerified: '2026-05-17T10:02:45.175Z'
+      lastVerified: '2026-05-17T14:15:04.409Z'
     execution-pattern:
       path: .aiox-core/development/tasks/blocks/execution-pattern.md
       layer: L2
@@ -5697,7 +5754,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a29498d6f59be665a1fe494f3d2ce138da1b7f7eb62028f60acbe7a577bb2bd
-      lastVerified: '2026-05-17T10:02:45.175Z'
+      lastVerified: '2026-05-17T14:15:04.409Z'
     finalization:
       path: .aiox-core/development/tasks/blocks/finalization.md
       layer: L2
@@ -5718,7 +5775,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8414839ac579a6e25c8ad8cc3218bb5f216288ef30a0a995dde59d3d7dc9130e
-      lastVerified: '2026-05-17T10:02:45.175Z'
+      lastVerified: '2026-05-17T14:15:04.409Z'
   templates:
     activation-instructions-inline-greeting:
       path: .aiox-core/product/templates/activation-instructions-inline-greeting.yaml
@@ -5741,12 +5798,14 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d4d3dc2bf0c06c0094ab0e76029c0ad322222e3420240ac3abcac6c150a4ae01
-      lastVerified: '2026-05-17T10:02:45.179Z'
+      lastVerified: '2026-05-17T14:15:04.413Z'
     activation-instructions-template:
       path: .aiox-core/product/templates/activation-instructions-template.md
       layer: L2
       type: template
-      purpose: '"Show all available commands"'
+      purpose: >-
+        This template defines the canonical activation-instructions format for AIOX agents after GreetingBuilder
+        integration (Story 6.1.2.5).
       keywords:
         - activation
         - instructions
@@ -5762,7 +5821,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b4df5343728e565d975c28cad8a1a9dac370d0cf827689ced1c553268dc265e7
-      lastVerified: '2026-05-17T10:02:45.180Z'
+      lastVerified: '2026-05-17T14:15:04.414Z'
     agent-template:
       path: .aiox-core/product/templates/agent-template.yaml
       layer: L2
@@ -5785,7 +5844,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:98676fcc493c0d5f09264dcc52fcc2cf1129f9a195824ecb4c2ec035c2515121
-      lastVerified: '2026-05-17T10:02:45.180Z'
+      lastVerified: '2026-05-17T14:15:04.414Z'
     aiox-ai-config:
       path: .aiox-core/product/templates/aiox-ai-config.yaml
       layer: L2
@@ -5807,12 +5866,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:14efe89e4be87326f621b1ff2a03c928806566ec134e74b191ff24156d5a0140
-      lastVerified: '2026-05-17T10:02:45.181Z'
+      lastVerified: '2026-05-17T14:15:04.414Z'
     architecture-tmpl:
       path: .aiox-core/product/templates/architecture-tmpl.yaml
       layer: L2
       type: template
-      purpose: '** {{model_purpose}}'
+      purpose: Entity at .aiox-core/product/templates/architecture-tmpl.yaml
       keywords:
         - architecture
         - tmpl
@@ -5828,12 +5887,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9483f38486932842e1bc1a73c35b3f90fa2cd9c703c7d5effabea7dc8f76350a
-      lastVerified: '2026-05-17T10:02:45.181Z'
+      lastVerified: '2026-05-17T14:15:04.415Z'
     brainstorming-output-tmpl:
       path: .aiox-core/product/templates/brainstorming-output-tmpl.yaml
       layer: L2
       type: template
-      purpose: '** {{technique_description}}"'
+      purpose: Entity at .aiox-core/product/templates/brainstorming-output-tmpl.yaml
       keywords:
         - brainstorming
         - output
@@ -5849,12 +5908,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:acd98caed4a32328afdf3f3f42554a4f45e507cc527e95593fb7e63ccb8e66a1
-      lastVerified: '2026-05-17T10:02:45.182Z'
+      lastVerified: '2026-05-17T14:15:04.415Z'
     brownfield-architecture-tmpl:
       path: .aiox-core/product/templates/brownfield-architecture-tmpl.yaml
       layer: L2
       type: template
-      purpose: '** {{existing_project_purpose}}'
+      purpose: Entity at .aiox-core/product/templates/brownfield-architecture-tmpl.yaml
       keywords:
         - brownfield
         - architecture
@@ -5871,7 +5930,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5d399d93a42b674758515e5cf70ffb21cd77befc9f54a8fe0b9dba0773bbbf66
-      lastVerified: '2026-05-17T10:02:45.182Z'
+      lastVerified: '2026-05-17T14:15:04.416Z'
     brownfield-prd-tmpl:
       path: .aiox-core/product/templates/brownfield-prd-tmpl.yaml
       layer: L2
@@ -5893,12 +5952,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bc1852d15e3a383c7519e5976094de3055c494fdd467acd83137700c900c4c61
-      lastVerified: '2026-05-17T10:02:45.183Z'
+      lastVerified: '2026-05-17T14:15:04.416Z'
     brownfield-risk-report-tmpl:
       path: .aiox-core/product/templates/brownfield-risk-report-tmpl.yaml
       layer: L2
       type: template
-      purpose: '>'
+      purpose: Brownfield Risk Report Template
       keywords:
         - brownfield
         - risk
@@ -5916,7 +5975,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2aca2b93e48ea944bce3c933f7466b4e520e4c26ec486e23f0a82cccf6e0356b
-      lastVerified: '2026-05-17T10:02:45.183Z'
+      lastVerified: '2026-05-17T14:15:04.416Z'
     changelog-template:
       path: .aiox-core/product/templates/changelog-template.md
       layer: L2
@@ -5925,7 +5984,8 @@ entities:
       keywords:
         - changelog
         - template
-      usedBy: []
+      usedBy:
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -5935,12 +5995,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:af44d857c9bf8808e89419d1d859557c3c827de143be3c0f36f2a053c9ee9197
-      lastVerified: '2026-05-17T10:02:45.184Z'
+      lastVerified: '2026-05-17T14:15:04.417Z'
     command-rationalization-matrix:
       path: .aiox-core/product/templates/command-rationalization-matrix.md
       layer: L2
       type: template
-      purpose: '** Systematic framework for evaluating agent commands for rationalization'
+      purpose: Command Rationalization Matrix Template
       keywords:
         - command
         - rationalization
@@ -5957,12 +6017,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:651157c5e6ad75323e24d5685660addb4f2cfe8bfa01e0c64a8e7e10c90f1d12
-      lastVerified: '2026-05-17T10:02:45.184Z'
+      lastVerified: '2026-05-17T14:15:04.417Z'
     competitor-analysis-tmpl:
       path: .aiox-core/product/templates/competitor-analysis-tmpl.yaml
       layer: L2
       type: template
-      purpose: '- New market entry assessment'
+      purpose: Entity at .aiox-core/product/templates/competitor-analysis-tmpl.yaml
       keywords:
         - competitor
         - analysis
@@ -5979,7 +6039,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:690cde6406250883a765eddcbad415c737268525340cf2c8679c8f3074c9d507
-      lastVerified: '2026-05-17T10:02:45.184Z'
+      lastVerified: '2026-05-17T14:15:04.417Z'
     current-approach-tmpl:
       path: .aiox-core/product/templates/current-approach-tmpl.md
       layer: L2
@@ -6002,12 +6062,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec258049a5cda587b24523faf6b26ed0242765f4e732af21c4f42e42cf326714
-      lastVerified: '2026-05-17T10:02:45.184Z'
+      lastVerified: '2026-05-17T14:15:04.417Z'
     design-story-tmpl:
       path: .aiox-core/product/templates/design-story-tmpl.yaml
       layer: L2
       type: template
-      purpose: Template for design, research, architecture, and documentation planning stories
+      purpose: Entity at .aiox-core/product/templates/design-story-tmpl.yaml
       keywords:
         - design
         - story
@@ -6029,7 +6089,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2bfefc11ae2bcfc679dbd924c58f8b764fa23538c14cb25344d6edef41968f29
-      lastVerified: '2026-05-17T10:02:45.185Z'
+      lastVerified: '2026-05-17T14:15:04.418Z'
     ds-artifact-analysis:
       path: .aiox-core/product/templates/ds-artifact-analysis.md
       layer: L2
@@ -6052,7 +6112,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2ef1866841e4dcd55f9510f7ca14fd1f754f1e9c8a66cdc74d37ebcee13ede5d
-      lastVerified: '2026-05-17T10:02:45.185Z'
+      lastVerified: '2026-05-17T14:15:04.418Z'
     front-end-architecture-tmpl:
       path: .aiox-core/product/templates/front-end-architecture-tmpl.yaml
       layer: L2
@@ -6075,12 +6135,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de0432b4f98236c3a1d6cc9975b90fbc57727653bdcf6132355c0bcf0b4dbb9c
-      lastVerified: '2026-05-17T10:02:45.186Z'
+      lastVerified: '2026-05-17T14:15:04.418Z'
     front-end-spec-tmpl:
       path: .aiox-core/product/templates/front-end-spec-tmpl.yaml
       layer: L2
       type: template
-      purpose: '** {{screen_purpose}}'
+      purpose: Entity at .aiox-core/product/templates/front-end-spec-tmpl.yaml
       keywords:
         - front
         - end
@@ -6098,12 +6158,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9033c7cccbd0893c11545c680f29c6743de8e7ad8e761c6c2487e2985b0a4411
-      lastVerified: '2026-05-17T10:02:45.186Z'
+      lastVerified: '2026-05-17T14:15:04.419Z'
     fullstack-architecture-tmpl:
       path: .aiox-core/product/templates/fullstack-architecture-tmpl.yaml
       layer: L2
       type: template
-      purpose: '** {{model_purpose}}'
+      purpose: Entity at .aiox-core/product/templates/fullstack-architecture-tmpl.yaml
       keywords:
         - fullstack
         - architecture
@@ -6120,18 +6180,19 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1ac74304138be53d87808b8e4afe6f870936a1f3a9e35e18c3321b3d42145215
-      lastVerified: '2026-05-17T10:02:45.187Z'
+      lastVerified: '2026-05-17T14:15:04.420Z'
     github-actions-cd:
       path: .aiox-core/product/templates/github-actions-cd.yml
       layer: L2
       type: template
-      purpose: Continuous Deployment workflow for staging and production
+      purpose: GitHub Actions CD Template
       keywords:
         - github
         - actions
         - cd
         - template
-      usedBy: []
+      usedBy:
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -6141,18 +6202,19 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e6d6f2da3909a76d188137962076988f8e639a8f580e278ddb076b917a159a63
-      lastVerified: '2026-05-17T10:02:45.187Z'
+      lastVerified: '2026-05-17T14:15:04.420Z'
     github-actions-ci:
       path: .aiox-core/product/templates/github-actions-ci.yml
       layer: L2
       type: template
-      purpose: Continuous Integration workflow for testing and validation
+      purpose: GitHub Actions CI Template
       keywords:
         - github
         - actions
         - ci
         - template
-      usedBy: []
+      usedBy:
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -6162,7 +6224,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5628f43737eb39ba06d9c127dc42c9d89dc1ac712560ea948dee4cc3707fb517
-      lastVerified: '2026-05-17T10:02:45.187Z'
+      lastVerified: '2026-05-17T14:15:04.420Z'
     github-pr-template:
       path: .aiox-core/product/templates/github-pr-template.md
       layer: L2
@@ -6174,7 +6236,8 @@ entities:
         - template
         - pull
         - request
-      usedBy: []
+      usedBy:
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -6184,12 +6247,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:472729ec721fbf37ece2027861bb44e0d7a8f5a5f12d6fddb5b4a58a1fc34dd6
-      lastVerified: '2026-05-17T10:02:45.187Z'
+      lastVerified: '2026-05-17T14:15:04.420Z'
     gordon-mcp:
       path: .aiox-core/product/templates/gordon-mcp.yaml
       layer: L2
       type: template
-      purpose: '"File system access for project files"'
+      purpose: Docker MCP Gordon Configuration Template
       keywords:
         - gordon
         - mcp
@@ -6206,12 +6269,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:54d961455a216f968bcb8234c5bf6cda3676e683f43dfcad7a18abc92dc767ab
-      lastVerified: '2026-05-17T10:02:45.187Z'
+      lastVerified: '2026-05-17T14:15:04.420Z'
     index-strategy-tmpl:
       path: .aiox-core/product/templates/index-strategy-tmpl.yaml
       layer: L2
       type: template
-      purpose: '"Purpose-built index plan tied to access patterns"'
+      purpose: Entity at .aiox-core/product/templates/index-strategy-tmpl.yaml
       keywords:
         - index
         - strategy
@@ -6227,12 +6290,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6db2b40f6eef47f4faa31ce513ee7b0d5f04d9a5e081a72e0cdbad402eb444ae
-      lastVerified: '2026-05-17T10:02:45.188Z'
+      lastVerified: '2026-05-17T14:15:04.420Z'
     market-research-tmpl:
       path: .aiox-core/product/templates/market-research-tmpl.yaml
       layer: L2
       type: template
-      purpose: '** {{brief_overview}}'
+      purpose: Entity at .aiox-core/product/templates/market-research-tmpl.yaml
       keywords:
         - market
         - research
@@ -6249,12 +6312,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a908f070009aa0403f9db542585401912aabe7913726bd2fa26b7954f162b674
-      lastVerified: '2026-05-17T10:02:45.188Z'
+      lastVerified: '2026-05-17T14:15:04.421Z'
     migration-plan-tmpl:
       path: .aiox-core/product/templates/migration-plan-tmpl.yaml
       layer: L2
       type: template
-      purpose: '"Plan and validate a safe schema migration with rollback and tests"'
+      purpose: Entity at .aiox-core/product/templates/migration-plan-tmpl.yaml
       keywords:
         - migration
         - plan
@@ -6270,7 +6333,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d0b8580cab768484a2730b7a7f1032e2bab9643940d29dd3c351b7ac930e8ea1
-      lastVerified: '2026-05-17T10:02:45.189Z'
+      lastVerified: '2026-05-17T14:15:04.421Z'
     migration-strategy-tmpl:
       path: .aiox-core/product/templates/migration-strategy-tmpl.md
       layer: L2
@@ -6293,7 +6356,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:957ffccbe9eb1f1ea90a8951ef9eb187d22e50c2f95c2ff048580892d2f2e25b
-      lastVerified: '2026-05-17T10:02:45.189Z'
+      lastVerified: '2026-05-17T14:15:04.422Z'
     personalized-agent-template:
       path: .aiox-core/product/templates/personalized-agent-template.md
       layer: L2
@@ -6314,12 +6377,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:64062d7d4756859c3522e2a228b9079d1c7a5e22c8d1da69a7f0aa148f6181f2
-      lastVerified: '2026-05-17T10:02:45.189Z'
+      lastVerified: '2026-05-17T14:15:04.422Z'
     personalized-checklist-template:
       path: .aiox-core/product/templates/personalized-checklist-template.md
       layer: L2
       type: template
-      purpose: '** {Brief description of what this checklist validates}'
+      purpose: '{1-2 sentence explanation of checklist purpose and scope}'
       keywords:
         - personalized
         - checklist
@@ -6339,7 +6402,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:269ea02fb70b16e94f84ca1910e1911b1fe9fb190f6ed6e22ced869bde3a2e2d
-      lastVerified: '2026-05-17T10:02:45.190Z'
+      lastVerified: '2026-05-17T14:15:04.422Z'
     personalized-task-template-v2:
       path: .aiox-core/product/templates/personalized-task-template-v2.md
       layer: L2
@@ -6362,7 +6425,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:50dae1fdfd967c1713c76e51a418bb0d00f5d9546cade796973da94faac978d3
-      lastVerified: '2026-05-17T10:02:45.192Z'
+      lastVerified: '2026-05-17T14:15:04.424Z'
     personalized-task-template:
       path: .aiox-core/product/templates/personalized-task-template.md
       layer: L2
@@ -6384,12 +6447,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7d47e5603d8c950afcfd64dc54820bb93681c35f040a842dfcf7f77ead16f53f
-      lastVerified: '2026-05-17T10:02:45.192Z'
+      lastVerified: '2026-05-17T14:15:04.424Z'
     personalized-template-file:
       path: .aiox-core/product/templates/personalized-template-file.yaml
       layer: L2
       type: template
-      purpose: '{Brief description of what this template generates}'
+      purpose: Template File Structure for Synkra AIOX
       keywords:
         - personalized
         - template
@@ -6407,12 +6470,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8de995f022e873f8230000c07b55510c52c1477f30c4cd868f1c6fc5ffa9fd9b
-      lastVerified: '2026-05-17T10:02:45.192Z'
+      lastVerified: '2026-05-17T14:15:04.424Z'
     personalized-workflow-template:
       path: .aiox-core/product/templates/personalized-workflow-template.yaml
       layer: L2
       type: template
-      purpose: '{Brief description of workflow purpose}'
+      purpose: Workflow Template for Synkra AIOX with Agent Personalization
       keywords:
         - personalized
         - workflow
@@ -6430,7 +6493,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2e61ec76a8638046aad135b3a8538810f32b1c7abc6353e35af61766453f74ba
-      lastVerified: '2026-05-17T10:02:45.193Z'
+      lastVerified: '2026-05-17T14:15:04.425Z'
     prd-tmpl:
       path: .aiox-core/product/templates/prd-tmpl.yaml
       layer: L2
@@ -6451,7 +6514,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:25c239f40e05f24aee1986601a98865188dbe3ea00a705028efc3adad6d420f3
-      lastVerified: '2026-05-17T10:02:45.193Z'
+      lastVerified: '2026-05-17T14:15:04.425Z'
     project-brief-tmpl:
       path: .aiox-core/product/templates/project-brief-tmpl.yaml
       layer: L2
@@ -6473,12 +6536,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b8d388268c24dc5018f48a87036d591b11cb122fafe9b59c17809b06ea5d9d58
-      lastVerified: '2026-05-17T10:02:45.193Z'
+      lastVerified: '2026-05-17T14:15:04.425Z'
     qa-gate-tmpl:
       path: .aiox-core/product/templates/qa-gate-tmpl.yaml
       layer: L2
       type: template
-      purpose: '{{critical_description}}'
+      purpose: Entity at .aiox-core/product/templates/qa-gate-tmpl.yaml
       keywords:
         - qa
         - gate
@@ -6494,12 +6557,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a0d3e4a37ee8f719aacb8a31949522bfa239982198d0f347ea7d3f44ad8003ca
-      lastVerified: '2026-05-17T10:02:45.194Z'
+      lastVerified: '2026-05-17T14:15:04.425Z'
     qa-report-tmpl:
       path: .aiox-core/product/templates/qa-report-tmpl.md
       layer: L2
       type: template
-      purpose: '**'
+      purpose: 'QA Report: {{storyId}}'
       keywords:
         - qa
         - report
@@ -6516,12 +6579,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b2b0059050648fad63bfad7fa128225990b2fa6a6fb914902b2a5baf707c1cc6
-      lastVerified: '2026-05-17T10:02:45.194Z'
+      lastVerified: '2026-05-17T14:15:04.425Z'
     rls-policies-tmpl:
       path: .aiox-core/product/templates/rls-policies-tmpl.yaml
       layer: L2
       type: template
-      purpose: '"Row Level Security policies for Supabase tables"'
+      purpose: Row Level Security policies for Supabase tables
       keywords:
         - rls
         - policies
@@ -6537,12 +6600,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3c303ab5a5f95c89f0caf9c632296e8ca43e29a921484523016c1c5bc320428f
-      lastVerified: '2026-05-17T10:02:45.195Z'
+      lastVerified: '2026-05-17T14:15:04.426Z'
     schema-design-tmpl:
       path: .aiox-core/product/templates/schema-design-tmpl.yaml
       layer: L2
       type: template
-      purpose: '"Comprehensive database schema design document for data modeling and implementation"'
+      purpose: Comprehensive database schema design document for data modeling and implementation
       keywords:
         - schema
         - design
@@ -6558,7 +6621,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7c5b7dfc67e1332e1fbf39657169094e2b92cd4fd6c7b441c3586981c732af95
-      lastVerified: '2026-05-17T10:02:45.195Z'
+      lastVerified: '2026-05-17T14:15:04.426Z'
     spec-tmpl:
       path: .aiox-core/product/templates/spec-tmpl.md
       layer: L2
@@ -6579,7 +6642,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ff625ad82e4e0f07c137ab5cd0567caac7980ab985783d2f76443dc900bffa5
-      lastVerified: '2026-05-17T10:02:45.195Z'
+      lastVerified: '2026-05-17T14:15:04.426Z'
     state-persistence-tmpl:
       path: .aiox-core/product/templates/state-persistence-tmpl.yaml
       layer: L2
@@ -6603,7 +6666,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7ff9caabce83ccc14acb05e9d06eaf369a8ebd54c2ddf4988efcc942f6c51037
-      lastVerified: '2026-05-17T10:02:45.195Z'
+      lastVerified: '2026-05-17T14:15:04.427Z'
     story-tmpl:
       path: .aiox-core/product/templates/story-tmpl.yaml
       layer: L2
@@ -6634,12 +6697,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0b64b49e5332cbce7d36da1ff40495628cb6ce650855b752dc82372706d41e13
-      lastVerified: '2026-05-17T10:02:45.196Z'
+      lastVerified: '2026-05-17T14:15:04.427Z'
     task-execution-report:
       path: .aiox-core/product/templates/task-execution-report.md
       layer: L2
       type: template
-      purpose: '** Standardized output structure with personality injection slots'
+      purpose: Task Execution Report Template
       keywords:
         - task
         - execution
@@ -6655,7 +6718,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e0f08a3e199234f3d2207ba8f435786b7d8e1b36174f46cb82fc3666b9a9309e
-      lastVerified: '2026-05-17T10:02:45.196Z'
+      lastVerified: '2026-05-17T14:15:04.427Z'
     task-template:
       path: .aiox-core/product/templates/task-template.md
       layer: L2
@@ -6676,12 +6739,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:aeb3a2843c1ca70a094601573899a47bb5956f3b5cd7a8bbad9d624ae39cf1fe
-      lastVerified: '2026-05-17T10:02:45.196Z'
+      lastVerified: '2026-05-17T14:15:04.427Z'
     tokens-schema-tmpl:
       path: .aiox-core/product/templates/tokens-schema-tmpl.yaml
       layer: L2
       type: template
-      purpose: '"Source of truth for all design tokens - generated by Brad from consolidated patterns"'
+      purpose: Source of truth for all design tokens - generated by Brad from consolidated patterns
       keywords:
         - tokens
         - schema
@@ -6698,12 +6761,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:66a7c164278cbe8b41dcc8525e382bdf5c59673a6694930aa33b857f199b4c2b
-      lastVerified: '2026-05-17T10:02:45.197Z'
+      lastVerified: '2026-05-17T14:15:04.428Z'
     workflow-template:
       path: .aiox-core/product/templates/workflow-template.yaml
       layer: L2
       type: template
-      purpose: '"{{WORKFLOW_DESCRIPTION}}"'
+      purpose: yamllint disable
       keywords:
         - workflow
         - template
@@ -6720,7 +6783,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7185fbc069702ef6c4444c2c0cbf3d95f692435406ab3cad811768de4b7d4a28
-      lastVerified: '2026-05-17T10:02:45.197Z'
+      lastVerified: '2026-05-17T14:15:04.428Z'
     antigravity-rules:
       path: .aiox-core/product/templates/ide-rules/antigravity-rules.md
       layer: L2
@@ -6749,7 +6812,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:150fd84d590c2d41f169afdc2368743cb5a90a94a29df2f217b5e5a8e9c3ee1b
-      lastVerified: '2026-05-17T10:02:45.197Z'
+      lastVerified: '2026-05-17T14:15:04.428Z'
     claude-rules:
       path: .aiox-core/product/templates/ide-rules/claude-rules.md
       layer: L2
@@ -6782,7 +6845,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d5723c0a6d77b7137e9b8699937841f7452302b60905cd35276a319e6ce01742
-      lastVerified: '2026-05-17T10:02:45.197Z'
+      lastVerified: '2026-05-17T14:15:04.428Z'
     codex-rules:
       path: .aiox-core/product/templates/ide-rules/codex-rules.md
       layer: L2
@@ -6817,7 +6880,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:18302f137bda51c687b7c7ad76a17f73d84a1e254801ab9e72837d577962b7c5
-      lastVerified: '2026-05-17T10:02:45.197Z'
+      lastVerified: '2026-05-17T14:15:04.429Z'
     copilot-rules:
       path: .aiox-core/product/templates/ide-rules/copilot-rules.md
       layer: L2
@@ -6840,7 +6903,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5f7ecf4f6dbac28bc49b3a61d0902dcc28023b2918082195aab721b0a24847be
-      lastVerified: '2026-05-17T10:02:45.197Z'
+      lastVerified: '2026-05-17T14:15:04.429Z'
     cursor-rules:
       path: .aiox-core/product/templates/ide-rules/cursor-rules.md
       layer: L2
@@ -6869,7 +6932,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ea607f2b6a089afccbcaaec3b1197b5396c4446e76a689a51867a78bceda09b2
-      lastVerified: '2026-05-17T10:02:45.198Z'
+      lastVerified: '2026-05-17T14:15:04.429Z'
     gemini-rules:
       path: .aiox-core/product/templates/ide-rules/gemini-rules.md
       layer: L2
@@ -6890,7 +6953,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:20f687384c4deb909e9171f8e83f40b962a9cc717755b62d88db285316b2188a
-      lastVerified: '2026-05-17T10:02:45.198Z'
+      lastVerified: '2026-05-17T14:15:04.429Z'
   scripts:
     activation-runtime:
       path: .aiox-core/development/scripts/activation-runtime.js
@@ -6912,12 +6975,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3750084310b5a88e2f8d345ad4b417a408f2633d10dab11f4d648e8e10caa90c
-      lastVerified: '2026-05-17T10:02:45.199Z'
+      lastVerified: '2026-05-17T14:15:04.430Z'
     agent-assignment-resolver:
       path: .aiox-core/development/scripts/agent-assignment-resolver.js
       layer: L2
       type: script
-      purpose: 'Resolve {TODO: Agent Name} placeholders in all 114 task files'
+      purpose: Entity at .aiox-core/development/scripts/agent-assignment-resolver.js
       keywords:
         - agent
         - assignment
@@ -6932,12 +6995,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ae8a89d038cd9af894d9ec45d8b97ed930f84f70e88f17dbf1a3c556e336c75e
-      lastVerified: '2026-05-17T10:02:45.200Z'
+      lastVerified: '2026-05-17T14:15:04.431Z'
     agent-config-loader:
       path: .aiox-core/development/scripts/agent-config-loader.js
       layer: L2
       type: script
-      purpose: Description"
+      purpose: Entity at .aiox-core/development/scripts/agent-config-loader.js
       keywords:
         - agent
         - config
@@ -6957,12 +7020,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6935a5574f887d88101c44340a96f2a4f8d01b2bdeb433108b84253178a106c7
-      lastVerified: '2026-05-17T10:02:45.200Z'
+      lastVerified: '2026-05-17T14:15:04.431Z'
     agent-exit-hooks:
       path: .aiox-core/development/scripts/agent-exit-hooks.js
       layer: L2
       type: script
-      purpose: '* - Save workflow state when commands complete successfully'
+      purpose: Entity at .aiox-core/development/scripts/agent-exit-hooks.js
       keywords:
         - agent
         - exit
@@ -6978,12 +7041,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7aee7f33cae1bc4192a5085898caaf57f4866ce68488637d0f90a6372b616ce8
-      lastVerified: '2026-05-17T10:02:45.200Z'
+      lastVerified: '2026-05-17T14:15:04.432Z'
     apply-inline-greeting-all-agents:
       path: .aiox-core/development/scripts/apply-inline-greeting-all-agents.js
       layer: L2
       type: script
-      purpose: '"**Role:** {persona.role}"'
+      purpose: Entity at .aiox-core/development/scripts/apply-inline-greeting-all-agents.js
       keywords:
         - apply
         - inline
@@ -7000,12 +7063,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5de6a7ddcab1ae34043b8a030b664deb9ce79e187ca30d22656716240e76a030
-      lastVerified: '2026-05-17T10:02:45.201Z'
+      lastVerified: '2026-05-17T14:15:04.432Z'
     approval-workflow:
       path: .aiox-core/development/scripts/approval-workflow.js
       layer: L2
       type: script
-      purpose: impactReport.summary,
+      purpose: Entity at .aiox-core/development/scripts/approval-workflow.js
       keywords:
         - approval
         - workflow
@@ -7019,7 +7082,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:06979905e62b61e6dde1d2e1714ce61b9a4538a31f31ae1e5f41365f36395b09
-      lastVerified: '2026-05-17T10:02:45.201Z'
+      lastVerified: '2026-05-17T14:15:04.432Z'
     audit-agent-config:
       path: .aiox-core/development/scripts/audit-agent-config.js
       layer: L2
@@ -7039,12 +7102,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d3908286737b3951a0140224aae604d63ab485d503d1f0fb83bc902112637db0
-      lastVerified: '2026-05-17T10:02:45.201Z'
+      lastVerified: '2026-05-17T14:15:04.432Z'
     backlog-manager:
       path: .aiox-core/development/scripts/backlog-manager.js
       layer: L2
       type: script
-      purpose: this.description,
+      purpose: Entity at .aiox-core/development/scripts/backlog-manager.js
       keywords:
         - backlog
         - manager
@@ -7061,7 +7124,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7790e867301aed155dcad303feb8113ffd45abe99052e70749ceaae894e9620b
-      lastVerified: '2026-05-17T10:02:45.201Z'
+      lastVerified: '2026-05-17T14:15:04.433Z'
     backup-manager:
       path: .aiox-core/development/scripts/backup-manager.js
       layer: L2
@@ -7082,12 +7145,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:81c9fd6a4b8a8e7feb1f7a9d6ba790e597ad8113a9ca0723ae20eb111bfb3cee
-      lastVerified: '2026-05-17T10:02:45.202Z'
+      lastVerified: '2026-05-17T14:15:04.433Z'
     batch-update-agents-session-context:
       path: .aiox-core/development/scripts/batch-update-agents-session-context.js
       layer: L2
       type: script
-      purpose: ${successCount} updated, ${failCount} failed`);
+      purpose: Entity at .aiox-core/development/scripts/batch-update-agents-session-context.js
       keywords:
         - batch
         - update
@@ -7104,7 +7167,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d6fa38b55d788f0832021a15492d6b19d8967b481c05b87ab67d33a90ff7269b
-      lastVerified: '2026-05-17T10:02:45.202Z'
+      lastVerified: '2026-05-17T14:15:04.433Z'
     branch-manager:
       path: .aiox-core/development/scripts/branch-manager.js
       layer: L2
@@ -7124,12 +7187,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5d292b329fea370ee9e0930c5d6e9cb5c69af78ec1435ee194ddba0c3d2232a1
-      lastVerified: '2026-05-17T10:02:45.202Z'
+      lastVerified: '2026-05-17T14:15:04.433Z'
     code-quality-improver:
       path: .aiox-core/development/scripts/code-quality-improver.js
       layer: L2
       type: script
-      purpose: '''Apply consistent code formatting'','
+      purpose: Entity at .aiox-core/development/scripts/code-quality-improver.js
       keywords:
         - code
         - quality
@@ -7144,12 +7207,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d0c844089e53dcd6c06755d4cb432a60fbebcedcf5a86ed635650573549a1941
-      lastVerified: '2026-05-17T10:02:45.203Z'
+      lastVerified: '2026-05-17T14:15:04.434Z'
     commit-message-generator:
       path: .aiox-core/development/scripts/commit-message-generator.js
       layer: L2
       type: script
-      purpose: ''';'
+      purpose: Entity at .aiox-core/development/scripts/commit-message-generator.js
       keywords:
         - commit
         - message
@@ -7166,12 +7229,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c5990a5a012a2994d9a4d29ded445fef21d51e0b8203292104fbbd76b3e23826
-      lastVerified: '2026-05-17T10:02:45.203Z'
+      lastVerified: '2026-05-17T14:15:04.434Z'
     conflict-resolver:
       path: .aiox-core/development/scripts/conflict-resolver.js
       layer: L2
       type: script
-      purpose: '''No conflicts detected'','
+      purpose: Entity at .aiox-core/development/scripts/conflict-resolver.js
       keywords:
         - conflict
         - resolver
@@ -7186,7 +7249,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8971b9aca2ab23a9478ac70e59710ec843f483fcbe088371444f4fc9b56c5278
-      lastVerified: '2026-05-17T10:02:45.204Z'
+      lastVerified: '2026-05-17T14:15:04.435Z'
     decision-context:
       path: .aiox-core/development/scripts/decision-context.js
       layer: L2
@@ -7206,7 +7269,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7deca4e738f078e2ccded6e8e26d2322697ea7b9fedf5a48fe8eec18e227c347
-      lastVerified: '2026-05-17T10:02:45.204Z'
+      lastVerified: '2026-05-17T14:15:04.435Z'
     decision-log-generator:
       path: .aiox-core/development/scripts/decision-log-generator.js
       layer: L2
@@ -7233,7 +7296,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:15f1c67d72d2572c68cf8738dfc549166c424475f6706502496f4e21596db504
-      lastVerified: '2026-05-17T10:02:45.204Z'
+      lastVerified: '2026-05-17T14:15:04.435Z'
     decision-log-indexer:
       path: .aiox-core/development/scripts/decision-log-indexer.js
       layer: L2
@@ -7254,12 +7317,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4525176b92aefc6ea7387fc350e325192af044769b4774fde5bf35d74f93fd56
-      lastVerified: '2026-05-17T10:02:45.205Z'
+      lastVerified: '2026-05-17T14:15:04.435Z'
     decision-recorder:
       path: .aiox-core/development/scripts/decision-recorder.js
       layer: L2
       type: script
-      purpose: ''');'
+      purpose: Entity at .aiox-core/development/scripts/decision-recorder.js
       keywords:
         - decision
         - recorder
@@ -7277,12 +7340,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73a259407434e4c4653232e578d408ea6dbde5b809a8c16b7cb169933b941c1c
-      lastVerified: '2026-05-17T10:02:45.205Z'
+      lastVerified: '2026-05-17T14:15:04.436Z'
     dependency-analyzer:
       path: .aiox-core/development/scripts/dependency-analyzer.js
       layer: L2
       type: script
-      purpose: '`Dependency task for ${id}`,'
+      purpose: Entity at .aiox-core/development/scripts/dependency-analyzer.js
       keywords:
         - dependency
         - analyzer
@@ -7296,7 +7359,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0ab1a54c3df1cd81c8bc4b7f4d769f91c7b0bfa6ce38b8c7e1d7d5b223d2245f
-      lastVerified: '2026-05-17T10:02:45.205Z'
+      lastVerified: '2026-05-17T14:15:04.436Z'
     dev-context-loader:
       path: .aiox-core/development/scripts/dev-context-loader.js
       layer: L2
@@ -7316,12 +7379,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0db8d8c4ec863935b02263560d90a901462fb51a87e922baee26882c9d3b8f7c
-      lastVerified: '2026-05-17T10:02:45.206Z'
+      lastVerified: '2026-05-17T14:15:04.436Z'
     diff-generator:
       path: .aiox-core/development/scripts/diff-generator.js
       layer: L2
       type: script
-      purpose: '{'
+      purpose: Entity at .aiox-core/development/scripts/diff-generator.js
       keywords:
         - diff
         - generator
@@ -7335,7 +7398,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cad97b0096fc034fa6ed6cbd14a963abe32d880c1ce8034b6aa62af2e2239833
-      lastVerified: '2026-05-17T10:02:45.206Z'
+      lastVerified: '2026-05-17T14:15:04.436Z'
     elicitation-engine:
       path: .aiox-core/development/scripts/elicitation-engine.js
       layer: L2
@@ -7356,7 +7419,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ce7ea9b9c7e3600fcec27eee444a2860c15ec187ca449f3b63564f453d71c50
-      lastVerified: '2026-05-17T10:02:45.206Z'
+      lastVerified: '2026-05-17T14:15:04.436Z'
     elicitation-session-manager:
       path: .aiox-core/development/scripts/elicitation-session-manager.js
       layer: L2
@@ -7377,7 +7440,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0a7141f2cf61e8fa32f8c861633b50e87e75bc6023b650756c1b55ad947d314b
-      lastVerified: '2026-05-17T10:02:45.206Z'
+      lastVerified: '2026-05-17T14:15:04.437Z'
     generate-greeting:
       path: .aiox-core/development/scripts/generate-greeting.js
       layer: L2
@@ -7397,7 +7460,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:49b857fe36a0216a0df8395a6847f14608bd6a228817276201d22598a6862a4f
-      lastVerified: '2026-05-17T10:02:45.206Z'
+      lastVerified: '2026-05-17T14:15:04.437Z'
     git-wrapper:
       path: .aiox-core/development/scripts/git-wrapper.js
       layer: L2
@@ -7417,12 +7480,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ca880db21647162725bbc5bcd4a01613ad2cc4911aa829a9b9242a05bb62283a
-      lastVerified: '2026-05-17T10:02:45.207Z'
+      lastVerified: '2026-05-17T14:15:04.437Z'
     greeting-builder:
       path: .aiox-core/development/scripts/greeting-builder.js
       layer: L2
       type: script
-      purpose: 'context.sessionMessage, recommendedCommand: null };'
+      purpose: Entity at .aiox-core/development/scripts/greeting-builder.js
       keywords:
         - greeting
         - builder
@@ -7448,7 +7511,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dd0c50dc690a44fdddd9cf8adde609ea0ef2aa6916a78b9fcc971195ddff5656
-      lastVerified: '2026-05-17T10:02:45.208Z'
+      lastVerified: '2026-05-17T14:15:04.438Z'
     greeting-config-cli:
       path: .aiox-core/development/scripts/greeting-config-cli.js
       layer: L2
@@ -7469,7 +7532,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c6e5c4dac08349b17cae64562311a5c2fab8d7c29bc96d86cbe2b43846312b3d
-      lastVerified: '2026-05-17T10:02:45.209Z'
+      lastVerified: '2026-05-17T14:15:04.439Z'
     greeting-preference-manager:
       path: .aiox-core/development/scripts/greeting-preference-manager.js
       layer: L2
@@ -7492,7 +7555,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f6e8034fb7eb27a05f0ef186351282073c3e9b7d5d1db67fb88814c9b72fc219
-      lastVerified: '2026-05-17T10:02:45.209Z'
+      lastVerified: '2026-05-17T14:15:04.439Z'
     issue-triage:
       path: .aiox-core/development/scripts/issue-triage.js
       layer: L2
@@ -7511,12 +7574,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a9f9741b1426732f19803bf9f292b15d8eed0fb875cf02df70735f48512f2310
-      lastVerified: '2026-05-17T10:02:45.209Z'
+      lastVerified: '2026-05-17T14:15:04.439Z'
     manifest-preview:
       path: .aiox-core/development/scripts/manifest-preview.js
       layer: L2
       type: script
-      purpose: componentInfo.description })
+      purpose: Entity at .aiox-core/development/scripts/manifest-preview.js
       keywords:
         - manifest
         - preview
@@ -7532,12 +7595,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:93fff0b2f1993f1f03352a8d9162b93368a7f3b0caf1223ea23b228d092d2084
-      lastVerified: '2026-05-17T10:02:45.209Z'
+      lastVerified: '2026-05-17T14:15:04.439Z'
     metrics-tracker:
       path: .aiox-core/development/scripts/metrics-tracker.js
       layer: L2
       type: script
-      purpose: this.generateImpactSummary(entry),
+      purpose: Entity at .aiox-core/development/scripts/metrics-tracker.js
       keywords:
         - metrics
         - tracker
@@ -7552,12 +7615,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ac90ed08276a66591c8170ef5b5501f46cb1ba9d276b383e20fc77a563083312
-      lastVerified: '2026-05-17T10:02:45.209Z'
+      lastVerified: '2026-05-17T14:15:04.439Z'
     migrate-task-to-v2:
       path: .aiox-core/development/scripts/migrate-task-to-v2.js
       layer: L2
       type: script
-      purpose: '** Validate prerequisites BEFORE task execution (blocking)'
+      purpose: Entity at .aiox-core/development/scripts/migrate-task-to-v2.js
       keywords:
         - migrate
         - task
@@ -7573,7 +7636,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6bfef70de9592d53657f10a4e5c4582ac0ff11868d29e78b86676db45816152d
-      lastVerified: '2026-05-17T10:02:45.209Z'
+      lastVerified: '2026-05-17T14:15:04.440Z'
     modification-validator:
       path: .aiox-core/development/scripts/modification-validator.js
       layer: L2
@@ -7595,12 +7658,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8bff78c5ce3a7c1add30f21f3b835aafd1b54b1752b7f24fc687a672026d7b13
-      lastVerified: '2026-05-17T10:02:45.210Z'
+      lastVerified: '2026-05-17T14:15:04.440Z'
     pattern-learner:
       path: .aiox-core/development/scripts/pattern-learner.js
       layer: L2
       type: script
-      purpose: '`Look for code matching: ${pattern.from}`,'
+      purpose: Entity at .aiox-core/development/scripts/pattern-learner.js
       keywords:
         - pattern
         - learner
@@ -7615,7 +7678,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d562b095bd15dc12a4f474883a1ddb25fa4b7353729c1ff1eaa53675b964de52
-      lastVerified: '2026-05-17T10:02:45.210Z'
+      lastVerified: '2026-05-17T14:15:04.440Z'
     performance-analyzer:
       path: .aiox-core/development/scripts/performance-analyzer.js
       layer: L2
@@ -7634,12 +7697,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:52fc6c7dd22d7bdbbdfe51393c845075ee4fad75067fd91665682b9f0654e7c4
-      lastVerified: '2026-05-17T10:02:45.211Z'
+      lastVerified: '2026-05-17T14:15:04.441Z'
     populate-entity-registry:
       path: .aiox-core/development/scripts/populate-entity-registry.js
       layer: L2
       type: script
-      purpose: getCategoryDescription(c.category),
+      purpose: Entity at .aiox-core/development/scripts/populate-entity-registry.js
       keywords:
         - populate
         - entity
@@ -7654,13 +7717,13 @@ entities:
         score: 0.7
         constraints: []
         extensionPoints: []
-      checksum: sha256:418fcbf6ca3a6259f8d13e3290e8e49d6a16917b304039a6470264c5fdece89e
-      lastVerified: '2026-05-17T10:02:45.211Z'
+      checksum: sha256:2bdf871a3435304f69044bd7463c94647316f7d43e5b891c80c5f181f0f01401
+      lastVerified: '2026-05-17T14:15:04.441Z'
     refactoring-suggester:
       path: .aiox-core/development/scripts/refactoring-suggester.js
       layer: L2
       type: script
-      purpose: '''Extract long methods into smaller, focused methods'','
+      purpose: Entity at .aiox-core/development/scripts/refactoring-suggester.js
       keywords:
         - refactoring
         - suggester
@@ -7674,12 +7737,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d50ea6b609c9cf8385979386fee4b4385d11ebcde15460260f66d04c705f6cd9
-      lastVerified: '2026-05-17T10:02:45.211Z'
+      lastVerified: '2026-05-17T14:15:04.441Z'
     rollback-handler:
       path: .aiox-core/development/scripts/rollback-handler.js
       layer: L2
       type: script
-      purpose: ${txn.description}`));
+      purpose: Entity at .aiox-core/development/scripts/rollback-handler.js
       keywords:
         - rollback
         - handler
@@ -7695,12 +7758,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1017334a2fcc7c13cf46f12da127525435c0689e4d123d44156699431e941cd8
-      lastVerified: '2026-05-17T10:02:45.212Z'
+      lastVerified: '2026-05-17T14:15:04.442Z'
     security-checker:
       path: .aiox-core/development/scripts/security-checker.js
       layer: L2
       type: script
-      purpose: '{'
+      purpose: Entity at .aiox-core/development/scripts/security-checker.js
       keywords:
         - security
         - checker
@@ -7714,7 +7777,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e567af91b0b79e7ba51399cf6bfe4279417e632465f923bc8334c28f9405883c
-      lastVerified: '2026-05-17T10:02:45.212Z'
+      lastVerified: '2026-05-17T14:15:04.442Z'
     skill-validator:
       path: .aiox-core/development/scripts/skill-validator.js
       layer: L2
@@ -7733,7 +7796,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b6bab880896a6fdb16d288c11e1d8fe3fa9f57f144b213bcb6eca1560ec38af1
-      lastVerified: '2026-05-17T10:02:45.212Z'
+      lastVerified: '2026-05-17T14:15:04.442Z'
     story-index-generator:
       path: .aiox-core/development/scripts/story-index-generator.js
       layer: L2
@@ -7754,12 +7817,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c9ce1d2f89e76b9b2250aaa2b49a2881fc331dfbdec0bc0c5b7e1ec7767af140
-      lastVerified: '2026-05-17T10:02:45.212Z'
+      lastVerified: '2026-05-17T14:15:04.442Z'
     story-manager:
       path: .aiox-core/development/scripts/story-manager.js
       layer: L2
       type: script
-      purpose: storyContent,
+      purpose: Entity at .aiox-core/development/scripts/story-manager.js
       keywords:
         - story
         - manager
@@ -7780,7 +7843,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ba05c6dc3b29dad5ca57b0dafad8951d750bc30bdc04a9b083d4878c6f84f8f2
-      lastVerified: '2026-05-17T10:02:45.213Z'
+      lastVerified: '2026-05-17T14:15:04.442Z'
     story-update-hook:
       path: .aiox-core/development/scripts/story-update-hook.js
       layer: L2
@@ -7802,12 +7865,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:554a162e434717f86858ef04d8fdfe3ac40decf060cdc3d4d4987959fb2c51df
-      lastVerified: '2026-05-17T10:02:45.213Z'
+      lastVerified: '2026-05-17T14:15:04.443Z'
     task-identifier-resolver:
       path: .aiox-core/development/scripts/task-identifier-resolver.js
       layer: L2
       type: script
-      purpose: 'Resolve {TODO: task identifier} placeholders in all 114 task files'
+      purpose: Entity at .aiox-core/development/scripts/task-identifier-resolver.js
       keywords:
         - task
         - identifier
@@ -7822,7 +7885,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ef63e5302a7393d4409e50fc437fdf33bd85f40b1907862ccfd507188f072d22
-      lastVerified: '2026-05-17T10:02:45.213Z'
+      lastVerified: '2026-05-17T14:15:04.443Z'
     template-engine:
       path: .aiox-core/development/scripts/template-engine.js
       layer: L2
@@ -7841,7 +7904,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b97d091cb9a09e64d8632ae106cd00b3fd8a25bfbdb60d8cda6e5591c7dfd67f
-      lastVerified: '2026-05-17T10:02:45.213Z'
+      lastVerified: '2026-05-17T14:15:04.443Z'
     template-validator:
       path: .aiox-core/development/scripts/template-validator.js
       layer: L2
@@ -7861,7 +7924,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fb87e8d076b57469d33034f2cae32fd01eae81900317a267d26ab18eebaacb17
-      lastVerified: '2026-05-17T10:02:45.214Z'
+      lastVerified: '2026-05-17T14:15:04.443Z'
     test-generator:
       path: .aiox-core/development/scripts/test-generator.js
       layer: L2
@@ -7880,12 +7943,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c49f0d828ba4e5d996f6dc4fedd540fe2a95091de5e45093018686181493d164
-      lastVerified: '2026-05-17T10:02:45.214Z'
+      lastVerified: '2026-05-17T14:15:04.443Z'
     test-greeting-system:
       path: .aiox-core/development/scripts/test-greeting-system.js
       layer: L2
       type: script
-      purpose: '''Show all available commands with descriptions'' },'
+      purpose: Entity at .aiox-core/development/scripts/test-greeting-system.js
       keywords:
         - test
         - greeting
@@ -7901,12 +7964,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:598f32f09db543e67c0e79da78aaa6e2c78eb54b8f91a5014a27c67468e663bb
-      lastVerified: '2026-05-17T10:02:45.214Z'
+      lastVerified: '2026-05-17T14:15:04.444Z'
     transaction-manager:
       path: .aiox-core/development/scripts/transaction-manager.js
       layer: L2
       type: script
-      purpose: options.description || 'Component operation',
+      purpose: Entity at .aiox-core/development/scripts/transaction-manager.js
       keywords:
         - transaction
         - manager
@@ -7921,12 +7984,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c1049e40ffa489206b48a8c95b0a55093ebf95fc2b2fb522e33b0fc8023d7d2a
-      lastVerified: '2026-05-17T10:02:45.215Z'
+      lastVerified: '2026-05-17T14:15:04.444Z'
     unified-activation-pipeline:
       path: .aiox-core/development/scripts/unified-activation-pipeline.js
       layer: L2
       type: script
-      purpose: '''Agent identity — greeting is broken without this'','
+      purpose: Entity at .aiox-core/development/scripts/unified-activation-pipeline.js
       keywords:
         - unified
         - activation
@@ -7953,7 +8016,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6910a7f6b0cef65a0886e0b29bbcb0ee401ca4fb444eb255a7a368cb67327aa7
-      lastVerified: '2026-05-17T10:02:45.216Z'
+      lastVerified: '2026-05-17T14:15:04.445Z'
     usage-tracker:
       path: .aiox-core/development/scripts/usage-tracker.js
       layer: L2
@@ -7973,7 +8036,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6057623755bf0ee1d9e0fb36740fc41914a5f8ca8ad994d40edec260e273744b
-      lastVerified: '2026-05-17T10:02:45.216Z'
+      lastVerified: '2026-05-17T14:15:04.445Z'
     validate-filenames:
       path: .aiox-core/development/scripts/validate-filenames.js
       layer: L2
@@ -7992,7 +8055,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0228b1538ff02dfe1f747038cbb5e86630683a3c950e27d6315bcd762b1a93fd
-      lastVerified: '2026-05-17T10:02:45.217Z'
+      lastVerified: '2026-05-17T14:15:04.446Z'
     validate-task-v2:
       path: .aiox-core/development/scripts/validate-task-v2.js
       layer: L2
@@ -8012,7 +8075,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4abe50b097c2d0f7a722b691ecd84021ea48b76a017ad76f4c49f748d002fe09
-      lastVerified: '2026-05-17T10:02:45.217Z'
+      lastVerified: '2026-05-17T14:15:04.446Z'
     verify-workflow-gaps:
       path: .aiox-core/development/scripts/verify-workflow-gaps.js
       layer: L2
@@ -8038,12 +8101,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a06a3fac2c4fdf995f18d6108d48855a1156b763ef906a3943b94dc9a709c167
-      lastVerified: '2026-05-17T10:02:45.217Z'
+      lastVerified: '2026-05-17T14:15:04.446Z'
     version-tracker:
       path: .aiox-core/development/scripts/version-tracker.js
       layer: L2
       type: script
-      purpose: v.description,
+      purpose: Entity at .aiox-core/development/scripts/version-tracker.js
       keywords:
         - version
         - tracker
@@ -8057,12 +8120,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d11804b82497e2a9c6e83191095681f5d57ac956b69975294f3f9d2efd0a7bdd
-      lastVerified: '2026-05-17T10:02:45.218Z'
+      lastVerified: '2026-05-17T14:15:04.447Z'
     workflow-navigator:
       path: .aiox-core/development/scripts/workflow-navigator.js
       layer: L2
       type: script
-      purpose: step.description || '',
+      purpose: Entity at .aiox-core/development/scripts/workflow-navigator.js
       keywords:
         - workflow
         - navigator
@@ -8079,7 +8142,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e9af315c4b6ed0f3a0ccc0956921b04f75865a019ada427bdb1d871a1a059bcb
-      lastVerified: '2026-05-17T10:02:45.218Z'
+      lastVerified: '2026-05-17T14:15:04.447Z'
     workflow-state-manager:
       path: .aiox-core/development/scripts/workflow-state-manager.js
       layer: L2
@@ -8102,12 +8165,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:34b249724bb9b4625b4c6e0c67f412d341927323278867367faf8999d09e741c
-      lastVerified: '2026-05-17T10:02:45.218Z'
+      lastVerified: '2026-05-17T14:15:04.447Z'
     workflow-validator:
       path: .aiox-core/development/scripts/workflow-validator.js
       layer: L2
       type: script
-      purpose: data.description,
+      purpose: Entity at .aiox-core/development/scripts/workflow-validator.js
       keywords:
         - workflow
         - validator
@@ -8126,7 +8189,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:abb16e5cd34ec06bbca0a31af3fc500c3a5c98f66d0a72546e4a2827653abcd3
-      lastVerified: '2026-05-17T10:02:45.219Z'
+      lastVerified: '2026-05-17T14:15:04.447Z'
     yaml-validator:
       path: .aiox-core/development/scripts/yaml-validator.js
       layer: L2
@@ -8145,7 +8208,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:916864f9e56e1ccb7fc1596bd2da47400e4037f848a0d4e2bc46d0fa24cc544f
-      lastVerified: '2026-05-17T10:02:45.219Z'
+      lastVerified: '2026-05-17T14:15:04.448Z'
     index:
       path: .aiox-core/development/scripts/squad/index.js
       layer: L2
@@ -8171,12 +8234,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d9bab56298104c00cc55d5e68bcf8bf660bc0f2a3f8c7609dc2ed911d34a4492
-      lastVerified: '2026-05-17T10:02:45.219Z'
+      lastVerified: '2026-05-17T14:15:04.448Z'
     squad-analyzer:
       path: .aiox-core/development/scripts/squad/squad-analyzer.js
       layer: L2
       type: script
-      purpose: manifest.description || '',
+      purpose: Entity at .aiox-core/development/scripts/squad/squad-analyzer.js
       keywords:
         - squad
         - analyzer
@@ -8191,12 +8254,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3aa6fd5273ee0cc35331d4150ed98ef43e8ab678c7c7eaaf4b6ea4b40c657b0c
-      lastVerified: '2026-05-17T10:02:45.220Z'
+      lastVerified: '2026-05-17T14:15:04.448Z'
     squad-designer:
       path: .aiox-core/development/scripts/squad/squad-designer.js
       layer: L2
       type: script
-      purpose: '`Squad for ${analysis.domain.replace(/-/g, '' '')} management`,'
+      purpose: Generated by *design-squad
       keywords:
         - squad
         - designer
@@ -8214,12 +8277,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:101cbb7d6ded0d6f991b29ac63dfee2c7bb86cbc8c4fefef728b7d12c3352829
-      lastVerified: '2026-05-17T10:02:45.220Z'
+      lastVerified: '2026-05-17T14:15:04.449Z'
     squad-downloader:
       path: .aiox-core/development/scripts/squad/squad-downloader.js
       layer: L2
       type: script
-      purpose: 'string, type: string}>>}'
+      purpose: Entity at .aiox-core/development/scripts/squad/squad-downloader.js
       keywords:
         - squad
         - downloader
@@ -8236,12 +8299,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e171444c33222c3ee7b34a874ce2298de010ddf9f883d9741084621084564dc9
-      lastVerified: '2026-05-17T10:02:45.221Z'
+      lastVerified: '2026-05-17T14:15:04.449Z'
     squad-extender:
       path: .aiox-core/development/scripts/squad/squad-extender.js
       layer: L2
       type: script
-      purpose: 'description || `${type} component: ${name}`,'
+      purpose: ${context.componentName}
       keywords:
         - squad
         - extender
@@ -8257,12 +8320,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de3ee647aa5d1fb32a4216777f3bd4716022fec64f0566c0a004b0ea4d110cca
-      lastVerified: '2026-05-17T10:02:45.221Z'
+      lastVerified: '2026-05-17T14:15:04.449Z'
     squad-generator:
       path: .aiox-core/development/scripts/squad/squad-generator.js
       layer: L2
       type: script
-      purpose: ${safeYamlValue(config.description || 'Custom squad')}
+      purpose: '*${taskName.replace(/-/g, ''-'')}'
       keywords:
         - squad
         - generator
@@ -8281,7 +8344,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c8c75b71af915c95b781662ba5cdee5899fd6842966fd8b90019923e091be575
-      lastVerified: '2026-05-17T10:02:45.222Z'
+      lastVerified: '2026-05-17T14:15:04.450Z'
     squad-loader:
       path: .aiox-core/development/scripts/squad/squad-loader.js
       layer: L2
@@ -8307,7 +8370,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7093b9457c93da6845722bf7eac660164963d5007c459afae2149340a7979f1f
-      lastVerified: '2026-05-17T10:02:45.222Z'
+      lastVerified: '2026-05-17T14:15:04.450Z'
     squad-migrator:
       path: .aiox-core/development/scripts/squad/squad-migrator.js
       layer: L2
@@ -8328,12 +8391,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:38d7906b3718701130c79ed66f2916710f0f13fb2d445b13e8cdb1c199192a0d
-      lastVerified: '2026-05-17T10:02:45.222Z'
+      lastVerified: '2026-05-17T14:15:04.450Z'
     squad-publisher:
       path: .aiox-core/development/scripts/squad/squad-publisher.js
       layer: L2
       type: script
-      purpose: '** ${manifest.description || ''No description provided''}'
+      purpose: Entity at .aiox-core/development/scripts/squad/squad-publisher.js
       keywords:
         - squad
         - publisher
@@ -8350,7 +8413,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73b3adcf1b6edb16cd1679fe37852d1f2fde5c89cee4ea7b0ae8ca95f7ff85d2
-      lastVerified: '2026-05-17T10:02:45.223Z'
+      lastVerified: '2026-05-17T14:15:04.451Z'
     squad-validator:
       path: .aiox-core/development/scripts/squad/squad-validator.js
       layer: L2
@@ -8379,7 +8442,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bba0ca266653ca7d6162de011165256e6e49ebe34f2136ae16a4c3393901ab27
-      lastVerified: '2026-05-17T10:02:45.223Z'
+      lastVerified: '2026-05-17T14:15:04.451Z'
   modules:
     index.esm:
       path: .aiox-core/core/index.esm.js
@@ -8410,7 +8473,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:10586193db3efc151c4347d24786a657a01f611a0ffb55ce4008e62c6fe89e40
-      lastVerified: '2026-05-17T10:02:45.229Z'
+      lastVerified: '2026-05-17T14:15:04.459Z'
     index:
       path: .aiox-core/core/index.js
       layer: L1
@@ -8443,7 +8506,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b09d5546bdb1507c60ddc5dc9b48760b55e4e6a4ccc8fdcb63e168e8ea334b13
-      lastVerified: '2026-05-17T10:02:45.229Z'
+      lastVerified: '2026-05-17T14:15:04.459Z'
     code-intel-client:
       path: .aiox-core/core/code-intel/code-intel-client.js
       layer: L1
@@ -8466,7 +8529,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c9a08a37775acf90397aa079a4ad2c5edcc47f2cfd592b26ae9f3d154d1deb8
-      lastVerified: '2026-05-17T10:02:45.229Z'
+      lastVerified: '2026-05-17T14:15:04.459Z'
     code-intel-enricher:
       path: .aiox-core/core/code-intel/code-intel-enricher.js
       layer: L1
@@ -8487,7 +8550,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ee54acdce08258a5f52ee51b38e5c4ffe727e42c8682818120addf7f6863549f
-      lastVerified: '2026-05-17T10:02:45.229Z'
+      lastVerified: '2026-05-17T14:15:04.460Z'
     hook-runtime:
       path: .aiox-core/core/code-intel/hook-runtime.js
       layer: L1
@@ -8507,7 +8570,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4d812dc503650ef90249ad2993b3f713aea806138a27455a6a9757329d829c8e
-      lastVerified: '2026-05-17T10:02:45.230Z'
+      lastVerified: '2026-05-17T14:15:04.460Z'
     code-intel-index:
       path: .aiox-core/core/code-intel/index.js
       layer: L1
@@ -8533,7 +8596,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c8103fb966def9e8ed53dc1840e0e853b5fa4f13291a73a179cbae3545f38754
-      lastVerified: '2026-05-17T10:02:45.230Z'
+      lastVerified: '2026-05-17T14:15:04.460Z'
     registry-syncer:
       path: .aiox-core/core/code-intel/registry-syncer.js
       layer: L1
@@ -8555,7 +8618,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0fc20a7f90fc1ac2078878267db64517fd2ae75d8d2a81101d0cac77d1bf6458
-      lastVerified: '2026-05-17T10:02:45.231Z'
+      lastVerified: '2026-05-17T14:15:04.461Z'
     config-cache:
       path: .aiox-core/core/config/config-cache.js
       layer: L1
@@ -8574,7 +8637,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9f3c3f90f574d5f49dd94592ab28109465d025b3a740d8639ab781c2560c12ab
-      lastVerified: '2026-05-17T10:02:45.231Z'
+      lastVerified: '2026-05-17T14:15:04.461Z'
     config-loader:
       path: .aiox-core/core/config/config-loader.js
       layer: L1
@@ -8595,7 +8658,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:05c8cfa5fe8c0bd659ac65791e5b551767e581a465cad6bb42a9c0a31847e4b4
-      lastVerified: '2026-05-17T10:02:45.231Z'
+      lastVerified: '2026-05-17T14:15:04.461Z'
     config-resolver:
       path: .aiox-core/core/config/config-resolver.js
       layer: L1
@@ -8622,7 +8685,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3b29df6954cec440debef87cb4e4e7610c94dc74e562d32c74b8ec57d893213b
-      lastVerified: '2026-05-17T10:02:45.231Z'
+      lastVerified: '2026-05-17T14:15:04.462Z'
     env-interpolator:
       path: .aiox-core/core/config/env-interpolator.js
       layer: L1
@@ -8643,7 +8706,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d9d9782d1c685fc1734034f656903ff35ac71665c0bedb3fc479544c89d1ece1
-      lastVerified: '2026-05-17T10:02:45.232Z'
+      lastVerified: '2026-05-17T14:15:04.462Z'
     merge-utils:
       path: .aiox-core/core/config/merge-utils.js
       layer: L1
@@ -8665,7 +8728,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e25cb65f4c4e855cfeb4acced46d64a8c9cf7e55a97ac051ec3d985b8855c823
-      lastVerified: '2026-05-17T10:02:45.232Z'
+      lastVerified: '2026-05-17T14:15:04.462Z'
     migrate-config:
       path: .aiox-core/core/config/migrate-config.js
       layer: L1
@@ -8684,7 +8747,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5f46e718e0891d6bf5f46d0f9375960a8e12d010b9699cb287bd0fe71f252f41
-      lastVerified: '2026-05-17T10:02:45.232Z'
+      lastVerified: '2026-05-17T14:15:04.462Z'
     template-overrides:
       path: .aiox-core/core/config/template-overrides.js
       layer: L1
@@ -8703,7 +8766,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:202d141a292bc5a8dd0697e044d7627b260839ae8b7119fd40ae486b3a1b0825
-      lastVerified: '2026-05-17T10:02:45.233Z'
+      lastVerified: '2026-05-17T14:15:04.462Z'
     fix-handler:
       path: .aiox-core/core/doctor/fix-handler.js
       layer: L1
@@ -8725,7 +8788,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c8255536f08a622b2773819080bdbf5d65f8f3f43b77eb257d98064cd74903a3
-      lastVerified: '2026-05-17T10:02:45.233Z'
+      lastVerified: '2026-05-17T14:15:04.463Z'
     doctor-index:
       path: .aiox-core/core/doctor/index.js
       layer: L1
@@ -8747,12 +8810,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a6072bf0e5c198b6d83ecf3fb5425d63982ad3a201455ba9e3ae3bd51f690ad6
-      lastVerified: '2026-05-17T10:02:45.233Z'
+      lastVerified: '2026-05-17T14:15:04.463Z'
     agent-elicitation:
       path: .aiox-core/core/elicitation/agent-elicitation.js
       layer: L1
       type: module
-      purpose: '''Let\''s start with the fundamental details about your agent'','
+      purpose: Entity at .aiox-core/core/elicitation/agent-elicitation.js
       keywords:
         - agent
         - elicitation
@@ -8768,7 +8831,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ef13ebff1375279e7b8f0f0bbd3699a0d201f9a67127efa64c4142159a26f417
-      lastVerified: '2026-05-17T10:02:45.233Z'
+      lastVerified: '2026-05-17T14:15:04.463Z'
     elicitation-engine:
       path: .aiox-core/core/elicitation/elicitation-engine.js
       layer: L1
@@ -8793,7 +8856,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:256f31ef3a5dd0ba085beb2a1556194e5f2e47d4d15cfeba6896b0022933400c
-      lastVerified: '2026-05-17T10:02:45.234Z'
+      lastVerified: '2026-05-17T14:15:04.464Z'
     session-manager:
       path: .aiox-core/core/elicitation/session-manager.js
       layer: L1
@@ -8815,12 +8878,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:79e410d808c4b15802d04c9c7f806796c048e846a69d1a69783c619954771f9b
-      lastVerified: '2026-05-17T10:02:45.234Z'
+      lastVerified: '2026-05-17T14:15:04.464Z'
     task-elicitation:
       path: .aiox-core/core/elicitation/task-elicitation.js
       layer: L1
       type: module
-      purpose: '''Define the fundamental details of your task'','
+      purpose: Entity at .aiox-core/core/elicitation/task-elicitation.js
       keywords:
         - task
         - elicitation
@@ -8836,12 +8899,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cc44ad635e60cbdb67d18209b4b50d1fb2824de2234ec607a6639eb1754bfc75
-      lastVerified: '2026-05-17T10:02:45.234Z'
+      lastVerified: '2026-05-17T14:15:04.464Z'
     workflow-elicitation:
       path: .aiox-core/core/elicitation/workflow-elicitation.js
       layer: L1
       type: module
-      purpose: '''Where should this workflow be created?'','
+      purpose: Entity at .aiox-core/core/elicitation/workflow-elicitation.js
       keywords:
         - workflow
         - elicitation
@@ -8858,7 +8921,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:722d9b28d2485e3b5b89af6ea136e6d3907b805b9870f6e07e943d0264dc7fff
-      lastVerified: '2026-05-17T10:02:45.234Z'
+      lastVerified: '2026-05-17T14:15:04.464Z'
     aiox-error:
       path: .aiox-core/core/errors/aiox-error.js
       layer: L1
@@ -8882,7 +8945,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6734641df389f921f1d139c129ec007d15b3a08114a15fe9faf792ed1036d0c8
-      lastVerified: '2026-05-17T10:02:45.234Z'
+      lastVerified: '2026-05-17T14:15:04.464Z'
     constants:
       path: .aiox-core/core/errors/constants.js
       layer: L1
@@ -8904,7 +8967,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9f6fa0b1a9b8538d321674ac43628f42452ce2ac770d0433c1ab84b55b1e56dd
-      lastVerified: '2026-05-17T10:02:45.234Z'
+      lastVerified: '2026-05-17T14:15:04.465Z'
     error-registry:
       path: .aiox-core/core/errors/error-registry.js
       layer: L1
@@ -8927,7 +8990,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7ba8dffa725860a285618593b8ed47b05c4fa488fdedf1282c2e214881c370bc
-      lastVerified: '2026-05-17T10:02:45.234Z'
+      lastVerified: '2026-05-17T14:15:04.465Z'
     errors-index:
       path: .aiox-core/core/errors/index.js
       layer: L1
@@ -8952,7 +9015,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:462d0aed6f57f2e4b9d51bcb20467451473c927e0d182b5c3ad43f352f44122c
-      lastVerified: '2026-05-17T10:02:45.235Z'
+      lastVerified: '2026-05-17T14:15:04.465Z'
     serializer:
       path: .aiox-core/core/errors/serializer.js
       layer: L1
@@ -8974,7 +9037,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7144adaf3a245afd732aef16e2cdb61f08246badb6b90ac1a7f4b73705ff3ce8
-      lastVerified: '2026-05-17T10:02:45.235Z'
+      lastVerified: '2026-05-17T14:15:04.465Z'
     utils:
       path: .aiox-core/core/errors/utils.js
       layer: L1
@@ -8996,7 +9059,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:24b8ff80e98efc2b562843262490b7ac537ee77565715b644f212652192ced62
-      lastVerified: '2026-05-17T10:02:45.235Z'
+      lastVerified: '2026-05-17T14:15:04.466Z'
     dashboard-emitter:
       path: .aiox-core/core/events/dashboard-emitter.js
       layer: L1
@@ -9018,7 +9081,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c694e4fc5765d6c396b25617cc34e3447068af780fdbb202b060a31cd357549
-      lastVerified: '2026-05-17T10:02:45.235Z'
+      lastVerified: '2026-05-17T14:15:04.466Z'
     events-index:
       path: .aiox-core/core/events/index.js
       layer: L1
@@ -9039,7 +9102,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c5a3a1ba660f1a0d7963e4e8a29ee536a301621c941d962c00f67ade17ba7db3
-      lastVerified: '2026-05-17T10:02:45.235Z'
+      lastVerified: '2026-05-17T14:15:04.466Z'
     types:
       path: .aiox-core/core/events/types.js
       layer: L1
@@ -9059,12 +9122,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b9b69520fb8f51aaa9c768006282dfbf17846df9edc829ddc6557d7fa9930865
-      lastVerified: '2026-05-17T10:02:45.235Z'
+      lastVerified: '2026-05-17T14:15:04.466Z'
     autonomous-build-loop:
       path: .aiox-core/core/execution/autonomous-build-loop.js
       layer: L1
       type: module
-      purpose: subtask.description,
+      purpose: Entity at .aiox-core/core/execution/autonomous-build-loop.js
       keywords:
         - autonomous
         - build
@@ -9085,12 +9148,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:22246474800340c7a97c8b865f5f9e3cb162efd45c5db1be2f9f729969a0b6d0
-      lastVerified: '2026-05-17T10:02:45.236Z'
+      lastVerified: '2026-05-17T14:15:04.467Z'
     build-orchestrator:
       path: .aiox-core/core/execution/build-orchestrator.js
       layer: L1
       type: module
-      purpose: ${subtask.description}
+      purpose: Entity at .aiox-core/core/execution/build-orchestrator.js
       keywords:
         - build
         - orchestrator
@@ -9110,7 +9173,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:51aec922a58d5d4121ef156bb961ac7b8f29db711679897fdade6ca71a1635e5
-      lastVerified: '2026-05-17T10:02:45.237Z'
+      lastVerified: '2026-05-17T14:15:04.468Z'
     build-state-manager:
       path: .aiox-core/core/execution/build-state-manager.js
       layer: L1
@@ -9136,12 +9199,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:02bafb4a29e7f769ae775fbc4e571ad34882569665f61ebc28eb87f7043eafc8
-      lastVerified: '2026-05-17T10:02:45.238Z'
+      lastVerified: '2026-05-17T14:15:04.469Z'
     context-injector:
       path: .aiox-core/core/execution/context-injector.js
       layer: L1
       type: module
-      purpose: task.description,
+      purpose: Entity at .aiox-core/core/execution/context-injector.js
       keywords:
         - context
         - injector
@@ -9157,7 +9220,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7654f6e6c3d555f3963369e71edf84b15c0fdec53bd161800b71782f78275244
-      lastVerified: '2026-05-17T10:02:45.238Z'
+      lastVerified: '2026-05-17T14:15:04.469Z'
     parallel-executor:
       path: .aiox-core/core/execution/parallel-executor.js
       layer: L1
@@ -9178,12 +9241,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:46870e5c8ff8db3ee0386e477d427cc98eeb008f630818b093a9524b410590ae
-      lastVerified: '2026-05-17T10:02:45.239Z'
+      lastVerified: '2026-05-17T14:15:04.469Z'
     parallel-monitor:
       path: .aiox-core/core/execution/parallel-monitor.js
       layer: L1
       type: module
-      purpose: t.description,
+      purpose: Entity at .aiox-core/core/execution/parallel-monitor.js
       keywords:
         - parallel
         - monitor
@@ -9197,7 +9260,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:58ecd92f5de9c688f28cf952ae6cc5ee07ddf14dc89fb0ea13b2f0a527e29fae
-      lastVerified: '2026-05-17T10:02:45.239Z'
+      lastVerified: '2026-05-17T14:15:04.469Z'
     rate-limit-manager:
       path: .aiox-core/core/execution/rate-limit-manager.js
       layer: L1
@@ -9218,7 +9281,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b6e2ca99cf59a9dfa5a4e48109d0a47f36262efcc73e69f11a1c0c727d48abb
-      lastVerified: '2026-05-17T10:02:45.239Z'
+      lastVerified: '2026-05-17T14:15:04.469Z'
     result-aggregator:
       path: .aiox-core/core/execution/result-aggregator.js
       layer: L1
@@ -9237,7 +9300,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bcd102ca46e74d61af151aa7877921807c9bf5aba45bfba73f9f5c8cf714d8e2
-      lastVerified: '2026-05-17T10:02:45.240Z'
+      lastVerified: '2026-05-17T14:15:04.470Z'
     semantic-merge-engine:
       path: .aiox-core/core/execution/semantic-merge-engine.js
       layer: L1
@@ -9258,12 +9321,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:26f2a057407cf114a0611944960a8e6d58d93c5e03abe905489e6b699cb98a75
-      lastVerified: '2026-05-17T10:02:45.241Z'
+      lastVerified: '2026-05-17T14:15:04.470Z'
     subagent-dispatcher:
       path: .aiox-core/core/execution/subagent-dispatcher.js
       layer: L1
       type: module
-      purpose: '** ${task.description}\n\n`;'
+      purpose: Entity at .aiox-core/core/execution/subagent-dispatcher.js
       keywords:
         - subagent
         - dispatcher
@@ -9279,12 +9342,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa8ce6aa5fdd85f7a06c3c560a85d904222658076158c35031ddae19bb63efe1
-      lastVerified: '2026-05-17T10:02:45.242Z'
+      lastVerified: '2026-05-17T14:15:04.471Z'
     wave-executor:
       path: .aiox-core/core/execution/wave-executor.js
       layer: L1
       type: module
-      purpose: t.description })),
+      purpose: Entity at .aiox-core/core/execution/wave-executor.js
       keywords:
         - wave
         - executor
@@ -9300,7 +9363,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4e2324edb37ae0729062b5ac029f2891e050e7efd3a48d0f4a1dc4f227a6716b
-      lastVerified: '2026-05-17T10:02:45.243Z'
+      lastVerified: '2026-05-17T14:15:04.472Z'
     delegate-cli:
       path: .aiox-core/core/external-executors/delegate-cli.js
       layer: L1
@@ -9320,7 +9383,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3f4bb7d4edd742ad13dc91ebdc7296b94ac762caa50ea6943429d93cd65c0ce1
-      lastVerified: '2026-05-17T10:02:45.243Z'
+      lastVerified: '2026-05-17T14:15:04.472Z'
     external-executors-index:
       path: .aiox-core/core/external-executors/index.js
       layer: L1
@@ -9340,7 +9403,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:db61bee165e4a7dba3627275d52d6b162e3b2cbf47d31d88beb38682cb8352db
-      lastVerified: '2026-05-17T10:02:45.243Z'
+      lastVerified: '2026-05-17T14:15:04.472Z'
     cli:
       path: .aiox-core/core/graph-dashboard/cli.js
       layer: L1
@@ -9369,7 +9432,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:29f273a06fecc77eb3e39162ba1aaf28e1cbadb2a000158f009817021a30b4d1
-      lastVerified: '2026-05-17T10:02:45.243Z'
+      lastVerified: '2026-05-17T14:15:04.473Z'
     graph-dashboard-index:
       path: .aiox-core/core/graph-dashboard/index.js
       layer: L1
@@ -9390,12 +9453,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d4e43c674dd7c119afd0afacc5b899c35de82890a61a3bcefc957819314f8cee
-      lastVerified: '2026-05-17T10:02:45.244Z'
+      lastVerified: '2026-05-17T14:15:04.473Z'
     base-check:
       path: .aiox-core/core/health-check/base-check.js
       layer: L1
       type: module
-      purpose: this.description,
+      purpose: Entity at .aiox-core/core/health-check/base-check.js
       keywords:
         - base
         - check
@@ -9450,7 +9513,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4bdc81b92825c72ab185fa8f161aa0348d63071f2bc0d894317199e00c269f8d
-      lastVerified: '2026-05-17T10:02:45.244Z'
+      lastVerified: '2026-05-17T14:15:04.473Z'
     check-registry:
       path: .aiox-core/core/health-check/check-registry.js
       layer: L1
@@ -9476,7 +9539,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:131564effd0499f61a2420914be706b9134db955b4adf09bd03eee511c323867
-      lastVerified: '2026-05-17T10:02:45.244Z'
+      lastVerified: '2026-05-17T14:15:04.474Z'
     engine:
       path: .aiox-core/core/health-check/engine.js
       layer: L1
@@ -9496,12 +9559,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7a53405621243960ce482e8d3052a40caf8704d670a9f3388eca294056971497
-      lastVerified: '2026-05-17T10:02:45.245Z'
+      lastVerified: '2026-05-17T14:15:04.474Z'
     health-check-index:
       path: .aiox-core/core/health-check/index.js
       layer: L1
       type: module
-      purpose: '{'
+      purpose: Entity at .aiox-core/core/health-check/index.js
       keywords:
         - index
       usedBy:
@@ -9520,12 +9583,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:738bec37c11cfb02e9df96e3631f74fa0652f5a531c7b0f1d8887e0141b1f72e
-      lastVerified: '2026-05-17T10:02:45.245Z'
+      lastVerified: '2026-05-17T14:15:04.474Z'
     ideation-engine:
       path: .aiox-core/core/ideation/ideation-engine.js
       layer: L1
       type: module
-      purpose: '{'
+      purpose: Entity at .aiox-core/core/ideation/ideation-engine.js
       keywords:
         - ideation
         - engine
@@ -9539,7 +9602,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c91f7bc999eca74394eeae9bc7400e63e134de4092d6bdc08b92bf423e423ec3
-      lastVerified: '2026-05-17T10:02:45.245Z'
+      lastVerified: '2026-05-17T14:15:04.475Z'
     circuit-breaker:
       path: .aiox-core/core/ids/circuit-breaker.js
       layer: L1
@@ -9560,12 +9623,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:63be126f2e0d320daa60cb5b68b21df93cad4c19d1f959e06a6ac776213f8eba
-      lastVerified: '2026-05-17T10:02:45.246Z'
+      lastVerified: '2026-05-17T14:15:04.475Z'
     framework-governor:
       path: .aiox-core/core/ids/framework-governor.js
       layer: L1
       type: module
-      purpose: metadata.purpose || '',
+      purpose: Entity at .aiox-core/core/ids/framework-governor.js
       keywords:
         - framework
         - governor
@@ -9583,12 +9646,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ef7a3b7444a51f2f122c114c662b1db544d1c9e7833dc6f77dce30ac3a2005a2
-      lastVerified: '2026-05-17T10:02:45.246Z'
+      lastVerified: '2026-05-17T14:15:04.476Z'
     incremental-decision-engine:
       path: .aiox-core/core/ids/incremental-decision-engine.js
       layer: L1
       type: module
-      purpose: '{ totalEntities: 0, matchesFound: 0, decision: ''CREATE'', confidence: ''low'' },'
+      purpose: Entity at .aiox-core/core/ids/incremental-decision-engine.js
       keywords:
         - incremental
         - decision
@@ -9605,7 +9668,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:257b1f67f6df8eb91fe0a95405563611b8bf2f836cbca2398a0a394e40d6c219
-      lastVerified: '2026-05-17T10:02:45.247Z'
+      lastVerified: '2026-05-17T14:15:04.476Z'
     ids-index:
       path: .aiox-core/core/ids/index.js
       layer: L1
@@ -9635,7 +9698,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:363ef37a0fcc18e9e2646650f74750a77c21a95e16de976f64f52825cc50a6a1
-      lastVerified: '2026-05-17T10:02:45.247Z'
+      lastVerified: '2026-05-17T14:15:04.476Z'
     layer-classifier:
       path: .aiox-core/core/ids/layer-classifier.js
       layer: L1
@@ -9655,12 +9718,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2a240b70ac3507e50a64b96d580c4d933bf2116125fb52c8237db2ed9ebf27b7
-      lastVerified: '2026-05-17T10:02:45.247Z'
+      lastVerified: '2026-05-17T14:15:04.477Z'
     registry-healer:
       path: .aiox-core/core/ids/registry-healer.js
       layer: L1
       type: module
-      purpose: '''Referenced file does not exist on disk'','
+      purpose: Entity at .aiox-core/core/ids/registry-healer.js
       keywords:
         - registry
         - healer
@@ -9676,7 +9739,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2b128ea4c1e8bc8f9324390ab55c1b3623c9ad3352522cbecec1acaefe472c5d
-      lastVerified: '2026-05-17T10:02:45.248Z'
+      lastVerified: '2026-05-17T14:15:04.477Z'
     registry-loader:
       path: .aiox-core/core/ids/registry-loader.js
       layer: L1
@@ -9701,7 +9764,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:88c67bace0a5ab6a14cb1d096e3f9cab9f5edc0dd8377788e27b692ccefbd487
-      lastVerified: '2026-05-17T10:02:45.248Z'
+      lastVerified: '2026-05-17T14:15:04.477Z'
     registry-updater:
       path: .aiox-core/core/ids/registry-updater.js
       layer: L1
@@ -9722,7 +9785,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:00ae2e78486a9e7b3c8bf8e9ca0e9e955211ee4ae795c630e7f2934840d5596d
-      lastVerified: '2026-05-17T10:02:45.249Z'
+      lastVerified: '2026-05-17T14:15:04.478Z'
     verification-gate:
       path: .aiox-core/core/ids/verification-gate.js
       layer: L1
@@ -9743,7 +9806,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:96050661c90fa52bfc755911d02c9194ec35c00e71fc6bbc92a13686dd53bb91
-      lastVerified: '2026-05-17T10:02:45.249Z'
+      lastVerified: '2026-05-17T14:15:04.478Z'
     manifest-generator:
       path: .aiox-core/core/manifest/manifest-generator.js
       layer: L1
@@ -9762,12 +9825,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:81b796990dd747bbb9785d205dbe5f6d5556754fc51745fb84b7ce4675acbdbf
-      lastVerified: '2026-05-17T10:02:45.249Z'
+      lastVerified: '2026-05-17T14:15:04.478Z'
     manifest-validator:
       path: .aiox-core/core/manifest/manifest-validator.js
       layer: L1
       type: module
-      purpose: '{'
+      purpose: Entity at .aiox-core/core/manifest/manifest-validator.js
       keywords:
         - manifest
         - validator
@@ -9781,7 +9844,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3558e7dbf653eac385222a299d0eddaaf77e119a70ec034f7a7291c401d7be2c
-      lastVerified: '2026-05-17T10:02:45.249Z'
+      lastVerified: '2026-05-17T14:15:04.478Z'
     config-migrator:
       path: .aiox-core/core/mcp/config-migrator.js
       layer: L1
@@ -9803,7 +9866,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0603a288d79e8526a2c757834bab5191bbc240b1b9dcb548b09d10cee97de322
-      lastVerified: '2026-05-17T10:02:45.250Z'
+      lastVerified: '2026-05-17T14:15:04.479Z'
     global-config-manager:
       path: .aiox-core/core/mcp/global-config-manager.js
       layer: L1
@@ -9826,7 +9889,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c010cfff03119c8369a3c4c3cc73ce31d79108dc15c5c66e67f63766a2a2c5d8
-      lastVerified: '2026-05-17T10:02:45.250Z'
+      lastVerified: '2026-05-17T14:15:04.479Z'
     mcp-index:
       path: .aiox-core/core/mcp/index.js
       layer: L1
@@ -9848,7 +9911,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4f9be6c05a2d6d305f6a3c0130e5e1eca18feb41de47245e51ebe1c9a32ffa7f
-      lastVerified: '2026-05-17T10:02:45.250Z'
+      lastVerified: '2026-05-17T14:15:04.479Z'
     os-detector:
       path: .aiox-core/core/mcp/os-detector.js
       layer: L1
@@ -9870,7 +9933,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7c5eb398bf1e53ddc5e31a9367d01709eba56bc53f653430ea7de07e32aa2a11
-      lastVerified: '2026-05-17T10:02:45.250Z'
+      lastVerified: '2026-05-17T14:15:04.479Z'
     symlink-manager:
       path: .aiox-core/core/mcp/symlink-manager.js
       layer: L1
@@ -9892,12 +9955,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b2c68e5664f7f8595b81cbfba69be16d7f37f8d21608c99ddd066808aa2653c1
-      lastVerified: '2026-05-17T10:02:45.250Z'
+      lastVerified: '2026-05-17T14:15:04.479Z'
     gotchas-memory:
       path: .aiox-core/core/memory/gotchas-memory.js
       layer: L1
       type: module
-      purpose: data.description || '',
+      purpose: Entity at .aiox-core/core/memory/gotchas-memory.js
       keywords:
         - gotchas
         - memory
@@ -9916,12 +9979,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:deeb90a6dff9ef284537a1dabf52566cec3f64244f31f4081432515985a94e25
-      lastVerified: '2026-05-17T10:02:45.251Z'
+      lastVerified: '2026-05-17T14:15:04.480Z'
     agent-invoker:
       path: .aiox-core/core/orchestration/agent-invoker.js
       layer: L1
       type: module
-      purpose: null,
+      purpose: Entity at .aiox-core/core/orchestration/agent-invoker.js
       keywords:
         - agent
         - invoker
@@ -9937,12 +10000,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5e1e3428163c35b0c91f694b76a5ca1e520249de1f7f65aae87e6723c01a45e7
-      lastVerified: '2026-05-17T10:02:45.251Z'
+      lastVerified: '2026-05-17T14:15:04.480Z'
     bob-orchestrator:
       path: .aiox-core/core/orchestration/bob-orchestrator.js
       layer: L1
       type: module
-      purpose: sessionCheck.summary,
+      purpose: Entity at .aiox-core/core/orchestration/bob-orchestrator.js
       keywords:
         - bob
         - orchestrator
@@ -9971,7 +10034,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:971a21ed77f09ab76dc2822030c4b36edd1fd9d8ec405b25b32f36f0cd606ec8
-      lastVerified: '2026-05-17T10:02:45.252Z'
+      lastVerified: '2026-05-17T14:15:04.481Z'
     bob-status-writer:
       path: .aiox-core/core/orchestration/bob-status-writer.js
       layer: L1
@@ -9993,7 +10056,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d0368d44b8b45549f503d737b0fdb21afb02db8d544b19f4d0289828501ac016
-      lastVerified: '2026-05-17T10:02:45.252Z'
+      lastVerified: '2026-05-17T14:15:04.481Z'
     brownfield-handler:
       path: .aiox-core/core/orchestration/brownfield-handler.js
       layer: L1
@@ -10017,12 +10080,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:153eed3dcad1b5f58e0abb9ec4fb0c7013f441efeb169ea4a0cfda23f75928fc
-      lastVerified: '2026-05-17T10:02:45.253Z'
+      lastVerified: '2026-05-17T14:15:04.482Z'
     checklist-runner:
       path: .aiox-core/core/orchestration/checklist-runner.js
       layer: L1
       type: module
-      purpose: item,
+      purpose: Entity at .aiox-core/core/orchestration/checklist-runner.js
       keywords:
         - checklist
         - runner
@@ -10038,7 +10101,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:40f17b74c2fe6746f45aa5750c0b85b5af22221e010951eb6e93f5796fb70a8f
-      lastVerified: '2026-05-17T10:02:45.254Z'
+      lastVerified: '2026-05-17T14:15:04.482Z'
     cli-commands:
       path: .aiox-core/core/orchestration/cli-commands.js
       layer: L1
@@ -10059,7 +10122,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cedd09f6938b3e1e0e19c06f4763de00281ddb31529d16ab9e4f74d194a3bd3b
-      lastVerified: '2026-05-17T10:02:45.254Z'
+      lastVerified: '2026-05-17T14:15:04.482Z'
     condition-evaluator:
       path: .aiox-core/core/orchestration/condition-evaluator.js
       layer: L1
@@ -10080,7 +10143,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:daa6755c76359bb99a2e687c9c56f74b52b7151b0b0677a771b8fff24538d2ad
-      lastVerified: '2026-05-17T10:02:45.254Z'
+      lastVerified: '2026-05-17T14:15:04.483Z'
     context-manager:
       path: .aiox-core/core/orchestration/context-manager.js
       layer: L1
@@ -10102,7 +10165,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b6ed0e4eb069558998f95ab0c68fa040b1b8c2aab74ab44e26ab682fe9e247b4
-      lastVerified: '2026-05-17T10:02:45.255Z'
+      lastVerified: '2026-05-17T14:15:04.483Z'
     dashboard-integration:
       path: .aiox-core/core/orchestration/dashboard-integration.js
       layer: L1
@@ -10124,7 +10187,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8f2dd7d3885a9eaf58957505d312923e149f2771ae3ca0cda879631683f826c9
-      lastVerified: '2026-05-17T10:02:45.255Z'
+      lastVerified: '2026-05-17T14:15:04.484Z'
     data-lifecycle-manager:
       path: .aiox-core/core/orchestration/data-lifecycle-manager.js
       layer: L1
@@ -10148,7 +10211,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7fe6c9d9a278a1d7714e7fdba8710fafbc221520b096639be46f2ce1549a5c2a
-      lastVerified: '2026-05-17T10:02:45.256Z'
+      lastVerified: '2026-05-17T14:15:04.484Z'
     epic-context-accumulator:
       path: .aiox-core/core/orchestration/epic-context-accumulator.js
       layer: L1
@@ -10169,7 +10232,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4f342f7fc05f404de2b899358f86143106737b56d6c486c98e988a67d420078b
-      lastVerified: '2026-05-17T10:02:45.256Z'
+      lastVerified: '2026-05-17T14:15:04.484Z'
     execution-profile-resolver:
       path: .aiox-core/core/orchestration/execution-profile-resolver.js
       layer: L1
@@ -10191,7 +10254,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bb35f1c16c47c9306128c5f3e6c90df3ed91f9358576ea97a59007b74f5e9927
-      lastVerified: '2026-05-17T10:02:45.256Z'
+      lastVerified: '2026-05-17T14:15:04.484Z'
     executor-assignment:
       path: .aiox-core/core/orchestration/executor-assignment.js
       layer: L1
@@ -10214,12 +10277,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c046e3e837dbbb82d3877985192d3438d49f369274ac709789b913c502ada617
-      lastVerified: '2026-05-17T10:02:45.257Z'
+      lastVerified: '2026-05-17T14:15:04.484Z'
     fast-path-gate:
       path: .aiox-core/core/orchestration/fast-path-gate.js
       layer: L1
       type: module
-      purpose: String(task.description || task.summary || task.title || ''),
+      purpose: Entity at .aiox-core/core/orchestration/fast-path-gate.js
       keywords:
         - fast
         - path
@@ -10235,7 +10298,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ecd04d15600bcbf1c717cfe5f1ac3ce38bdde30275fd38f7f48f96cf0757b249
-      lastVerified: '2026-05-17T10:02:45.257Z'
+      lastVerified: '2026-05-17T14:15:04.485Z'
     gate-evaluator:
       path: .aiox-core/core/orchestration/gate-evaluator.js
       layer: L1
@@ -10256,7 +10319,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4e9e78745f937ee78b13704f3acdb45b19d4aab9bc0f17a5adaf5eecfc58e653
-      lastVerified: '2026-05-17T10:02:45.257Z'
+      lastVerified: '2026-05-17T14:15:04.485Z'
     gemini-model-selector:
       path: .aiox-core/core/orchestration/gemini-model-selector.js
       layer: L1
@@ -10277,7 +10340,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2fe54c401ae60c0b5dc07f74c7a464992a0558b10c0b61f183c06943441d0d57
-      lastVerified: '2026-05-17T10:02:45.257Z'
+      lastVerified: '2026-05-17T14:15:04.485Z'
     greenfield-handler:
       path: .aiox-core/core/orchestration/greenfield-handler.js
       layer: L1
@@ -10302,7 +10365,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:949c80c9c0430d4ddb1fa6e721661bad479ab476a4fb529aad8bf8dafa6e57fd
-      lastVerified: '2026-05-17T10:02:45.258Z'
+      lastVerified: '2026-05-17T14:15:04.486Z'
     orchestration-index:
       path: .aiox-core/core/orchestration/index.js
       layer: L1
@@ -10350,7 +10413,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:eaebc2df86ad8fdd91082c4b1f007f967b2de89eb1ac4e5902e3b46b2eb5b169
-      lastVerified: '2026-05-17T10:02:45.259Z'
+      lastVerified: '2026-05-17T14:15:04.487Z'
     lock-manager:
       path: .aiox-core/core/orchestration/lock-manager.js
       layer: L1
@@ -10372,12 +10435,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:30af501b40da2a7bcfd591c62e367c5667eefd40af91d265c986521c93e7d1f2
-      lastVerified: '2026-05-17T10:02:45.259Z'
+      lastVerified: '2026-05-17T14:15:04.487Z'
     master-orchestrator:
       path: .aiox-core/core/orchestration/master-orchestrator.js
       layer: L1
       type: module
-      purpose: '''Requirements → Specification generation'','
+      purpose: Entity at .aiox-core/core/orchestration/master-orchestrator.js
       keywords:
         - master
         - orchestrator
@@ -10399,7 +10462,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:88238a9e0ef7d058efe0ca2fe7a9d0e34202bff7e409fd1a97886b0a8ccdce97
-      lastVerified: '2026-05-17T10:02:45.260Z'
+      lastVerified: '2026-05-17T14:15:04.488Z'
     message-formatter:
       path: .aiox-core/core/orchestration/message-formatter.js
       layer: L1
@@ -10420,12 +10483,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b7413c04fa22db1c5fc2f5c2aa47bb8ca0374e079894a44df21b733da6c258ae
-      lastVerified: '2026-05-17T10:02:45.260Z'
+      lastVerified: '2026-05-17T14:15:04.488Z'
     orchestration-parallel-executor:
       path: .aiox-core/core/orchestration/parallel-executor.js
       layer: L1
       type: module
-      purpose: '{'
+      purpose: Entity at .aiox-core/core/orchestration/parallel-executor.js
       keywords:
         - parallel
         - executor
@@ -10439,7 +10502,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:17b9669337d080509cb270eb8564a0f5684b2abbad1056f81b6947bb0b2b594f
-      lastVerified: '2026-05-17T10:02:45.261Z'
+      lastVerified: '2026-05-17T14:15:04.489Z'
     recovery-handler:
       path: .aiox-core/core/orchestration/recovery-handler.js
       layer: L1
@@ -10463,12 +10526,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3224718aa40bbdd08e117b27ac71f4ec66252d9874acaf9bb3addfe8ca4d0c06
-      lastVerified: '2026-05-17T10:02:45.261Z'
+      lastVerified: '2026-05-17T14:15:04.489Z'
     session-state:
       path: .aiox-core/core/orchestration/session-state.js
       layer: L1
       type: module
-      purpose: '''Resume from last saved state'','
+      purpose: Entity at .aiox-core/core/orchestration/session-state.js
       keywords:
         - session
         - state
@@ -10491,12 +10554,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:70d511bf6a03e8cacefcec0065a4727cfb380471c89762bb291840968f55b44b
-      lastVerified: '2026-05-17T10:02:45.261Z'
+      lastVerified: '2026-05-17T14:15:04.490Z'
     skill-dispatcher:
       path: .aiox-core/core/orchestration/skill-dispatcher.js
       layer: L1
       type: module
-      purpose: '''No result returned from skill'','
+      purpose: Entity at .aiox-core/core/orchestration/skill-dispatcher.js
       keywords:
         - skill
         - dispatcher
@@ -10512,12 +10575,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ebee66973a1df5d9dfed195ac6d83765a92023ba504e1814674345094fb8117
-      lastVerified: '2026-05-17T10:02:45.262Z'
+      lastVerified: '2026-05-17T14:15:04.490Z'
     subagent-prompt-builder:
       path: .aiox-core/core/orchestration/subagent-prompt-builder.js
       layer: L1
       type: module
-      purpose: ${phaseData.result.summary}\n`;
+      purpose: Entity at .aiox-core/core/orchestration/subagent-prompt-builder.js
       keywords:
         - subagent
         - prompt
@@ -10534,7 +10597,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c014eaae229e6c84742273701a6ef21a19343e34ef8be38d5d6a9bc59ecd8b02
-      lastVerified: '2026-05-17T10:02:45.262Z'
+      lastVerified: '2026-05-17T14:15:04.490Z'
     surface-checker:
       path: .aiox-core/core/orchestration/surface-checker.js
       layer: L1
@@ -10558,7 +10621,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:92e9d5bea78c3db4940c39f79e537821b36451cd524d69e6b738272aa63c08b6
-      lastVerified: '2026-05-17T10:02:45.262Z'
+      lastVerified: '2026-05-17T14:15:04.490Z'
     task-complexity-classifier:
       path: .aiox-core/core/orchestration/task-complexity-classifier.js
       layer: L1
@@ -10579,7 +10642,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:33b3b7c349352d607c156e0018c508f0869a1c7d233d107bed194a51bc608c93
-      lastVerified: '2026-05-17T10:02:45.262Z'
+      lastVerified: '2026-05-17T14:15:04.490Z'
     tech-stack-detector:
       path: .aiox-core/core/orchestration/tech-stack-detector.js
       layer: L1
@@ -10602,12 +10665,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:074c52757e181cc1e344b26ae191ac67488d18e9da2b06b5def23abb6c64c056
-      lastVerified: '2026-05-17T10:02:45.263Z'
+      lastVerified: '2026-05-17T14:15:04.491Z'
     terminal-spawner:
       path: .aiox-core/core/orchestration/terminal-spawner.js
       layer: L1
       type: module
-      purpose: '''Apple Silicon'' },'
+      purpose: Entity at .aiox-core/core/orchestration/terminal-spawner.js
       keywords:
         - terminal
         - spawner
@@ -10624,7 +10687,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a6453c6acf0ff007444adeaa5e4620890fff38f0b31b058a2da04d790fb098ab
-      lastVerified: '2026-05-17T10:02:45.263Z'
+      lastVerified: '2026-05-17T14:15:04.491Z'
     workflow-executor:
       path: .aiox-core/core/orchestration/workflow-executor.js
       layer: L1
@@ -10651,7 +10714,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:49372791e5729fd7987c80efe1400168e8d59eac000a009b88d9fde6735cf4db
-      lastVerified: '2026-05-17T10:02:45.263Z'
+      lastVerified: '2026-05-17T14:15:04.492Z'
     workflow-orchestrator:
       path: .aiox-core/core/orchestration/workflow-orchestrator.js
       layer: L1
@@ -10679,7 +10742,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:82816bd5e6fecc9bbb77292444e53254c72bf93e5c04260784743354c6a58627
-      lastVerified: '2026-05-17T10:02:45.264Z'
+      lastVerified: '2026-05-17T14:15:04.492Z'
     permissions-index:
       path: .aiox-core/core/permissions/index.js
       layer: L1
@@ -10702,7 +10765,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5748821f5b7fcc2c54e74956ddd9e05326fa96520a753a506feb9910042f562b
-      lastVerified: '2026-05-17T10:02:45.264Z'
+      lastVerified: '2026-05-17T14:15:04.493Z'
     operation-guard:
       path: .aiox-core/core/permissions/operation-guard.js
       layer: L1
@@ -10724,12 +10787,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f9b1b1bd547145c0d8a0f47534af0678ee852df6236acd05c53e479cb0e3f0bd
-      lastVerified: '2026-05-17T10:02:45.264Z'
+      lastVerified: '2026-05-17T14:15:04.493Z'
     permission-mode:
       path: .aiox-core/core/permissions/permission-mode.js
       layer: L1
       type: module
-      purpose: '''Read-only mode - safe exploration'','
+      purpose: Entity at .aiox-core/core/permissions/permission-mode.js
       keywords:
         - permission
         - mode
@@ -10746,7 +10809,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:84f09067c7154d97cb2252b9a7def00562acf569cfc3b035d6d4e39fb40d4033
-      lastVerified: '2026-05-17T10:02:45.264Z'
+      lastVerified: '2026-05-17T14:15:04.493Z'
     pro-updater:
       path: .aiox-core/core/pro/pro-updater.js
       layer: L1
@@ -10765,7 +10828,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:30ea78b8ab088e695936ae662057697410856751f463eeb649e00b67dcc31531
-      lastVerified: '2026-05-17T10:02:45.265Z'
+      lastVerified: '2026-05-17T14:15:04.493Z'
     base-layer:
       path: .aiox-core/core/quality-gates/base-layer.js
       layer: L1
@@ -10787,7 +10850,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a9a3921da08176b0bd44f338a59abc1f5107f3b1ee56571e840bf4e8ed233f4
-      lastVerified: '2026-05-17T10:02:45.265Z'
+      lastVerified: '2026-05-17T14:15:04.494Z'
     checklist-generator:
       path: .aiox-core/core/quality-gates/checklist-generator.js
       layer: L1
@@ -10807,12 +10870,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7f2800f6e2465a846c9bef8a73403e7b91bf18d1d1425804d31244bd883ec55a
-      lastVerified: '2026-05-17T10:02:45.265Z'
+      lastVerified: '2026-05-17T14:15:04.494Z'
     focus-area-recommender:
       path: .aiox-core/core/quality-gates/focus-area-recommender.js
       layer: L1
       type: module
-      purpose: ''''','
+      purpose: Entity at .aiox-core/core/quality-gates/focus-area-recommender.js
       keywords:
         - focus
         - area
@@ -10828,7 +10891,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f6364e2d444d19a8a3d0fb59d5264ae55137d48e008f5a3efe57f92465c4b53e
-      lastVerified: '2026-05-17T10:02:45.265Z'
+      lastVerified: '2026-05-17T14:15:04.494Z'
     human-review-orchestrator:
       path: .aiox-core/core/quality-gates/human-review-orchestrator.js
       layer: L1
@@ -10851,7 +10914,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3462b577d1bfa561156e72483241cb3bd0a6756448bd17acb3f4d92ead144781
-      lastVerified: '2026-05-17T10:02:45.265Z'
+      lastVerified: '2026-05-17T14:15:04.494Z'
     layer1-precommit:
       path: .aiox-core/core/quality-gates/layer1-precommit.js
       layer: L1
@@ -10872,7 +10935,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:250b62740b473383e41b371bb59edddabd8a312f5f48a5a8e883e6196a48b8f3
-      lastVerified: '2026-05-17T10:02:45.265Z'
+      lastVerified: '2026-05-17T14:15:04.495Z'
     layer2-pr-automation:
       path: .aiox-core/core/quality-gates/layer2-pr-automation.js
       layer: L1
@@ -10894,7 +10957,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:af31e7ac60b74b52ee983d0fcff7457042eea553b6127538cab41eb94eaee8e0
-      lastVerified: '2026-05-17T10:02:45.265Z'
+      lastVerified: '2026-05-17T14:15:04.495Z'
     layer3-human-review:
       path: .aiox-core/core/quality-gates/layer3-human-review.js
       layer: L1
@@ -10917,7 +10980,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9bf79d5adfddae55d7dddfda777cd2775aa76f82204ddd0f660f6edbd093b16b
-      lastVerified: '2026-05-17T10:02:45.266Z'
+      lastVerified: '2026-05-17T14:15:04.495Z'
     notification-manager:
       path: .aiox-core/core/quality-gates/notification-manager.js
       layer: L1
@@ -10938,7 +11001,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:89466b448383f8021075f43b870036b2e1d0277e543bd4357dd4988dc7c31b14
-      lastVerified: '2026-05-17T10:02:45.266Z'
+      lastVerified: '2026-05-17T14:15:04.495Z'
     quality-gate-manager:
       path: .aiox-core/core/quality-gates/quality-gate-manager.js
       layer: L1
@@ -10963,12 +11026,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b0d5ce2653218eae63121e892d886c3234a87bf98536369c75b537163e07fb26
-      lastVerified: '2026-05-17T10:02:45.266Z'
+      lastVerified: '2026-05-17T14:15:04.496Z'
     build-registry:
       path: .aiox-core/core/registry/build-registry.js
       layer: L1
       type: module
-      purpose: getCategoryDescription(worker.category),
+      purpose: Entity at .aiox-core/core/registry/build-registry.js
       keywords:
         - build
         - registry
@@ -10982,7 +11045,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e23f7e4f2d378de42204698eb0a818f6f8a4868a97341c8fbb92158c3e7d4767
-      lastVerified: '2026-05-17T10:02:45.266Z'
+      lastVerified: '2026-05-17T14:15:04.496Z'
     registry-registry-loader:
       path: .aiox-core/core/registry/registry-loader.js
       layer: L1
@@ -11001,12 +11064,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0cf9fa2ca39f7c4ca20043f3c4d7742e40dec7e94f81b706cf9318ebee199975
-      lastVerified: '2026-05-17T10:02:45.267Z'
+      lastVerified: '2026-05-17T14:15:04.497Z'
     validate-registry:
       path: .aiox-core/core/registry/validate-registry.js
       layer: L1
       type: module
-      purpose: '''Registry file loads without errors'','
+      purpose: Entity at .aiox-core/core/registry/validate-registry.js
       keywords:
         - validate
         - registry
@@ -11020,12 +11083,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d9805ce445661a3a2d9e6c73bf35cbd1bc2403419825442cd7b8f01cc1409cb3
-      lastVerified: '2026-05-17T10:02:45.267Z'
+      lastVerified: '2026-05-17T14:15:04.497Z'
     agent-immortality:
       path: .aiox-core/core/resilience/agent-immortality.js
       layer: L1
       type: module
-      purpose: truncate(summary, options.maxLegacyChars ?? DEFAULT_CONFIG.maxLegacyChars),
+      purpose: Entity at .aiox-core/core/resilience/agent-immortality.js
       keywords:
         - agent
         - immortality
@@ -11040,7 +11103,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d1612c672e91a802924c4a61d8beade66d5740487ca0a244950a2c8249a70962
-      lastVerified: '2026-05-17T10:02:45.267Z'
+      lastVerified: '2026-05-17T14:15:04.497Z'
     resilience-index:
       path: .aiox-core/core/resilience/index.js
       layer: L1
@@ -11060,7 +11123,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5acbb55fbbf25fc052c0ee2eac5f35d30228144e9f426083b89aabc9e54d084f
-      lastVerified: '2026-05-17T10:02:45.267Z'
+      lastVerified: '2026-05-17T14:15:04.497Z'
     context-detector:
       path: .aiox-core/core/session/context-detector.js
       layer: L1
@@ -11086,7 +11149,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5537563d5dfc613e16fd610c9e1407e7811c4f19745a78a4fc81c34af20000f4
-      lastVerified: '2026-05-17T10:02:45.267Z'
+      lastVerified: '2026-05-17T14:15:04.498Z'
     context-loader:
       path: .aiox-core/core/session/context-loader.js
       layer: L1
@@ -11110,7 +11173,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e810e119059dce081d1143b16e4e6bb7aa65684169b4ebc36f55ecbaf109bd63
-      lastVerified: '2026-05-17T10:02:45.267Z'
+      lastVerified: '2026-05-17T14:15:04.498Z'
     synapse-engine:
       path: .aiox-core/core/synapse/engine.js
       layer: L1
@@ -11133,7 +11196,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b65523b2fec6a44ab380298c4d98f0569209dec8b50be3922479ffcd6548df0
-      lastVerified: '2026-05-17T10:02:45.268Z'
+      lastVerified: '2026-05-17T14:15:04.498Z'
     ui-index:
       path: .aiox-core/core/ui/index.js
       layer: L1
@@ -11154,7 +11217,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:49f683bbedad4f161006e7317c409ec12af2aa9f7ba0750c4d1d15ac3df05350
-      lastVerified: '2026-05-17T10:02:45.268Z'
+      lastVerified: '2026-05-17T14:15:04.498Z'
     observability-panel:
       path: .aiox-core/core/ui/observability-panel.js
       layer: L1
@@ -11176,7 +11239,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f73bb7b80e60d8158c5044b13bb4dd4945270d3d44b8ac3e2c30635e5040f0f8
-      lastVerified: '2026-05-17T10:02:45.268Z'
+      lastVerified: '2026-05-17T14:15:04.499Z'
     panel-renderer:
       path: .aiox-core/core/ui/panel-renderer.js
       layer: L1
@@ -11197,7 +11260,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d51a8a9d1dd76ce6bc08d38eaf53f4f7df948cc4edc8e7f56d68c39522f64dc6
-      lastVerified: '2026-05-17T10:02:45.268Z'
+      lastVerified: '2026-05-17T14:15:04.499Z'
     output-formatter:
       path: .aiox-core/core/utils/output-formatter.js
       layer: L1
@@ -11216,7 +11279,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6fdfee469b7c108ec24a045b9b2719d836a242052abd285957a9ac732c6fc594
-      lastVerified: '2026-05-17T10:02:45.268Z'
+      lastVerified: '2026-05-17T14:15:04.499Z'
     security-utils:
       path: .aiox-core/core/utils/security-utils.js
       layer: L1
@@ -11235,7 +11298,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:00c938eda0e142b8c204b50afdd662864b5209b60a32a0e6e847e4e4cbceee09
-      lastVerified: '2026-05-17T10:02:45.269Z'
+      lastVerified: '2026-05-17T14:15:04.499Z'
     yaml-validator:
       path: .aiox-core/core/utils/yaml-validator.js
       layer: L1
@@ -11254,7 +11317,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:05084596198634dd2a670a752d5c451edfe268e16e3bae511db52184f895366f
-      lastVerified: '2026-05-17T10:02:45.269Z'
+      lastVerified: '2026-05-17T14:15:04.499Z'
     creation-helper:
       path: .aiox-core/core/code-intel/helpers/creation-helper.js
       layer: L1
@@ -11274,7 +11337,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e674fdbe6979dbe961853f080d5971ba264dee23ab70abafcc21ee99356206e7
-      lastVerified: '2026-05-17T10:02:45.269Z'
+      lastVerified: '2026-05-17T14:15:04.499Z'
     dev-helper:
       path: .aiox-core/core/code-intel/helpers/dev-helper.js
       layer: L1
@@ -11295,12 +11358,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7e7f9bb92725ca1d85b0a7151668bc5bcdd6fc9b73fed5b2b2c28217d14535ab
-      lastVerified: '2026-05-17T10:02:45.269Z'
+      lastVerified: '2026-05-17T14:15:04.500Z'
     devops-helper:
       path: .aiox-core/core/code-intel/helpers/devops-helper.js
       layer: L1
       type: module
-      purpose: 'string, testCoverage: Array|null}|null>} Impact summary or null'
+      purpose: Entity at .aiox-core/core/code-intel/helpers/devops-helper.js
       keywords:
         - devops
         - helper
@@ -11317,12 +11380,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e72f95de2f3737b6e12094526eabfb4974a8339ce6d25f2e323f734fe567c155
-      lastVerified: '2026-05-17T10:02:45.269Z'
+      lastVerified: '2026-05-17T14:15:04.500Z'
     planning-helper:
       path: .aiox-core/core/code-intel/helpers/planning-helper.js
       layer: L1
       type: module
-      purpose: '{totalDeps: number, depth: string}}|null>}'
+      purpose: Entity at .aiox-core/core/code-intel/helpers/planning-helper.js
       keywords:
         - planning
         - helper
@@ -11342,7 +11405,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9ca5b57b74b5729685369662659e15a91e35ec3a33691973be000ecd85974f3d
-      lastVerified: '2026-05-17T10:02:45.269Z'
+      lastVerified: '2026-05-17T14:15:04.500Z'
     qa-helper:
       path: .aiox-core/core/code-intel/helpers/qa-helper.js
       layer: L1
@@ -11362,7 +11425,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9dbb84c1c4ed1aa57385ad2a6c74520f2020e6f8883012dd57c51486172ee528
-      lastVerified: '2026-05-17T10:02:45.269Z'
+      lastVerified: '2026-05-17T14:15:04.500Z'
     story-helper:
       path: .aiox-core/core/code-intel/helpers/story-helper.js
       layer: L1
@@ -11382,7 +11445,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:778466253ac66103ebc3b1caf71f44b06a0d5fb3d39fe8d3d473dd4bc73fefc6
-      lastVerified: '2026-05-17T10:02:45.270Z'
+      lastVerified: '2026-05-17T14:15:04.501Z'
     code-graph-provider:
       path: .aiox-core/core/code-intel/providers/code-graph-provider.js
       layer: L1
@@ -11405,7 +11468,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:83251871bc2d65864a4e148e3921408e74662a2739bfbd12395a2daaa4bde9a0
-      lastVerified: '2026-05-17T10:02:45.270Z'
+      lastVerified: '2026-05-17T14:15:04.501Z'
     provider-interface:
       path: .aiox-core/core/code-intel/providers/provider-interface.js
       layer: L1
@@ -11427,12 +11490,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:74df278e31f240ee4499f10989c4b6f8c7c7cba6e8f317cb433a23fd6693c487
-      lastVerified: '2026-05-17T10:02:45.270Z'
+      lastVerified: '2026-05-17T14:15:04.501Z'
     registry-provider:
       path: .aiox-core/core/code-intel/providers/registry-provider.js
       layer: L1
       type: module
-      purpose: '`${entities.length} ${category} entities follow consistent structure`,'
+      purpose: Entity at .aiox-core/core/code-intel/providers/registry-provider.js
       keywords:
         - registry
         - provider
@@ -11450,7 +11513,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d7173384a1c0ff33326d1f45ee3fba0a6cbf7d7fe0476c1a60fda5442f5486e3
-      lastVerified: '2026-05-17T10:02:45.270Z'
+      lastVerified: '2026-05-17T14:15:04.501Z'
     agent-memory:
       path: .aiox-core/core/doctor/checks/agent-memory.js
       layer: L1
@@ -11471,7 +11534,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:08d5d685e4fdaaedf081020229844f4a58c9fd00244e4c37eb5b3fd78f4feb61
-      lastVerified: '2026-05-17T10:02:45.270Z'
+      lastVerified: '2026-05-17T14:15:04.501Z'
     claude-md:
       path: .aiox-core/core/doctor/checks/claude-md.js
       layer: L1
@@ -11491,7 +11554,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:88162c90d0b671c1a924fd6e18aeeb0fb229d19fb4204c12551feafbdef5d01d
-      lastVerified: '2026-05-17T10:02:45.271Z'
+      lastVerified: '2026-05-17T14:15:04.501Z'
     code-intel:
       path: .aiox-core/core/doctor/checks/code-intel.js
       layer: L1
@@ -11519,7 +11582,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ed69815b54a686ef1076964f1eb667059712d35487fc2f1785a9897f59436fb
-      lastVerified: '2026-05-17T10:02:45.271Z'
+      lastVerified: '2026-05-17T14:15:04.502Z'
     commands-count:
       path: .aiox-core/core/doctor/checks/commands-count.js
       layer: L1
@@ -11539,7 +11602,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:eb3be16a561337ed64883ba578df1cb74790fcb6edee47bfd309d2480e66fbee
-      lastVerified: '2026-05-17T10:02:45.271Z'
+      lastVerified: '2026-05-17T14:15:04.502Z'
     core-config:
       path: .aiox-core/core/doctor/checks/core-config.js
       layer: L1
@@ -11559,7 +11622,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:53ddc48091f64805c100d08fb8cac5d1b4d74e844c8cfcde122f881a428b650b
-      lastVerified: '2026-05-17T10:02:45.271Z'
+      lastVerified: '2026-05-17T14:15:04.502Z'
     entity-registry:
       path: .aiox-core/core/doctor/checks/entity-registry.js
       layer: L1
@@ -11578,7 +11641,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bed5f0881102fecf77e7a4f990a1363b840422701f736e806c1c69908acae0aa
-      lastVerified: '2026-05-17T10:02:45.272Z'
+      lastVerified: '2026-05-17T14:15:04.502Z'
     git-hooks:
       path: .aiox-core/core/doctor/checks/git-hooks.js
       layer: L1
@@ -11598,7 +11661,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3fe9411a64265c581952f40044b70cc21b324773f54e4b902e4ce390c976fa2f
-      lastVerified: '2026-05-17T10:02:45.272Z'
+      lastVerified: '2026-05-17T14:15:04.502Z'
     graph-dashboard:
       path: .aiox-core/core/doctor/checks/graph-dashboard.js
       layer: L1
@@ -11618,7 +11681,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c4a16ab33117169aac7e4e29d841eec4f28a076f6d93fb9d872749831a14a17
-      lastVerified: '2026-05-17T10:02:45.272Z'
+      lastVerified: '2026-05-17T14:15:04.502Z'
     hooks-claude-count:
       path: .aiox-core/core/doctor/checks/hooks-claude-count.js
       layer: L1
@@ -11639,7 +11702,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:026ddf0248819b89b1147e0876a2934e38e0113d3c6380d68a752d432060e7ec
-      lastVerified: '2026-05-17T10:02:45.272Z'
+      lastVerified: '2026-05-17T14:15:04.502Z'
     ide-sync:
       path: .aiox-core/core/doctor/checks/ide-sync.js
       layer: L1
@@ -11659,7 +11722,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4ddd037b4ad18c4201ca1428a1044efd313e9d2721cd399aebd3c5043fd4e2d1
-      lastVerified: '2026-05-17T10:02:45.272Z'
+      lastVerified: '2026-05-17T14:15:04.503Z'
     doctor-checks-index:
       path: .aiox-core/core/doctor/checks/index.js
       layer: L1
@@ -11693,7 +11756,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c4034f86b66895c1ab9a8be4148577d5b886c21f31e05d32cbf8e4970e88f204
-      lastVerified: '2026-05-17T10:02:45.273Z'
+      lastVerified: '2026-05-17T14:15:04.503Z'
     node-version:
       path: .aiox-core/core/doctor/checks/node-version.js
       layer: L1
@@ -11714,7 +11777,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9e8bd100affa46131ac495c1e60ce87c88bbe879d459601a502589824d1aeac1
-      lastVerified: '2026-05-17T10:02:45.273Z'
+      lastVerified: '2026-05-17T14:15:04.503Z'
     npm-packages:
       path: .aiox-core/core/doctor/checks/npm-packages.js
       layer: L1
@@ -11734,7 +11797,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c54cb15dc3492ec50b4edc4733ecc5c41d5a00536aed87a5a5d815f472ee9f7
-      lastVerified: '2026-05-17T10:02:45.273Z'
+      lastVerified: '2026-05-17T14:15:04.503Z'
     rules-files:
       path: .aiox-core/core/doctor/checks/rules-files.js
       layer: L1
@@ -11755,7 +11818,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec58342215cede634f50c5b3164155c4f27fd8070af176ec0e02e6deec6fb218
-      lastVerified: '2026-05-17T10:02:45.273Z'
+      lastVerified: '2026-05-17T14:15:04.503Z'
     settings-json:
       path: .aiox-core/core/doctor/checks/settings-json.js
       layer: L1
@@ -11775,7 +11838,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bd26841b966fcfa003eca6f85416d4f877b9dcfea0e4017df9f2a97c14c33fbb
-      lastVerified: '2026-05-17T10:02:45.273Z'
+      lastVerified: '2026-05-17T14:15:04.503Z'
     skills-count:
       path: .aiox-core/core/doctor/checks/skills-count.js
       layer: L1
@@ -11795,7 +11858,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:811d904bde6d2ba4940f19cbe6a29cc12c5df6908ac95cb37bcb7add687fe4cc
-      lastVerified: '2026-05-17T10:02:45.273Z'
+      lastVerified: '2026-05-17T14:15:04.504Z'
     json:
       path: .aiox-core/core/doctor/formatters/json.js
       layer: L1
@@ -11815,12 +11878,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ea3f28f168f48ca3002661210932846f0e82c3dd9261d5e9115036f67e5a1ea4
-      lastVerified: '2026-05-17T10:02:45.274Z'
+      lastVerified: '2026-05-17T14:15:04.504Z'
     text:
       path: .aiox-core/core/doctor/formatters/text.js
       layer: L1
       type: module
-      purpose: ${pass} PASS | ${warn} WARN | ${fail} FAIL | ${info} INFO`);
+      purpose: Entity at .aiox-core/core/doctor/formatters/text.js
       keywords:
         - text
       usedBy:
@@ -11834,7 +11897,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bd582b33c2d915516798627351c46d6d8edb56f655bb91037dfdbac159de77eb
-      lastVerified: '2026-05-17T10:02:45.274Z'
+      lastVerified: '2026-05-17T14:15:04.504Z'
     code-intel-source:
       path: .aiox-core/core/graph-dashboard/data-sources/code-intel-source.js
       layer: L1
@@ -11858,7 +11921,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2b0534f57a8f6ca2ff5942e42faf147f1be84773b3af33c9e506ee8f318b558c
-      lastVerified: '2026-05-17T10:02:45.274Z'
+      lastVerified: '2026-05-17T14:15:04.504Z'
     metrics-source:
       path: .aiox-core/core/graph-dashboard/data-sources/metrics-source.js
       layer: L1
@@ -11879,7 +11942,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b1e4027f82350760b67ea8f58e04a5e739f87f010838487043e29dab7301ae9e
-      lastVerified: '2026-05-17T10:02:45.274Z'
+      lastVerified: '2026-05-17T14:15:04.504Z'
     registry-source:
       path: .aiox-core/core/graph-dashboard/data-sources/registry-source.js
       layer: L1
@@ -11900,7 +11963,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:32d2a4bd5b102823d5933e5f9a648ae7e647cb1918092063161fed80d32b844b
-      lastVerified: '2026-05-17T10:02:45.274Z'
+      lastVerified: '2026-05-17T14:15:04.504Z'
     dot-formatter:
       path: .aiox-core/core/graph-dashboard/formatters/dot-formatter.js
       layer: L1
@@ -11920,7 +11983,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c369343f2b617a730951eb137d5ba74087bfd9f5dddbbf439e1fc2f87117d7a
-      lastVerified: '2026-05-17T10:02:45.274Z'
+      lastVerified: '2026-05-17T14:15:04.504Z'
     html-formatter:
       path: .aiox-core/core/graph-dashboard/formatters/html-formatter.js
       layer: L1
@@ -11940,7 +12003,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:81bfd3d61234cf17a0d7e25fbcdb86ddddc3f911e25a95f21604f7fe1d8d6a84
-      lastVerified: '2026-05-17T10:02:45.275Z'
+      lastVerified: '2026-05-17T14:15:04.505Z'
     json-formatter:
       path: .aiox-core/core/graph-dashboard/formatters/json-formatter.js
       layer: L1
@@ -11960,7 +12023,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0544ec384f716130a5141edc7ad6733dccd82b86e37fc1606f1120b0037c3f8d
-      lastVerified: '2026-05-17T10:02:45.275Z'
+      lastVerified: '2026-05-17T14:15:04.505Z'
     mermaid-formatter:
       path: .aiox-core/core/graph-dashboard/formatters/mermaid-formatter.js
       layer: L1
@@ -11980,7 +12043,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a6a5361cb7cdce2632d348ad32c659a3c383471fd338e76d578cc83c0888b2d7
-      lastVerified: '2026-05-17T10:02:45.276Z'
+      lastVerified: '2026-05-17T14:15:04.505Z'
     stats-renderer:
       path: .aiox-core/core/graph-dashboard/renderers/stats-renderer.js
       layer: L1
@@ -12000,7 +12063,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:375f904e8592a546f594f63b2c717db03db500e7070372db6de5524ac74ba474
-      lastVerified: '2026-05-17T10:02:45.276Z'
+      lastVerified: '2026-05-17T14:15:04.505Z'
     status-renderer:
       path: .aiox-core/core/graph-dashboard/renderers/status-renderer.js
       layer: L1
@@ -12020,7 +12083,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8e971ae267a570fac96782ee2d1ddb7787cc1efde9e17a2f23c9261ae0286acb
-      lastVerified: '2026-05-17T10:02:45.276Z'
+      lastVerified: '2026-05-17T14:15:04.505Z'
     tree-renderer:
       path: .aiox-core/core/graph-dashboard/renderers/tree-renderer.js
       layer: L1
@@ -12041,7 +12104,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:067bb5aefdfff0442a6132b89cec9ac61e84c9a9295097209a71c839978cef10
-      lastVerified: '2026-05-17T10:02:45.276Z'
+      lastVerified: '2026-05-17T14:15:04.506Z'
     health-check-checks-index:
       path: .aiox-core/core/health-check/checks/index.js
       layer: L1
@@ -12064,7 +12127,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d0713cca1b852d1b5a93d0c8e7d3c0fd3f3f05dde858ba1d5e5f9e053f41ae13
-      lastVerified: '2026-05-17T10:02:45.276Z'
+      lastVerified: '2026-05-17T14:15:04.506Z'
     backup-manager:
       path: .aiox-core/core/health-check/healers/backup-manager.js
       layer: L1
@@ -12083,12 +12146,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2827c219b84ef9a133a057c7b15b752a7681807711de47c0807b87b16973ffb1
-      lastVerified: '2026-05-17T10:02:45.276Z'
+      lastVerified: '2026-05-17T14:15:04.506Z'
     health-check-healers-index:
       path: .aiox-core/core/health-check/healers/index.js
       layer: L1
       type: module
-      purpose: healer.promptDescription || checkResult.recommendation,
+      purpose: Entity at .aiox-core/core/health-check/healers/index.js
       keywords:
         - index
       usedBy:
@@ -12104,7 +12167,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:09bb735207abb8ed6edbaa82247567d47f77fe3f09920e6b64c719338a9dd9e8
-      lastVerified: '2026-05-17T10:02:45.277Z'
+      lastVerified: '2026-05-17T14:15:04.506Z'
     console:
       path: .aiox-core/core/health-check/reporters/console.js
       layer: L1
@@ -12124,7 +12187,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:573f28a6c9c2a4087ccd349398f47351aa9a752c92a1f2e4a3c3f396682d5516
-      lastVerified: '2026-05-17T10:02:45.277Z'
+      lastVerified: '2026-05-17T14:15:04.507Z'
     health-check-reporters-index:
       path: .aiox-core/core/health-check/reporters/index.js
       layer: L1
@@ -12146,12 +12209,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5e32e3e0fa9e152bf2ffbcdbc80cbd046722eff75745ef571b21d55de760f9a2
-      lastVerified: '2026-05-17T10:02:45.277Z'
+      lastVerified: '2026-05-17T14:15:04.507Z'
     health-check-reporters-json:
       path: .aiox-core/core/health-check/reporters/json.js
       layer: L1
       type: module
-      purpose: data.summary,
+      purpose: Entity at .aiox-core/core/health-check/reporters/json.js
       keywords:
         - json
       usedBy: []
@@ -12165,12 +12228,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:56b97bb379b7f9e35cd0796ae51c17d990429b0b17f4a34f4350c65333b40b12
-      lastVerified: '2026-05-17T10:02:45.277Z'
+      lastVerified: '2026-05-17T14:15:04.507Z'
     markdown:
       path: .aiox-core/core/health-check/reporters/markdown.js
       layer: L1
       type: module
-      purpose: r.message,
+      purpose: Entity at .aiox-core/core/health-check/reporters/markdown.js
       keywords:
         - markdown
       usedBy:
@@ -12185,12 +12248,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9bc17bd3bc540f60bd3ea102586cd1e04b8b7ae10e8980fad75f185eec29ad51
-      lastVerified: '2026-05-17T10:02:45.277Z'
+      lastVerified: '2026-05-17T14:15:04.507Z'
     g1-epic-creation:
       path: .aiox-core/core/ids/gates/g1-epic-creation.js
       layer: L1
       type: module
-      purpose: Queries the registry for related entities before epic approval.
+      purpose: Entity at .aiox-core/core/ids/gates/g1-epic-creation.js
       keywords:
         - g1
         - epic
@@ -12206,12 +12269,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ba7c342b176f38f2c80cb141fe820b9a963a1966e33fef3a4ec568363b011c5f
-      lastVerified: '2026-05-17T10:02:45.277Z'
+      lastVerified: '2026-05-17T14:15:04.507Z'
     g2-story-creation:
       path: .aiox-core/core/ids/gates/g2-story-creation.js
       layer: L1
       type: module
-      purpose: Checks for existing tasks and templates matching the story work
+      purpose: Entity at .aiox-core/core/ids/gates/g2-story-creation.js
       keywords:
         - g2
         - story
@@ -12227,12 +12290,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cb6312358a3d1c92a0094d25861e0747d0c1d63ffb08c82d8ed0a115a73ca1c5
-      lastVerified: '2026-05-17T10:02:45.277Z'
+      lastVerified: '2026-05-17T14:15:04.508Z'
     g3-story-validation:
       path: .aiox-core/core/ids/gates/g3-story-validation.js
       layer: L1
       type: module
-      purpose: Validates that artifacts referenced in a story actually exist
+      purpose: Entity at .aiox-core/core/ids/gates/g3-story-validation.js
       keywords:
         - g3
         - story
@@ -12248,12 +12311,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7b24912d9e80c5ca52d11950b133df6782b1c0c0914127ccef0dc8384026b4ae
-      lastVerified: '2026-05-17T10:02:45.278Z'
+      lastVerified: '2026-05-17T14:15:04.508Z'
     g4-dev-context:
       path: .aiox-core/core/ids/gates/g4-dev-context.js
       layer: L1
       type: module
-      purpose: Automated reminder at start of development task.
+      purpose: Entity at .aiox-core/core/ids/gates/g4-dev-context.js
       keywords:
         - g4
         - dev
@@ -12269,12 +12332,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a0fdd59eb0c3a8a59862397b1af5af84971ce051929ae9d32361b7ca99a444fb
-      lastVerified: '2026-05-17T10:02:45.278Z'
+      lastVerified: '2026-05-17T14:15:04.508Z'
     g5-semantic-handshake:
       path: .aiox-core/core/ids/gates/g5-semantic-handshake.js
       layer: L1
       type: module
-      purpose: Preserve intent integrity between planning and implementation by
+      purpose: Entity at .aiox-core/core/ids/gates/g5-semantic-handshake.js
       keywords:
         - g5
         - semantic
@@ -12290,7 +12353,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a008c60a4afc98f03dc41219989f7306884254d802b0958282a29462c9fd0f72
-      lastVerified: '2026-05-17T10:02:45.278Z'
+      lastVerified: '2026-05-17T14:15:04.508Z'
     active-modules.verify:
       path: .aiox-core/core/memory/__tests__/active-modules.verify.js
       layer: L1
@@ -12312,12 +12375,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:895ec75f6a303edf4cffa0ab7adbb8a4876f62626cc0d7178420efd5758f21a9
-      lastVerified: '2026-05-17T10:02:45.280Z'
+      lastVerified: '2026-05-17T14:15:04.522Z'
     epic-3-executor:
       path: .aiox-core/core/orchestration/executors/epic-3-executor.js
       layer: L1
       type: module
-      purpose: Entity at .aiox-core/core/orchestration/executors/epic-3-executor.js
+      purpose: This is an auto-generated specification stub. The full specification will be generated
       keywords:
         - epic
         - executor
@@ -12333,7 +12396,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1cadb0544660cead45f940839a0bec51f6a8ef143b7ab1dc006b89c4abb0c1c0
-      lastVerified: '2026-05-17T10:02:45.280Z'
+      lastVerified: '2026-05-17T14:15:04.525Z'
     epic-4-executor:
       path: .aiox-core/core/orchestration/executors/epic-4-executor.js
       layer: L1
@@ -12359,7 +12422,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b2f8944114839f9b02a0b46d037fa64e2d1584d3aab6ff74537e32a16b6a793d
-      lastVerified: '2026-05-17T10:02:45.280Z'
+      lastVerified: '2026-05-17T14:15:04.536Z'
     epic-5-executor:
       path: .aiox-core/core/orchestration/executors/epic-5-executor.js
       layer: L1
@@ -12382,7 +12445,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d334dc728dec74fdb744f14d83f9fd2b7dabc46bcaa0d2dfae482cc131e0107b
-      lastVerified: '2026-05-17T10:02:45.280Z'
+      lastVerified: '2026-05-17T14:15:04.536Z'
     epic-6-executor:
       path: .aiox-core/core/orchestration/executors/epic-6-executor.js
       layer: L1
@@ -12404,7 +12467,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1bbc14e8236f87c074db46833345a724ee5056a28b97fbb2528d4eedd350ab12
-      lastVerified: '2026-05-17T10:02:45.280Z'
+      lastVerified: '2026-05-17T14:15:04.545Z'
     epic-executor:
       path: .aiox-core/core/orchestration/executors/epic-executor.js
       layer: L1
@@ -12428,7 +12491,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f2b20cd8cc4f3473bfcc7afdc0bc20e21665bab92274433ede58eabc4691a6b9
-      lastVerified: '2026-05-17T10:02:45.280Z'
+      lastVerified: '2026-05-17T14:15:04.547Z'
     orchestration-executors-index:
       path: .aiox-core/core/orchestration/executors/index.js
       layer: L1
@@ -12452,7 +12515,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:21f66b6d59c67079bfd6f30dcb675bab60d8a3b6283c24246497d641beed1f57
-      lastVerified: '2026-05-17T10:02:45.281Z'
+      lastVerified: '2026-05-17T14:15:04.548Z'
     permission-mode.test:
       path: .aiox-core/core/permissions/__tests__/permission-mode.test.js
       layer: L1
@@ -12474,7 +12537,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8c8a48c75933a7bf3cf4588f8e4af3911cbb6b67fb07fa526a79bada8949ce2c
-      lastVerified: '2026-05-17T10:02:45.281Z'
+      lastVerified: '2026-05-17T14:15:04.550Z'
     context-builder:
       path: .aiox-core/core/synapse/context/context-builder.js
       layer: L1
@@ -12494,7 +12557,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:121cd0a1df8a44098831cd4335536e8facf4e65b8aec48f4ce9c2d432dc6252a
-      lastVerified: '2026-05-17T10:02:45.281Z'
+      lastVerified: '2026-05-17T14:15:04.550Z'
     context-tracker:
       path: .aiox-core/core/synapse/context/context-tracker.js
       layer: L1
@@ -12515,12 +12578,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5a54a15fbbbd4b6095e7e78297cb87e4a123a7c1d714a7c7916272ef6fd680f1
-      lastVerified: '2026-05-17T10:02:45.281Z'
+      lastVerified: '2026-05-17T14:15:04.552Z'
     hierarchical-context-manager:
       path: .aiox-core/core/synapse/context/hierarchical-context-manager.js
       layer: L1
       type: module
-      purpose: this._longTermSummaries.map(message => message.content).join('\n\n'),
+      purpose: Entity at .aiox-core/core/synapse/context/hierarchical-context-manager.js
       keywords:
         - hierarchical
         - context
@@ -12536,7 +12599,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:34f5b9e64c46880138ad684d64e7006f63c16211a219afa81a2c1b6236748af5
-      lastVerified: '2026-05-17T10:02:45.282Z'
+      lastVerified: '2026-05-17T14:15:04.552Z'
     synapse-context-index:
       path: .aiox-core/core/synapse/context/index.js
       layer: L1
@@ -12554,12 +12617,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6475a5730451d8754cc6c7ab4c1ef4decca98e093c69045661eae17da5897e07
-      lastVerified: '2026-05-17T10:02:45.282Z'
+      lastVerified: '2026-05-17T14:15:04.552Z'
     semantic-handshake-engine:
       path: .aiox-core/core/synapse/context/semantic-handshake-engine.js
       layer: L1
       type: module
-      purpose: '''Must use PostgreSQL adapter, not SQLite or another local database.'','
+      purpose: Entity at .aiox-core/core/synapse/context/semantic-handshake-engine.js
       keywords:
         - semantic
         - handshake
@@ -12574,7 +12637,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:be5f2f7300902a2916f6758b46636b96f083c11e1b831f5835bf97859a4b80a6
-      lastVerified: '2026-05-17T10:02:45.282Z'
+      lastVerified: '2026-05-17T14:15:04.553Z'
     report-formatter:
       path: .aiox-core/core/synapse/diagnostics/report-formatter.js
       layer: L1
@@ -12594,7 +12657,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e6d26c1cd9910d8311306111cc3fef3a4bb1c4bd6b1ef0e4bb8f407da9baf7f1
-      lastVerified: '2026-05-17T10:02:45.282Z'
+      lastVerified: '2026-05-17T14:15:04.553Z'
     synapse-diagnostics:
       path: .aiox-core/core/synapse/diagnostics/synapse-diagnostics.js
       layer: L1
@@ -12620,7 +12683,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de9dffce0e380637027cbd64b062d3eeffc37e42a84a337e5758fbef39fe3a00
-      lastVerified: '2026-05-17T10:02:45.286Z'
+      lastVerified: '2026-05-17T14:15:04.554Z'
     domain-loader:
       path: .aiox-core/core/synapse/domain/domain-loader.js
       layer: L1
@@ -12648,7 +12711,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:af788f9da956b89eef1e5eb4ef4efdf05ca758c8969a2c375f568119495ebc05
-      lastVerified: '2026-05-17T10:02:45.287Z'
+      lastVerified: '2026-05-17T14:15:04.554Z'
     l0-constitution:
       path: .aiox-core/core/synapse/layers/l0-constitution.js
       layer: L1
@@ -12669,7 +12732,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2123a6a44915aaac2a6bbd26c67c285c9d1e12b50fe42a8ada668306b07d1c4a
-      lastVerified: '2026-05-17T10:02:45.287Z'
+      lastVerified: '2026-05-17T14:15:04.554Z'
     l1-global:
       path: .aiox-core/core/synapse/layers/l1-global.js
       layer: L1
@@ -12690,7 +12753,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:21f6969e6d64e9a85c876be6799db4ca7d090f0009057f4a06ead8da12392d45
-      lastVerified: '2026-05-17T10:02:45.287Z'
+      lastVerified: '2026-05-17T14:15:04.555Z'
     l2-agent:
       path: .aiox-core/core/synapse/layers/l2-agent.js
       layer: L1
@@ -12711,7 +12774,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a8677dc58ae7927c5292a4b52883bbc905c8112573b8b8631f0b8bc01ea2b6e6
-      lastVerified: '2026-05-17T10:02:45.287Z'
+      lastVerified: '2026-05-17T14:15:04.555Z'
     l3-workflow:
       path: .aiox-core/core/synapse/layers/l3-workflow.js
       layer: L1
@@ -12732,7 +12795,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:496cbd71d7dac9c1daa534ffac45c622d0c032f334fedf493e9322a565b2b181
-      lastVerified: '2026-05-17T10:02:45.288Z'
+      lastVerified: '2026-05-17T14:15:04.555Z'
     l4-task:
       path: .aiox-core/core/synapse/layers/l4-task.js
       layer: L1
@@ -12752,7 +12815,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:30df70c04b16e3aff95899211ef6ae3d9f0a8097ebdc7de92599fc6cb792e5f0
-      lastVerified: '2026-05-17T10:02:45.288Z'
+      lastVerified: '2026-05-17T14:15:04.555Z'
     l5-squad:
       path: .aiox-core/core/synapse/layers/l5-squad.js
       layer: L1
@@ -12773,7 +12836,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fabc2bcb01543ef7d249631da02297d67e42f4d0fcf9e159b79564793ce8f7bb
-      lastVerified: '2026-05-17T10:02:45.288Z'
+      lastVerified: '2026-05-17T14:15:04.555Z'
     l6-keyword:
       path: .aiox-core/core/synapse/layers/l6-keyword.js
       layer: L1
@@ -12794,7 +12857,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8e5405999a2ce2f3ca4e62e863cf702ba27448914241f5eb8f02760bc7477523
-      lastVerified: '2026-05-17T10:02:45.288Z'
+      lastVerified: '2026-05-17T14:15:04.556Z'
     l7-star-command:
       path: .aiox-core/core/synapse/layers/l7-star-command.js
       layer: L1
@@ -12816,7 +12879,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3b8372ac1c51830c1ef560b1012b112a3559651b0750e42f2037f7fe9e6787d6
-      lastVerified: '2026-05-17T10:02:45.288Z'
+      lastVerified: '2026-05-17T14:15:04.556Z'
     layer-processor:
       path: .aiox-core/core/synapse/layers/layer-processor.js
       layer: L1
@@ -12843,7 +12906,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9cdb5efb2e95780373dd0ce8dcb64791dd1471128fc6914d274c6744036842a3
-      lastVerified: '2026-05-17T10:02:45.288Z'
+      lastVerified: '2026-05-17T14:15:04.556Z'
     memory-bridge:
       path: .aiox-core/core/synapse/memory/memory-bridge.js
       layer: L1
@@ -12865,7 +12928,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:820875f97ceea80fc6402c0dab1706cfe58de527897b22dea68db40b0d6ec368
-      lastVerified: '2026-05-17T10:02:45.288Z'
+      lastVerified: '2026-05-17T14:15:04.557Z'
     synapse-memory-provider:
       path: .aiox-core/core/synapse/memory/synapse-memory-provider.js
       layer: L1
@@ -12888,7 +12951,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5d613d1fac7ee82c49a3f03b38735fd3cabfe87dd868494672ddfef300ea3145
-      lastVerified: '2026-05-17T10:02:45.288Z'
+      lastVerified: '2026-05-17T14:15:04.557Z'
     formatter:
       path: .aiox-core/core/synapse/output/formatter.js
       layer: L1
@@ -12908,7 +12971,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fe4f6c2f6091defb6af66dad71db0640f919b983111087f8cc5821e3d44ca864
-      lastVerified: '2026-05-17T10:02:45.289Z'
+      lastVerified: '2026-05-17T14:15:04.557Z'
     synapse-runtime-hook-runtime:
       path: .aiox-core/core/synapse/runtime/hook-runtime.js
       layer: L1
@@ -12927,7 +12990,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c8a31f8cfcc760de06c65abd3c5d23d9ffd8490f7f0ae4a674efaba73e10dd44
-      lastVerified: '2026-05-17T10:02:45.289Z'
+      lastVerified: '2026-05-17T14:15:04.557Z'
     generate-constitution:
       path: .aiox-core/core/synapse/scripts/generate-constitution.js
       layer: L1
@@ -12946,7 +13009,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9010d6b34667c96602b76baa1857f0629c797d911b7c42dc11414b007e5e2b91
-      lastVerified: '2026-05-17T10:02:45.289Z'
+      lastVerified: '2026-05-17T14:15:04.557Z'
     synapse-session-session-manager:
       path: .aiox-core/core/synapse/session/session-manager.js
       layer: L1
@@ -12966,7 +13029,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:98e8c8fa15b074b6102bcd51c6f91f101743338e8cde6de9c31d6b6eea5d6580
-      lastVerified: '2026-05-17T10:02:45.289Z'
+      lastVerified: '2026-05-17T14:15:04.558Z'
     atomic-write:
       path: .aiox-core/core/synapse/utils/atomic-write.js
       layer: L1
@@ -12988,7 +13051,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:efeef0fbcebb184df5b79f4ba4b4b7fe274c3ba7d1c705ce1af92628e920bd8b
-      lastVerified: '2026-05-17T10:02:45.289Z'
+      lastVerified: '2026-05-17T14:15:04.558Z'
     paths:
       path: .aiox-core/core/synapse/utils/paths.js
       layer: L1
@@ -13006,7 +13069,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bf8cf93c1a16295e7de055bee292e2778a152b6e7d6c648dbc054a4b04dffc10
-      lastVerified: '2026-05-17T10:02:45.290Z'
+      lastVerified: '2026-05-17T14:15:04.558Z'
     tokens:
       path: .aiox-core/core/synapse/utils/tokens.js
       layer: L1
@@ -13028,12 +13091,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3b927daec51d0a791f3fe4ef9aafc362773450e7cf50eb4b6d8ae9011d70df9a
-      lastVerified: '2026-05-17T10:02:45.290Z'
+      lastVerified: '2026-05-17T14:15:04.558Z'
     build-config:
       path: .aiox-core/core/health-check/checks/deployment/build-config.js
       layer: L1
       type: module
-      purpose: '''Verifies build configuration'','
+      purpose: Entity at .aiox-core/core/health-check/checks/deployment/build-config.js
       keywords:
         - build
         - config
@@ -13049,12 +13112,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2be009177bf26ca7e1ac2f1f6bc973e409ba1feac83906c96cab0b70e60c1af7
-      lastVerified: '2026-05-17T10:02:45.290Z'
+      lastVerified: '2026-05-17T14:15:04.558Z'
     ci-config:
       path: .aiox-core/core/health-check/checks/deployment/ci-config.js
       layer: L1
       type: module
-      purpose: '''Verifies CI/CD configuration'','
+      purpose: Entity at .aiox-core/core/health-check/checks/deployment/ci-config.js
       keywords:
         - ci
         - config
@@ -13070,12 +13133,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ad8399d53c01cb989cc17e60a3547aec2a0c31ba62d2664ef47482ccd0c6b144
-      lastVerified: '2026-05-17T10:02:45.290Z'
+      lastVerified: '2026-05-17T14:15:04.558Z'
     deployment-readiness:
       path: .aiox-core/core/health-check/checks/deployment/deployment-readiness.js
       layer: L1
       type: module
-      purpose: '''Verifies project is ready for deployment'','
+      purpose: Entity at .aiox-core/core/health-check/checks/deployment/deployment-readiness.js
       keywords:
         - deployment
         - readiness
@@ -13091,12 +13154,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7c4706e829968ddae47f9f372140c36fd96e3148eec5dade3e1d5b7c3b276d38
-      lastVerified: '2026-05-17T10:02:45.290Z'
+      lastVerified: '2026-05-17T14:15:04.558Z'
     docker-config:
       path: .aiox-core/core/health-check/checks/deployment/docker-config.js
       layer: L1
       type: module
-      purpose: '''Verifies Docker configuration'','
+      purpose: Entity at .aiox-core/core/health-check/checks/deployment/docker-config.js
       keywords:
         - docker
         - config
@@ -13112,12 +13175,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a4558144220078fcc203ae662756df4f0715ffe56d94853996f01a7100a8b11a
-      lastVerified: '2026-05-17T10:02:45.290Z'
+      lastVerified: '2026-05-17T14:15:04.559Z'
     env-file:
       path: .aiox-core/core/health-check/checks/deployment/env-file.js
       layer: L1
       type: module
-      purpose: '''Verifies .env configuration'','
+      purpose: Entity at .aiox-core/core/health-check/checks/deployment/env-file.js
       keywords:
         - env
         - file
@@ -13133,7 +13196,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2864d9210c0fcf58ac11016077ac24c23edd1dbb570ace46c1762de5f0d4ebae
-      lastVerified: '2026-05-17T10:02:45.291Z'
+      lastVerified: '2026-05-17T14:15:04.559Z'
     health-check-checks-deployment-index:
       path: .aiox-core/core/health-check/checks/deployment/index.js
       layer: L1
@@ -13158,12 +13221,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ac2b152a971650ecac4c84d92a7769b0aa6ec761c06b11e420bd62f0b8066eef
-      lastVerified: '2026-05-17T10:02:45.291Z'
+      lastVerified: '2026-05-17T14:15:04.559Z'
     disk-space:
       path: .aiox-core/core/health-check/checks/local/disk-space.js
       layer: L1
       type: module
-      purpose: '''Verifies sufficient disk space is available'','
+      purpose: Entity at .aiox-core/core/health-check/checks/local/disk-space.js
       keywords:
         - disk
         - space
@@ -13179,12 +13242,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa400f15c9bc1a61233472639bb44b6a5f4785fbe10690f8254e54edffb7dead
-      lastVerified: '2026-05-17T10:02:45.291Z'
+      lastVerified: '2026-05-17T14:15:04.559Z'
     environment-vars:
       path: .aiox-core/core/health-check/checks/local/environment-vars.js
       layer: L1
       type: module
-      purpose: '''Verifies required environment variables are set'','
+      purpose: Entity at .aiox-core/core/health-check/checks/local/environment-vars.js
       keywords:
         - environment
         - vars
@@ -13200,12 +13263,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4da9aefdf717e267d5a0e60408b866f49ca5f49cde0e6b1fb14050046a9458d0
-      lastVerified: '2026-05-17T10:02:45.292Z'
+      lastVerified: '2026-05-17T14:15:04.559Z'
     git-install:
       path: .aiox-core/core/health-check/checks/local/git-install.js
       layer: L1
       type: module
-      purpose: '''Verifies Git is installed and configured'','
+      purpose: Entity at .aiox-core/core/health-check/checks/local/git-install.js
       keywords:
         - git
         - install
@@ -13221,12 +13284,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f17dd15a5696de04b6530f6eb99d1c29d2a19486c7220be42f87712cb0858df2
-      lastVerified: '2026-05-17T10:02:45.292Z'
+      lastVerified: '2026-05-17T14:15:04.559Z'
     ide-detection:
       path: .aiox-core/core/health-check/checks/local/ide-detection.js
       layer: L1
       type: module
-      purpose: '''Detects IDE/editor configuration'','
+      purpose: Entity at .aiox-core/core/health-check/checks/local/ide-detection.js
       keywords:
         - ide
         - detection
@@ -13242,7 +13305,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:632ccbc44b3cd4306ba2391e6cea8e91e20ccedd62bb421f46ca33cd7daa7230
-      lastVerified: '2026-05-17T10:02:45.292Z'
+      lastVerified: '2026-05-17T14:15:04.560Z'
     health-check-checks-local-index:
       path: .aiox-core/core/health-check/checks/local/index.js
       layer: L1
@@ -13270,12 +13333,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9f98eecb00f844f22448489f993f84c045847e3ef579c8bcf7f15a7bd56b167b
-      lastVerified: '2026-05-17T10:02:45.293Z'
+      lastVerified: '2026-05-17T14:15:04.560Z'
     memory:
       path: .aiox-core/core/health-check/checks/local/memory.js
       layer: L1
       type: module
-      purpose: '''Verifies sufficient memory is available'','
+      purpose: Entity at .aiox-core/core/health-check/checks/local/memory.js
       keywords:
         - memory
       usedBy:
@@ -13291,12 +13354,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e959adc1f7f41ab5054bb8786967722d0364700b8e5139f94f5181a0d3dfc819
-      lastVerified: '2026-05-17T10:02:45.293Z'
+      lastVerified: '2026-05-17T14:15:04.560Z'
     network:
       path: .aiox-core/core/health-check/checks/local/network.js
       layer: L1
       type: module
-      purpose: '''Verifies network connectivity for development tools'','
+      purpose: Entity at .aiox-core/core/health-check/checks/local/network.js
       keywords:
         - network
       usedBy:
@@ -13311,12 +13374,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:77915bfd3f27b8f02c3eb8bb4d8c37f1e34541766633dde3b0d509b223435c98
-      lastVerified: '2026-05-17T10:02:45.293Z'
+      lastVerified: '2026-05-17T14:15:04.560Z'
     npm-install:
       path: .aiox-core/core/health-check/checks/local/npm-install.js
       layer: L1
       type: module
-      purpose: '''Verifies npm is installed and working'','
+      purpose: Entity at .aiox-core/core/health-check/checks/local/npm-install.js
       keywords:
         - npm
         - install
@@ -13332,12 +13395,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:592a7ed7468d4f5dc28c5261a363035545b84d4b32c2601bd52075e02f0cbdc2
-      lastVerified: '2026-05-17T10:02:45.293Z'
+      lastVerified: '2026-05-17T14:15:04.561Z'
     shell-environment:
       path: .aiox-core/core/health-check/checks/local/shell-environment.js
       layer: L1
       type: module
-      purpose: '''Verifies shell environment configuration'','
+      purpose: Entity at .aiox-core/core/health-check/checks/local/shell-environment.js
       keywords:
         - shell
         - environment
@@ -13353,12 +13416,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c98b9d4f3636d8c229c8031ed5126fc0fe35b6b740af320e21e05aaf1b5c402
-      lastVerified: '2026-05-17T10:02:45.293Z'
+      lastVerified: '2026-05-17T14:15:04.561Z'
     agent-config:
       path: .aiox-core/core/health-check/checks/project/agent-config.js
       layer: L1
       type: module
-      purpose: '''Verifies agent configuration files are valid'','
+      purpose: Entity at .aiox-core/core/health-check/checks/project/agent-config.js
       keywords:
         - agent
         - config
@@ -13374,12 +13437,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0195e2b95c94fcea2c7fae5636664e24657e182a0b3d8e95ce4ccf7b15809de2
-      lastVerified: '2026-05-17T10:02:45.294Z'
+      lastVerified: '2026-05-17T14:15:04.561Z'
     aiox-directory:
       path: .aiox-core/core/health-check/checks/project/aiox-directory.js
       layer: L1
       type: module
-      purpose: '''Verifies .aiox/ directory structure'','
+      purpose: Entity at .aiox-core/core/health-check/checks/project/aiox-directory.js
       keywords:
         - aiox
         - directory
@@ -13395,12 +13458,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:332d298d2ac7eb89ca6f3471f3a0970175f80c9a8735582af2ad5eb3331a8523
-      lastVerified: '2026-05-17T10:02:45.294Z'
+      lastVerified: '2026-05-17T14:15:04.561Z'
     dependencies:
       path: .aiox-core/core/health-check/checks/project/dependencies.js
       layer: L1
       type: module
-      purpose: '''Verifies required dependencies are installed'','
+      purpose: Entity at .aiox-core/core/health-check/checks/project/dependencies.js
       keywords:
         - dependencies
       usedBy:
@@ -13415,12 +13478,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:70feccca72c7eacd5740ec9b194a80d24f997f5300487633eba9a272cbf749df
-      lastVerified: '2026-05-17T10:02:45.294Z'
+      lastVerified: '2026-05-17T14:15:04.561Z'
     framework-config:
       path: .aiox-core/core/health-check/checks/project/framework-config.js
       layer: L1
       type: module
-      purpose: '''AIOX core framework'' },'
+      purpose: Entity at .aiox-core/core/health-check/checks/project/framework-config.js
       keywords:
         - framework
         - config
@@ -13436,7 +13499,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6ca4088a1b5399d47bc6bd04a4867b807b7003e7a91e35ddafcfcc3996f171fc
-      lastVerified: '2026-05-17T10:02:45.294Z'
+      lastVerified: '2026-05-17T14:15:04.561Z'
     health-check-checks-project-index:
       path: .aiox-core/core/health-check/checks/project/index.js
       layer: L1
@@ -13464,12 +13527,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:69a081967556f8325572c25615f19e30abf18d7c0c73a195953587dff34e8dfa
-      lastVerified: '2026-05-17T10:02:45.294Z'
+      lastVerified: '2026-05-17T14:15:04.561Z'
     health-check-checks-project-node-version:
       path: .aiox-core/core/health-check/checks/project/node-version.js
       layer: L1
       type: module
-      purpose: '''Verifies Node.js version meets minimum requirements'','
+      purpose: Entity at .aiox-core/core/health-check/checks/project/node-version.js
       keywords:
         - node
         - version
@@ -13484,12 +13547,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9bcebbd153d89b3f04d58850f48f2c2bcd9648286db656832197b429b7fc3391
-      lastVerified: '2026-05-17T10:02:45.294Z'
+      lastVerified: '2026-05-17T14:15:04.562Z'
     package-json:
       path: .aiox-core/core/health-check/checks/project/package-json.js
       layer: L1
       type: module
-      purpose: '''Verifies package.json exists and contains valid JSON'','
+      purpose: Entity at .aiox-core/core/health-check/checks/project/package-json.js
       keywords:
         - package
         - json
@@ -13505,12 +13568,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ba15da8cc0aaec18e7320db8c4942e04d3c159beb8605fa58a5939d6b77debe3
-      lastVerified: '2026-05-17T10:02:45.294Z'
+      lastVerified: '2026-05-17T14:15:04.562Z'
     task-definitions:
       path: .aiox-core/core/health-check/checks/project/task-definitions.js
       layer: L1
       type: module
-      purpose: '''Verifies task definition files are valid'','
+      purpose: Entity at .aiox-core/core/health-check/checks/project/task-definitions.js
       keywords:
         - task
         - definitions
@@ -13526,12 +13589,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:87c6edf9210856e065cd8c491a14b8a016aad429dbae7b0f814ac8b9b3989770
-      lastVerified: '2026-05-17T10:02:45.295Z'
+      lastVerified: '2026-05-17T14:15:04.562Z'
     workflow-dependencies:
       path: .aiox-core/core/health-check/checks/project/workflow-dependencies.js
       layer: L1
       type: module
-      purpose: '''Verifies workflow dependencies are satisfied'','
+      purpose: Entity at .aiox-core/core/health-check/checks/project/workflow-dependencies.js
       keywords:
         - workflow
         - dependencies
@@ -13547,12 +13610,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0eb04100b5c5a56b44b09ab7ca03426e01513c4eb109cc989603484329bc49d9
-      lastVerified: '2026-05-17T10:02:45.295Z'
+      lastVerified: '2026-05-17T14:15:04.562Z'
     branch-protection:
       path: .aiox-core/core/health-check/checks/repository/branch-protection.js
       layer: L1
       type: module
-      purpose: '''Verifies branch protection best practices'','
+      purpose: Entity at .aiox-core/core/health-check/checks/repository/branch-protection.js
       keywords:
         - branch
         - protection
@@ -13568,12 +13631,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4ee18e46c088005e2f39399dbd80a4fc3e8251baf1c9cbff698d7a941af8416f
-      lastVerified: '2026-05-17T10:02:45.295Z'
+      lastVerified: '2026-05-17T14:15:04.562Z'
     commit-history:
       path: .aiox-core/core/health-check/checks/repository/commit-history.js
       layer: L1
       type: module
-      purpose: '''Verifies commit history quality'','
+      purpose: Entity at .aiox-core/core/health-check/checks/repository/commit-history.js
       keywords:
         - commit
         - history
@@ -13589,12 +13652,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ae9d221803f518b0167d71a1c9c2ea5f2392c83d6279e87fbfb3dea95f5845ba
-      lastVerified: '2026-05-17T10:02:45.295Z'
+      lastVerified: '2026-05-17T14:15:04.562Z'
     conflicts:
       path: .aiox-core/core/health-check/checks/repository/conflicts.js
       layer: L1
       type: module
-      purpose: '''Checks for unresolved merge conflicts'','
+      purpose: Entity at .aiox-core/core/health-check/checks/repository/conflicts.js
       keywords:
         - conflicts
       usedBy:
@@ -13609,12 +13672,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6e9eb41c2a560a8cdc9154475be65ab1a110017d28c15a991af9dca5ebf9515e
-      lastVerified: '2026-05-17T10:02:45.295Z'
+      lastVerified: '2026-05-17T14:15:04.563Z'
     git-repo:
       path: .aiox-core/core/health-check/checks/repository/git-repo.js
       layer: L1
       type: module
-      purpose: '''Verifies project is a valid Git repository'','
+      purpose: Entity at .aiox-core/core/health-check/checks/repository/git-repo.js
       keywords:
         - git
         - repo
@@ -13630,12 +13693,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:80e1a09561f744772c40575f3f4c0d3a1847fbdf9825fbf616631c5edc67a833
-      lastVerified: '2026-05-17T10:02:45.296Z'
+      lastVerified: '2026-05-17T14:15:04.563Z'
     git-status:
       path: .aiox-core/core/health-check/checks/repository/git-status.js
       layer: L1
       type: module
-      purpose: '''Checks for uncommitted changes and working directory status'','
+      purpose: Entity at .aiox-core/core/health-check/checks/repository/git-status.js
       keywords:
         - git
         - status
@@ -13651,12 +13714,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:aad6379855e89558b43584e8812f04e6a2f771331bbebee116a451f9f4b177d1
-      lastVerified: '2026-05-17T10:02:45.296Z'
+      lastVerified: '2026-05-17T14:15:04.563Z'
     gitignore:
       path: .aiox-core/core/health-check/checks/repository/gitignore.js
       layer: L1
       type: module
-      purpose: '''Verifies .gitignore has required patterns'','
+      purpose: Entity at .aiox-core/core/health-check/checks/repository/gitignore.js
       keywords:
         - gitignore
       usedBy:
@@ -13671,7 +13734,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bec3b6a29ed336920a55d21f888ce29a4589a421d8a6695d40954ddd49eb4106
-      lastVerified: '2026-05-17T10:02:45.296Z'
+      lastVerified: '2026-05-17T14:15:04.563Z'
     health-check-checks-repository-index:
       path: .aiox-core/core/health-check/checks/repository/index.js
       layer: L1
@@ -13699,12 +13762,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f34fdabfde45775c0906fffd02ac1bed1ac03fe6deec119883ca681c2daff85c
-      lastVerified: '2026-05-17T10:02:45.296Z'
+      lastVerified: '2026-05-17T14:15:04.563Z'
     large-files:
       path: .aiox-core/core/health-check/checks/repository/large-files.js
       layer: L1
       type: module
-      purpose: '''Checks for large files in the repository'','
+      purpose: Entity at .aiox-core/core/health-check/checks/repository/large-files.js
       keywords:
         - large
         - files
@@ -13720,12 +13783,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8b1405280dd929c3ba5a47cf0a52bc7fd1f7efbc1ba3e8e4fdcbbcd56fe2a76e
-      lastVerified: '2026-05-17T10:02:45.296Z'
+      lastVerified: '2026-05-17T14:15:04.563Z'
     lockfile-integrity:
       path: .aiox-core/core/health-check/checks/repository/lockfile-integrity.js
       layer: L1
       type: module
-      purpose: '''Verifies package-lock.json integrity'','
+      purpose: Entity at .aiox-core/core/health-check/checks/repository/lockfile-integrity.js
       keywords:
         - lockfile
         - integrity
@@ -13741,12 +13804,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6b2d42f1d228f64079929c4d6cdeb9f5ed7217bb390ecfe2e00727c6f59527e0
-      lastVerified: '2026-05-17T10:02:45.297Z'
+      lastVerified: '2026-05-17T14:15:04.564Z'
     api-endpoints:
       path: .aiox-core/core/health-check/checks/services/api-endpoints.js
       layer: L1
       type: module
-      purpose: '''Verifies external API endpoint connectivity'','
+      purpose: Entity at .aiox-core/core/health-check/checks/services/api-endpoints.js
       keywords:
         - api
         - endpoints
@@ -13762,12 +13825,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2233d5af1610d5553353e21e720c9cb0ecfbb968ab605d14896705458ae7ca55
-      lastVerified: '2026-05-17T10:02:45.297Z'
+      lastVerified: '2026-05-17T14:15:04.564Z'
     claude-code:
       path: .aiox-core/core/health-check/checks/services/claude-code.js
       layer: L1
       type: module
-      purpose: '''Verifies Claude Code CLI configuration'','
+      purpose: Entity at .aiox-core/core/health-check/checks/services/claude-code.js
       keywords:
         - claude
         - code
@@ -13782,12 +13845,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:69af55e5ad7e941e5e6d0a9e3aab7a4e6c2aaec491aa5955fd6c23be432b5ab7
-      lastVerified: '2026-05-17T10:02:45.297Z'
+      lastVerified: '2026-05-17T14:15:04.564Z'
     gemini-cli:
       path: .aiox-core/core/health-check/checks/services/gemini-cli.js
       layer: L1
       type: module
-      purpose: '''Verifies Gemini CLI installation and configuration'','
+      purpose: Entity at .aiox-core/core/health-check/checks/services/gemini-cli.js
       keywords:
         - gemini
         - cli
@@ -13803,12 +13866,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1c37af5d3cd598c44bce4d37c9d90b3c72167841882d6ea3563cc55e2bfa147e
-      lastVerified: '2026-05-17T10:02:45.297Z'
+      lastVerified: '2026-05-17T14:15:04.564Z'
     github-cli:
       path: .aiox-core/core/health-check/checks/services/github-cli.js
       layer: L1
       type: module
-      purpose: '''Verifies GitHub CLI (gh) installation and authentication'','
+      purpose: Entity at .aiox-core/core/health-check/checks/services/github-cli.js
       keywords:
         - github
         - cli
@@ -13823,7 +13886,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b94fa0d8917a8506ce80620d390e9344935a700f87bf8034c3c24d12256cd85a
-      lastVerified: '2026-05-17T10:02:45.297Z'
+      lastVerified: '2026-05-17T14:15:04.564Z'
     health-check-checks-services-index:
       path: .aiox-core/core/health-check/checks/services/index.js
       layer: L1
@@ -13848,12 +13911,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:979198ad95353636e18153b3f7e7ed1e49e2bf04af653d95b3058b9735332667
-      lastVerified: '2026-05-17T10:02:45.297Z'
+      lastVerified: '2026-05-17T14:15:04.564Z'
     mcp-integration:
       path: .aiox-core/core/health-check/checks/services/mcp-integration.js
       layer: L1
       type: module
-      purpose: '''Verifies MCP server configuration'','
+      purpose: Entity at .aiox-core/core/health-check/checks/services/mcp-integration.js
       keywords:
         - mcp
         - integration
@@ -13869,7 +13932,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:139b29b91e4f2d0abf50b08a272a688036132abba8f71adca9b26c3fb8eb671e
-      lastVerified: '2026-05-17T10:02:45.298Z'
+      lastVerified: '2026-05-17T14:15:04.565Z'
     consistency-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/consistency-collector.js
       layer: L1
@@ -13889,7 +13952,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:65f4255f87c9900400649dc8b9aedaac4851b5939d93e127778bd93cee99db12
-      lastVerified: '2026-05-17T10:02:45.298Z'
+      lastVerified: '2026-05-17T14:15:04.565Z'
     hook-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/hook-collector.js
       layer: L1
@@ -13909,7 +13972,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c2cfa1b760bcb05decf5ad05f9159140cbe0cdc6b0f91581790e44d83dc6b660
-      lastVerified: '2026-05-17T10:02:45.298Z'
+      lastVerified: '2026-05-17T14:15:04.565Z'
     manifest-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/manifest-collector.js
       layer: L1
@@ -13930,12 +13993,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3dc895eb94485320ecbaca3a1d29e3776cfb691dd7dcc71cf44b34af30e8ebb6
-      lastVerified: '2026-05-17T10:02:45.299Z'
+      lastVerified: '2026-05-17T14:15:04.565Z'
     output-analyzer:
       path: .aiox-core/core/synapse/diagnostics/collectors/output-analyzer.js
       layer: L1
       type: module
-      purpose: string }>}
+      purpose: Entity at .aiox-core/core/synapse/diagnostics/collectors/output-analyzer.js
       keywords:
         - output
         - analyzer
@@ -13950,7 +14013,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e6846b1aba0a6cba17c297a871861d4f8199d7500220bff296a6a3291e32493e
-      lastVerified: '2026-05-17T10:02:45.299Z'
+      lastVerified: '2026-05-17T14:15:04.565Z'
     pipeline-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/pipeline-collector.js
       layer: L1
@@ -13971,7 +14034,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8655b6240e2f54b70def1a8c2fae00d40e2615cb95fd7ca0d64c2e0a6dfe3b73
-      lastVerified: '2026-05-17T10:02:45.299Z'
+      lastVerified: '2026-05-17T14:15:04.565Z'
     quality-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/quality-collector.js
       layer: L1
@@ -13991,7 +14054,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:30ae299eab6d569d09afe3530a5b2f1ff35ef75366a1ab56a9e2a57d39d3611c
-      lastVerified: '2026-05-17T10:02:45.299Z'
+      lastVerified: '2026-05-17T14:15:04.566Z'
     relevance-matrix:
       path: .aiox-core/core/synapse/diagnostics/collectors/relevance-matrix.js
       layer: L1
@@ -14011,7 +14074,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f92c4f7061dc82eed4310a27b69eade33d3015f9beb1bed688601a2dccbad22e
-      lastVerified: '2026-05-17T10:02:45.300Z'
+      lastVerified: '2026-05-17T14:15:04.566Z'
     safe-read-json:
       path: .aiox-core/core/synapse/diagnostics/collectors/safe-read-json.js
       layer: L1
@@ -14036,7 +14099,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dc7bcd13779207ad67b1c3929b7e1e0ccfa3563f3458c20cad28cb1922e9a74c
-      lastVerified: '2026-05-17T10:02:45.300Z'
+      lastVerified: '2026-05-17T14:15:04.566Z'
     session-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/session-collector.js
       layer: L1
@@ -14056,7 +14119,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a116d884d6947ddc8e5f3def012d93696576c584c4fde1639b8d895924fc09ea
-      lastVerified: '2026-05-17T10:02:45.300Z'
+      lastVerified: '2026-05-17T14:15:04.566Z'
     timing-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/timing-collector.js
       layer: L1
@@ -14076,7 +14139,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2523ce93f863a28f798d992c4f2fab041c91a09413b3186fd290e6035b391587
-      lastVerified: '2026-05-17T10:02:45.300Z'
+      lastVerified: '2026-05-17T14:15:04.566Z'
     uap-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/uap-collector.js
       layer: L1
@@ -14096,33 +14159,13 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dd025894f8f0d3bd22a147dbc0debef8b83e96f3c59483653404b3cd5a01d5aa
-      lastVerified: '2026-05-17T10:02:45.300Z'
-    component-creation-guide:
-      path: .aiox-core/core/docs/component-creation-guide.md
-      layer: L1
-      type: module
-      purpose: Analyzes provided dataset to identify patterns and insights
-      keywords:
-        - component
-        - creation
-        - guide
-      usedBy: []
-      dependencies: []
-      externalDeps: []
-      plannedDeps: []
-      lifecycle: orphan
-      adaptability:
-        score: 0.4
-        constraints: []
-        extensionPoints: []
-      checksum: sha256:b94ec24369c9c5a3b747307b14b425c4877de0ec3f5664e000d1f61fc3c61e27
-      lastVerified: '2026-05-17T13:08:28.420Z'
+      lastVerified: '2026-05-17T14:15:04.567Z'
   agents:
     aiox-master:
       path: .aiox-core/development/agents/aiox-master.md
       layer: L2
       type: agent
-      purpose: '''Show all available commands with descriptions'''
+      purpose: aiox-master
       keywords:
         - aiox
         - master
@@ -14195,19 +14238,21 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:66175a22e6982e5c0f4123f84af8388eb0cfc81124b8e9ec8f44d502c4ca6cf8
-      lastVerified: '2026-05-17T10:02:45.307Z'
+      lastVerified: '2026-05-17T14:15:04.573Z'
     analyst:
       path: .aiox-core/development/agents/analyst.md
       layer: L2
       type: agent
-      purpose: '''Show all available commands with descriptions'''
+      purpose: analyst
       keywords:
         - analyst
       usedBy:
         - add-mcp
+        - architect-analyze-impact
         - brownfield-create-epic
         - environment-bootstrap
         - spec-research-dependencies
+        - validate-next-story
         - brownfield-risk-report-tmpl
         - design-story-tmpl
         - story-tmpl
@@ -14245,12 +14290,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:35150d764c6dc74bc02b61a4d613c9278e87ffb209403db23991339fdda4f8e2
-      lastVerified: '2026-05-17T10:02:45.308Z'
+      lastVerified: '2026-05-17T14:15:04.575Z'
     architect:
       path: .aiox-core/development/agents/architect.md
       layer: L2
       type: agent
-      purpose: '''Show all available commands with descriptions'''
+      purpose: architect
       keywords:
         - architect
       usedBy:
@@ -14258,6 +14303,7 @@ entities:
         - brownfield-create-epic
         - create-brownfield-story
         - create-deep-research-prompt
+        - create-next-story
         - execute-epic-plan
         - plan-create-context
         - plan-create-implementation
@@ -14267,6 +14313,7 @@ entities:
         - spec-gather-requirements
         - spec-research-dependencies
         - spec-write-spec
+        - validate-next-story
         - validate-tech-preset
         - verify-subtask
         - design-story-tmpl
@@ -14317,7 +14364,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b89e95048df940056570ecb6589f18a9a6114b96ca1b9fde130fb7bdb2ded8f
-      lastVerified: '2026-05-17T10:02:45.309Z'
+      lastVerified: '2026-05-17T14:15:04.577Z'
     data-engineer:
       path: .aiox-core/development/agents/data-engineer.md
       layer: L2
@@ -14330,6 +14377,7 @@ entities:
       usedBy:
         - analyze-project-structure
         - brownfield-create-epic
+        - validate-next-story
         - story-tmpl
         - claude-rules
         - codex-rules
@@ -14383,12 +14431,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:41c791fbdf43f700f2e78418c8af18197d1135741bc7845d03013f726b125f6f
-      lastVerified: '2026-05-17T10:02:45.311Z'
+      lastVerified: '2026-05-17T14:15:04.579Z'
     dev:
       path: .aiox-core/development/agents/dev.md
       layer: L2
       type: agent
-      purpose: '''Show all available commands with descriptions'''
+      purpose: dev
       keywords:
         - dev
       usedBy:
@@ -14401,6 +14449,7 @@ entities:
         - build
         - cleanup-utilities
         - create-brownfield-story
+        - create-next-story
         - create-service
         - create-suite
         - delegate-to-external-executor
@@ -14427,6 +14476,7 @@ entities:
         - qa-run-tests
         - setup-llm-routing
         - story-checkpoint
+        - validate-next-story
         - verify-subtask
         - waves
         - story-tmpl
@@ -14495,12 +14545,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:eaaec824273f02b9ccbe6768d9e9147a5ad0d7faa9483b9730b1f02a71ef2769
-      lastVerified: '2026-05-17T10:02:45.313Z'
+      lastVerified: '2026-05-17T14:15:04.581Z'
     devops:
       path: .aiox-core/development/agents/devops.md
       layer: L2
       type: agent
-      purpose: '''Show all available commands with descriptions'''
+      purpose: devops
       keywords:
         - devops
       usedBy:
@@ -14521,20 +14571,62 @@ entities:
         - github-issue-triage
         - init-project-status
         - list-worktrees
+        - publish-npm
         - qa-gate
         - qa-review-story
+        - release-management
         - remove-worktree
         - resolve-github-issue
         - setup-github
         - setup-mcp-docker
         - triage-github-issues
         - update-aiox
+        - validate-next-story
         - story-tmpl
         - claude-rules
         - codex-rules
         - memory-audit-checklist
         - greenfield-fullstack
-      dependencies: []
+      dependencies:
+        - environment-bootstrap
+        - setup-github
+        - github-devops-version-management
+        - github-devops-pre-push-quality-gate
+        - github-devops-github-pr-automation
+        - ci-cd-configuration
+        - github-devops-repository-cleanup
+        - release-management
+        - search-mcp
+        - add-mcp
+        - list-mcps
+        - remove-mcp
+        - setup-mcp-docker
+        - check-docs-links
+        - triage-github-issues
+        - resolve-github-issue
+        - devops-pro-access-grant
+        - devops-pro-check-access
+        - devops-pro-request-reset
+        - devops-pro-resend-verification
+        - devops-pro-reset-password
+        - devops-pro-validate-login
+        - devops-pro-verify-status
+        - devops-pro-activate
+        - create-worktree
+        - list-worktrees
+        - remove-worktree
+        - cleanup-worktrees
+        - merge-worktree
+        - github-pr-template
+        - github-actions-ci.yml
+        - github-actions-cd.yml
+        - changelog-template
+        - pre-push-checklist
+        - release-checklist
+        - github-cli
+        - asset-inventory.js
+        - path-analyzer.js
+        - migrate-agent.js
       externalDeps:
         - coderabbit
         - git
@@ -14547,15 +14639,16 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5c52cc74f923ac381fa92fb969607b80a35f34b958c02d2d1edd1115f7690d35
-      lastVerified: '2026-05-17T12:22:53.091Z'
+      lastVerified: '2026-05-17T14:15:04.583Z'
     pm:
       path: .aiox-core/development/agents/pm.md
       layer: L2
       type: agent
-      purpose: '|'
+      purpose: pm
       keywords:
         - pm
       usedBy:
+        - architect-analyze-impact
         - brownfield-create-epic
         - create-deep-research-prompt
         - environment-bootstrap
@@ -14564,6 +14657,7 @@ entities:
         - spec-critique
         - spec-gather-requirements
         - spec-write-spec
+        - validate-next-story
         - command-rationalization-matrix
         - design-story-tmpl
         - story-tmpl
@@ -14605,17 +14699,18 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8c81fd9b6df9b98fa3d3654062464498396ddb4eaf0b6dc3a644ae4227982f4b
-      lastVerified: '2026-05-17T10:02:45.317Z'
+      lastVerified: '2026-05-17T14:15:04.585Z'
     po:
       path: .aiox-core/development/agents/po.md
       layer: L2
       type: agent
-      purpose: '''Show all available commands with descriptions'''
+      purpose: po
       keywords:
         - po
       usedBy:
         - brownfield-create-story
         - cleanup-utilities
+        - create-next-story
         - dev-backlog-debt
         - dev-develop-story
         - execute-epic-plan
@@ -14628,6 +14723,7 @@ entities:
         - qa-fix-issues
         - qa-gate
         - story-checkpoint
+        - validate-next-story
         - design-story-tmpl
         - antigravity-rules
         - claude-rules
@@ -14666,12 +14762,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f0090329fd2c2871d3b46d0b2ea1bb9ff3fe48c589fc25ed3d90cf2032621cfd
-      lastVerified: '2026-05-17T10:02:45.318Z'
+      lastVerified: '2026-05-17T14:15:04.586Z'
     qa:
       path: .aiox-core/development/agents/qa.md
       layer: L2
       type: agent
-      purpose: '''Show all available commands with descriptions'''
+      purpose: qa
       keywords:
         - qa
       usedBy:
@@ -14680,6 +14776,7 @@ entities:
         - apply-qa-fixes
         - build-autonomous
         - cleanup-utilities
+        - create-next-story
         - create-suite
         - dev-develop-story
         - execute-checklist
@@ -14697,6 +14794,7 @@ entities:
         - security-scan
         - spec-critique
         - spec-write-spec
+        - validate-next-story
         - design-story-tmpl
         - story-tmpl
         - antigravity-rules
@@ -14750,12 +14848,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cf4a8f473067a9d2909072215bce7b13917c779442e6f858681bd8b9f0b0c3c0
-      lastVerified: '2026-05-17T10:02:45.319Z'
+      lastVerified: '2026-05-17T14:15:04.587Z'
     sm:
       path: .aiox-core/development/agents/sm.md
       layer: L2
       type: agent
-      purpose: '''Show all available commands with descriptions'''
+      purpose: sm
       keywords:
         - sm
       usedBy:
@@ -14763,6 +14861,7 @@ entities:
         - dev-develop-story
         - po-close-story
         - project-status
+        - validate-next-story
         - design-story-tmpl
         - antigravity-rules
         - claude-rules
@@ -14792,12 +14891,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b09334044d3ba581f5403d5d15e0d35c25e580634e712f24bb5a1bc73c9d1cf3
-      lastVerified: '2026-05-17T10:02:45.321Z'
+      lastVerified: '2026-05-17T14:15:04.588Z'
     squad-creator:
       path: .aiox-core/development/agents/squad-creator.md
       layer: L2
       type: agent
-      purpose: '''Show all available commands with descriptions'''
+      purpose: squad-creator
       keywords:
         - squad
         - creator
@@ -14831,12 +14930,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9ae479d628a74fdf8372da4e5a306fdc93235bce8f4957b44ad9adc76643f8e1
-      lastVerified: '2026-05-17T10:02:45.321Z'
+      lastVerified: '2026-05-17T14:15:04.589Z'
     ux-design-expert:
       path: .aiox-core/development/agents/ux-design-expert.md
       layer: L2
       type: agent
-      purpose: '''Complete workflow from user research to component building'''
+      purpose: ux-design-expert
       keywords:
         - ux
         - design
@@ -14845,6 +14944,7 @@ entities:
       usedBy:
         - brownfield-create-epic
         - run-design-system-pipeline
+        - validate-next-story
         - design-story-tmpl
         - story-tmpl
         - claude-rules
@@ -14901,7 +15001,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b6a552405cf1a1eab76e307a505e8b431bffa30ab9681a16169b1427373b8a99
-      lastVerified: '2026-05-17T10:02:45.323Z'
+      lastVerified: '2026-05-17T14:15:04.590Z'
     MEMORY:
       path: .aiox-core/development/agents/analyst/MEMORY.md
       layer: L3
@@ -14922,7 +15022,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b8b52820ba1929ba12403fc437868dd9e8a9c2532abe99296ad05864618693b0
-      lastVerified: '2026-05-17T10:02:45.324Z'
+      lastVerified: '2026-05-17T14:15:04.590Z'
     architect-MEMORY:
       path: .aiox-core/development/agents/architect/MEMORY.md
       layer: L3
@@ -14943,7 +15043,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ee99a68876311e0dc67e0b77ff11f8fa2154f0803f27f4aa89db36df50753d3b
-      lastVerified: '2026-05-17T10:02:45.324Z'
+      lastVerified: '2026-05-17T14:15:04.591Z'
     data-engineer-MEMORY:
       path: .aiox-core/development/agents/data-engineer/MEMORY.md
       layer: L3
@@ -14965,7 +15065,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:20024028651bf2078bf4e58e38aaa84191521ef9b5c11b044eb152a026ec8412
-      lastVerified: '2026-05-17T10:02:45.324Z'
+      lastVerified: '2026-05-17T14:15:04.591Z'
     dev-MEMORY:
       path: .aiox-core/development/agents/dev/MEMORY.md
       layer: L3
@@ -14986,7 +15086,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7c6197418798fa00617f63f93ea6e87dbbbc1bebdb1fb92276433cb7990fd7c0
-      lastVerified: '2026-05-17T10:02:45.325Z'
+      lastVerified: '2026-05-17T14:15:04.591Z'
     devops-MEMORY:
       path: .aiox-core/development/agents/devops/MEMORY.md
       layer: L3
@@ -15007,7 +15107,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:eb2ee887047c94db3441126cd0198cac44cec779026d7842a3a1c7eba936027f
-      lastVerified: '2026-05-17T10:02:45.327Z'
+      lastVerified: '2026-05-17T14:15:04.591Z'
     pm-MEMORY:
       path: .aiox-core/development/agents/pm/MEMORY.md
       layer: L3
@@ -15027,7 +15127,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6a8a5661a32cdf440a21531004ad64767da700b70ff8483faddfb7bcde937f2b
-      lastVerified: '2026-05-17T10:02:45.327Z'
+      lastVerified: '2026-05-17T14:15:04.591Z'
     po-MEMORY:
       path: .aiox-core/development/agents/po/MEMORY.md
       layer: L3
@@ -15047,7 +15147,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4295cbf549671ec6a267bef05871d66fffeb6b898ada166ab1663f7d03632354
-      lastVerified: '2026-05-17T10:02:45.327Z'
+      lastVerified: '2026-05-17T14:15:04.591Z'
     qa-MEMORY:
       path: .aiox-core/development/agents/qa/MEMORY.md
       layer: L3
@@ -15067,7 +15167,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:eec482f057d09635940e9a46bdd6cbb677af12dc4deed64bf71196d551b93abf
-      lastVerified: '2026-05-17T10:02:45.327Z'
+      lastVerified: '2026-05-17T14:15:04.591Z'
     sm-MEMORY:
       path: .aiox-core/development/agents/sm/MEMORY.md
       layer: L3
@@ -15089,7 +15189,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4abaa92d85f4574a79a308f098e9ae719c28f72101e746f2a574ad92e120dcf4
-      lastVerified: '2026-05-17T10:02:45.328Z'
+      lastVerified: '2026-05-17T14:15:04.592Z'
     ux-MEMORY:
       path: .aiox-core/development/agents/ux/MEMORY.md
       layer: L3
@@ -15111,13 +15211,13 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:39e36c9af4aa959fb547152bed812954c33a4c6c8d1a5aababd49052f229fde6
-      lastVerified: '2026-05-17T10:02:45.328Z'
+      lastVerified: '2026-05-17T14:15:04.592Z'
   checklists:
     agent-quality-gate:
       path: .aiox-core/development/checklists/agent-quality-gate.md
       layer: L2
       type: checklist
-      purpose: '"Validate agent definitions meet Hybrid Loader quality standard + operational completeness"'
+      purpose: Agent Quality Gate Checklist
       keywords:
         - agent
         - quality
@@ -15133,7 +15233,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:46395b5c10794ca98321e4baaaaa1737485bec3f6bc3a616cf948478c0a1c644
-      lastVerified: '2026-05-17T10:02:45.329Z'
+      lastVerified: '2026-05-17T14:15:04.593Z'
     brownfield-compatibility-checklist:
       path: .aiox-core/development/checklists/brownfield-compatibility-checklist.md
       layer: L2
@@ -15155,7 +15255,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c5ff5d7cd45395e8766bf5c941ece8b0d5557758ecead7bef3ac3e08abee899
-      lastVerified: '2026-05-17T10:02:45.329Z'
+      lastVerified: '2026-05-17T14:15:04.593Z'
     issue-triage-checklist:
       path: .aiox-core/development/checklists/issue-triage-checklist.md
       layer: L2
@@ -15175,7 +15275,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c6dbaae38c0e3030dbffebcbcf95e5e766e0294a7a678531531cbd7ad6e54e2b
-      lastVerified: '2026-05-17T10:02:45.329Z'
+      lastVerified: '2026-05-17T14:15:04.593Z'
     memory-audit-checklist:
       path: .aiox-core/development/checklists/memory-audit-checklist.md
       layer: L2
@@ -15197,7 +15297,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bb3ca4ea56d0294a7acc1e9f5bd690ee70c676c28950b8a7c3c25bef8e428f7e
-      lastVerified: '2026-05-17T10:02:45.329Z'
+      lastVerified: '2026-05-17T14:15:04.593Z'
     self-critique-checklist:
       path: .aiox-core/development/checklists/self-critique-checklist.md
       layer: L2
@@ -15220,13 +15320,13 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:158f21a6be7a7cbc90de0302678490887c2f88b1d79d925f77a8a2209d2ae003
-      lastVerified: '2026-05-17T10:02:45.329Z'
+      lastVerified: '2026-05-17T14:15:04.593Z'
   data:
     agent-config-requirements:
       path: .aiox-core/data/agent-config-requirements.yaml
       layer: L3
       type: data
-      purpose: PVMind integration context (not used in AIOX-FullStack)
+      purpose: Agent Config Requirements
       keywords:
         - agent
         - config
@@ -15241,12 +15341,14 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:68e87b5777d1872c4fed6644dd3c7e3c3e8fd590df7d2b58c36d541cf8e38dd3
-      lastVerified: '2026-05-17T10:02:45.331Z'
+      lastVerified: '2026-05-17T14:15:04.594Z'
     aiox-kb:
       path: .aiox-core/data/aiox-kb.md
       layer: L3
       type: data
-      purpose: '"Complete story content..."'
+      purpose: >-
+        AIOX-Method is a framework that combines AI agents with Agile development methodologies. The v4 system
+        introduces a modular architecture with improved dependency management, bundle optimization, and s
       keywords:
         - aiox
         - kb
@@ -15262,12 +15364,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7ceaab838b4586a5314f0edea431f09fbc4dd82eb386f89db4442d1212add352
-      lastVerified: '2026-05-17T13:08:28.422Z'
+      lastVerified: '2026-05-17T14:15:04.595Z'
     entity-registry:
       path: .aiox-core/data/entity-registry.yaml
       layer: L3
       type: data
-      purpose: Add MCP Server Task
+      purpose: Entity at .aiox-core/data/entity-registry.yaml
       keywords:
         - entity
         - registry
@@ -15282,8 +15384,8 @@ entities:
         score: 0.5
         constraints: []
         extensionPoints: []
-      checksum: sha256:84acf809f112cb726710a9878904db6b9d5c0eb487a2e578de25ede0c2177c5e
-      lastVerified: '2026-05-17T10:02:45.334Z'
+      checksum: sha256:<self-reference>
+      lastVerified: '2026-05-17T14:15:04.693Z'
     learned-patterns:
       path: .aiox-core/data/learned-patterns.yaml
       layer: L3
@@ -15302,12 +15404,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
-      lastVerified: '2026-05-17T10:02:45.334Z'
+      lastVerified: '2026-05-17T14:15:04.598Z'
     mcp-tool-examples:
       path: .aiox-core/data/mcp-tool-examples.yaml
       layer: L3
       type: data
-      purpose: '"Look up React Server Components documentation"'
+      purpose: '============================================================================='
       keywords:
         - mcp
         - tool
@@ -15323,7 +15425,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8a38e4171d7434d79f83032d9c37f2f604d9411dbec6c3c0334d6661481745fd
-      lastVerified: '2026-05-17T10:02:45.335Z'
+      lastVerified: '2026-05-17T14:15:04.599Z'
     technical-preferences:
       path: .aiox-core/data/technical-preferences.md
       layer: L3
@@ -15345,12 +15447,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:abb9327d3ce96a3cd49e73a555da4078e81ea0c4dbfe7154420c3ec7ac1c93b7
-      lastVerified: '2026-05-17T10:02:45.335Z'
+      lastVerified: '2026-05-17T14:15:04.599Z'
     tool-registry:
       path: .aiox-core/data/tool-registry.yaml
       layer: L3
       type: data
-      purpose: Unified tool registry for AIOX token optimization
+      purpose: '============================================================================='
       keywords:
         - tool
         - registry
@@ -15365,12 +15467,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:64e867d0eb36c7f7ac86f4f73f1b2ff89f43f37f28a6de34389be74b9346860c
-      lastVerified: '2026-05-17T10:02:45.335Z'
+      lastVerified: '2026-05-17T14:15:04.599Z'
     workflow-chains:
       path: .aiox-core/data/workflow-chains.yaml
       layer: L3
       type: data
-      purpose: Full 4-phase workflow for all development work
+      purpose: Workflow Chains — Greeting Suggestion Data
       keywords:
         - workflow
         - chains
@@ -15387,12 +15489,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1fbf1625e267eedc315cf1e08e5827c250ddc6785fb2cb139e7702def9b66268
-      lastVerified: '2026-05-17T10:02:45.336Z'
+      lastVerified: '2026-05-17T14:15:04.599Z'
     workflow-patterns:
       path: .aiox-core/data/workflow-patterns.yaml
       layer: L3
       type: data
-      purpose: Human-readable workflow description
+      purpose: Workflow Patterns Definition
       keywords:
         - workflow
         - patterns
@@ -15407,12 +15509,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0e90d71ce0cc218d8710c1f195f74a24d3aa7513f5728f5e65da9220612c3617
-      lastVerified: '2026-05-17T10:02:45.336Z'
+      lastVerified: '2026-05-17T14:15:04.600Z'
     workflow-state-schema:
       path: .aiox-core/data/workflow-state-schema.yaml
       layer: L3
       type: data
-      purpose: Track workflow execution progress across sessions
+      purpose: Workflow State Schema
       keywords:
         - workflow
         - state
@@ -15427,12 +15529,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d80a645a9c48b8ab8168ddbe36279662d72de4fb5cd8953a6685e5d1bd9968db
-      lastVerified: '2026-05-17T10:02:45.336Z'
+      lastVerified: '2026-05-17T14:15:04.600Z'
     _template:
       path: .aiox-core/data/tech-presets/_template.md
       layer: L3
       type: data
-      purpose: '''Brief description of when to use this preset'''
+      purpose: Tech Preset Template
       keywords:
         - template
         - tech
@@ -15447,14 +15549,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:68b26930b728908b6097fc91956c8c446e5cc0dbe627e3b737495ebcd7e9569b
-      lastVerified: '2026-05-17T10:02:45.336Z'
+      lastVerified: '2026-05-17T14:15:04.600Z'
     angular-nestjs:
       path: .aiox-core/data/tech-presets/angular-nestjs.md
       layer: L3
       type: data
-      purpose: >-
-        'Arquitetura otimizada para aplicações fullstack com Angular 21 (Signals, Standalone Components) no frontend e
-        NestJS (Modular, DI, Guards) no backend'
+      purpose: Angular 21 + NestJS Tech Preset
       keywords:
         - angular
         - nestjs
@@ -15473,12 +15573,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d7b41b5076fc8a2c4312398f41414b8515cc0563ed727e4fe354548bdd80fb77
-      lastVerified: '2026-05-17T10:02:45.337Z'
+      lastVerified: '2026-05-17T14:15:04.601Z'
     csharp:
       path: .aiox-core/data/tech-presets/csharp.md
       layer: L3
       type: data
-      purpose: '''Arquitetura para APIs em .NET 9+ com camadas claras, EF Core e testes automatizados'''
+      purpose: C# Tech Preset
       keywords:
         - csharp
         - tech
@@ -15493,12 +15593,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4667d33407c59fd6c7b4558370893a14df6d461645fc840b2df2fb7508bd6fcf
-      lastVerified: '2026-05-17T10:02:45.337Z'
+      lastVerified: '2026-05-17T14:15:04.601Z'
     go:
       path: .aiox-core/data/tech-presets/go.md
       layer: L3
       type: data
-      purpose: '''Arquitetura para APIs e workers em Go 1.24+ com boundaries claros e alta testabilidade'''
+      purpose: Go Tech Preset
       keywords:
         - go
         - tech
@@ -15513,12 +15613,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e0851caecbdc2cea6531359fe640427685cd6ed664dbf991ccb135917c4d1ec2
-      lastVerified: '2026-05-17T10:02:45.338Z'
+      lastVerified: '2026-05-17T14:15:04.601Z'
     java:
       path: .aiox-core/data/tech-presets/java.md
       layer: L3
       type: data
-      purpose: '''Arquitetura para backend Java 21+ com Spring Boot 3+, DDD tatico e testes robustos'''
+      purpose: Java Tech Preset
       keywords:
         - java
         - tech
@@ -15533,14 +15633,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b912e04412f63b59439f7cca119802bed95a6cb756221e3ba7aee45c3d2890fd
-      lastVerified: '2026-05-17T10:02:45.338Z'
+      lastVerified: '2026-05-17T14:15:04.601Z'
     nextjs-react:
       path: .aiox-core/data/tech-presets/nextjs-react.md
       layer: L3
       type: data
-      purpose: >-
-        'Arquitetura otimizada para aplicações fullstack com Next.js 16+, React, TypeScript e padrões que maximizam a
-        eficiência do Claude Code'
+      purpose: Next.js + React Tech Preset
       keywords:
         - nextjs
         - react
@@ -15560,14 +15658,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:558ce0abd112ca39853fc5150bd850862e5fcfac74c8def80c3876b60c9f5d33
-      lastVerified: '2026-05-17T10:02:45.339Z'
+      lastVerified: '2026-05-17T14:15:04.601Z'
     php:
       path: .aiox-core/data/tech-presets/php.md
       layer: L3
       type: data
-      purpose: >-
-        'Arquitetura para APIs e sistemas web em PHP 8.3+ com Laravel 11, boundaries por contexto e testes
-        automatizados'
+      purpose: PHP Tech Preset
       keywords:
         - php
         - tech
@@ -15582,12 +15678,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:847dde754e7a98c4d11328768483358d2be7d2f10e43b6703403237987620077
-      lastVerified: '2026-05-17T10:02:45.339Z'
+      lastVerified: '2026-05-17T14:15:04.602Z'
     rust:
       path: .aiox-core/data/tech-presets/rust.md
       layer: L3
       type: data
-      purpose: '''Arquitetura para APIs e workers em Rust 1.77+ com contratos por traits, errors tipados e testes confiaveis'''
+      purpose: Rust Tech Preset
       keywords:
         - rust
         - tech
@@ -15602,13 +15698,13 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:58422e884e46660216d5389878ae2f0ab619da7d34f34ed1dff917dfd8fed7db
-      lastVerified: '2026-05-17T10:02:45.339Z'
+      lastVerified: '2026-05-17T14:15:04.602Z'
   workflows:
     auto-worktree:
       path: .aiox-core/development/workflows/auto-worktree.yaml
       layer: L2
       type: workflow
-      purpose: '>-'
+      purpose: Entity at .aiox-core/development/workflows/auto-worktree.yaml
       keywords:
         - auto
         - worktree
@@ -15625,12 +15721,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:74b0dff78c2b91eda03b9914a73cc99807645c8e0b174e576d22e0b3f5b75be3
-      lastVerified: '2026-05-17T10:02:45.341Z'
+      lastVerified: '2026-05-17T14:15:04.604Z'
     brownfield-discovery:
       path: .aiox-core/development/workflows/brownfield-discovery.yaml
       layer: L2
       type: workflow
-      purpose: '>-'
+      purpose: Entity at .aiox-core/development/workflows/brownfield-discovery.yaml
       keywords:
         - brownfield
         - discovery
@@ -15650,12 +15746,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a52662b683781546d4585d456aad1cb7d41343a8c934d9a6d6441f8d3dec5385
-      lastVerified: '2026-05-17T10:02:45.347Z'
+      lastVerified: '2026-05-17T14:15:04.605Z'
     brownfield-fullstack:
       path: .aiox-core/development/workflows/brownfield-fullstack.yaml
       layer: L2
       type: workflow
-      purpose: '>-'
+      purpose: Entity at .aiox-core/development/workflows/brownfield-fullstack.yaml
       keywords:
         - brownfield
         - fullstack
@@ -15676,12 +15772,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5200308dfa759d6ce37270f63853a6c1424d47ec552142d9ada6174aaf5c22ff
-      lastVerified: '2026-05-17T10:02:45.348Z'
+      lastVerified: '2026-05-17T14:15:04.606Z'
     brownfield-service:
       path: .aiox-core/development/workflows/brownfield-service.yaml
       layer: L2
       type: workflow
-      purpose: '>-'
+      purpose: Entity at .aiox-core/development/workflows/brownfield-service.yaml
       keywords:
         - brownfield
         - service
@@ -15701,12 +15797,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6ef271e25edd0dfe4235ea5aab14dbf89509250d8471580418ce58d50a1748e8
-      lastVerified: '2026-05-17T10:02:45.348Z'
+      lastVerified: '2026-05-17T14:15:04.607Z'
     brownfield-ui:
       path: .aiox-core/development/workflows/brownfield-ui.yaml
       layer: L2
       type: workflow
-      purpose: '>-'
+      purpose: Entity at .aiox-core/development/workflows/brownfield-ui.yaml
       keywords:
         - brownfield
         - ui
@@ -15727,12 +15823,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:553a05def42e2a884d59fdeaa1aaf07566e469e3ae30daf43543e8a934c1c67f
-      lastVerified: '2026-05-17T10:02:45.349Z'
+      lastVerified: '2026-05-17T14:15:04.608Z'
     design-system-build-quality:
       path: .aiox-core/development/workflows/design-system-build-quality.yaml
       layer: L2
       type: workflow
-      purpose: '>-'
+      purpose: Entity at .aiox-core/development/workflows/design-system-build-quality.yaml
       keywords:
         - design
         - system
@@ -15749,12 +15845,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e9aa8f3e1ae22aa0799627326a3548e78eee805e5652c12a15e84dbdbcd5ffe2
-      lastVerified: '2026-05-17T10:02:45.350Z'
+      lastVerified: '2026-05-17T14:15:04.608Z'
     development-cycle:
       path: .aiox-core/development/workflows/development-cycle.yaml
       layer: L2
       type: workflow
-      purpose: '>-'
+      purpose: '============================================'
       keywords:
         - development
         - cycle
@@ -15775,12 +15871,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c22f2700d6c3dcd227efec711ab206b4fa9e268768a15be86eea0405e2c82c4d
-      lastVerified: '2026-05-17T10:02:45.352Z'
+      lastVerified: '2026-05-17T14:15:04.610Z'
     epic-orchestration:
       path: .aiox-core/development/workflows/epic-orchestration.yaml
       layer: L2
       type: workflow
-      purpose: '>-'
+      purpose: '============================================'
       keywords:
         - epic
         - orchestration
@@ -15795,12 +15891,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4bb9d91027036d089ab880e46e4b256290761c4dbf17d716abe61b541161fe05
-      lastVerified: '2026-05-17T10:02:45.355Z'
+      lastVerified: '2026-05-17T14:15:04.611Z'
     greenfield-fullstack:
       path: .aiox-core/development/workflows/greenfield-fullstack.yaml
       layer: L2
       type: workflow
-      purpose: '>-'
+      purpose: Entity at .aiox-core/development/workflows/greenfield-fullstack.yaml
       keywords:
         - greenfield
         - fullstack
@@ -15824,12 +15920,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:106b47c4205ac395118a49f5d5fb194125f5c17819780f9a598ef434352013ef
-      lastVerified: '2026-05-17T10:02:45.356Z'
+      lastVerified: '2026-05-17T14:15:04.612Z'
     greenfield-service:
       path: .aiox-core/development/workflows/greenfield-service.yaml
       layer: L2
       type: workflow
-      purpose: '>-'
+      purpose: Entity at .aiox-core/development/workflows/greenfield-service.yaml
       keywords:
         - greenfield
         - service
@@ -15850,12 +15946,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b22d2ea83d2079878632f50351a21d7f2a9a8035283abd6fea701033774f9bb
-      lastVerified: '2026-05-17T10:02:45.357Z'
+      lastVerified: '2026-05-17T14:15:04.613Z'
     greenfield-ui:
       path: .aiox-core/development/workflows/greenfield-ui.yaml
       layer: L2
       type: workflow
-      purpose: '>-'
+      purpose: Entity at .aiox-core/development/workflows/greenfield-ui.yaml
       keywords:
         - greenfield
         - ui
@@ -15877,12 +15973,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e7818aa9f7c8db4efd6d7fd631fb8ff6f1aac4202c3f6253dfd6d50dd708fc30
-      lastVerified: '2026-05-17T10:02:45.358Z'
+      lastVerified: '2026-05-17T14:15:04.613Z'
     qa-loop:
       path: .aiox-core/development/workflows/qa-loop.yaml
       layer: L2
       type: workflow
-      purpose: '>-'
+      purpose: Entity at .aiox-core/development/workflows/qa-loop.yaml
       keywords:
         - qa
         - loop
@@ -15902,12 +15998,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:585d5e5dd2cf4d5682e8db2a816caa588ecf5ae3b332f4a5ceec9f406b5f0f09
-      lastVerified: '2026-05-17T10:02:45.358Z'
+      lastVerified: '2026-05-17T14:15:04.615Z'
     spec-pipeline:
       path: .aiox-core/development/workflows/spec-pipeline.yaml
       layer: L2
       type: workflow
-      purpose: '>-'
+      purpose: Entity at .aiox-core/development/workflows/spec-pipeline.yaml
       keywords:
         - spec
         - pipeline
@@ -15930,12 +16026,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4604ff3e2e945fbbb45006e32d8de81c73cb38782526ca3c87924549ccc29ccf
-      lastVerified: '2026-05-17T10:02:45.359Z'
+      lastVerified: '2026-05-17T14:15:04.616Z'
     story-development-cycle:
       path: .aiox-core/development/workflows/story-development-cycle.yaml
       layer: L2
       type: workflow
-      purpose: '>-'
+      purpose: Entity at .aiox-core/development/workflows/story-development-cycle.yaml
       keywords:
         - story
         - development
@@ -15954,7 +16050,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6125a3545e9a8550582d7d6ea640bbd5b0e4747b80e7c67ebf60ce284591220e
-      lastVerified: '2026-05-17T10:02:45.360Z'
+      lastVerified: '2026-05-17T14:15:04.617Z'
   utils:
     output-formatter:
       path: .aiox-core/core/utils/output-formatter.js
@@ -15974,7 +16070,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6fdfee469b7c108ec24a045b9b2719d836a242052abd285957a9ac732c6fc594
-      lastVerified: '2026-05-17T10:02:45.361Z'
+      lastVerified: '2026-05-17T14:15:04.618Z'
     security-utils:
       path: .aiox-core/core/utils/security-utils.js
       layer: L1
@@ -15993,7 +16089,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:00c938eda0e142b8c204b50afdd662864b5209b60a32a0e6e847e4e4cbceee09
-      lastVerified: '2026-05-17T10:02:45.361Z'
+      lastVerified: '2026-05-17T14:15:04.618Z'
     yaml-validator:
       path: .aiox-core/core/utils/yaml-validator.js
       layer: L1
@@ -16012,7 +16108,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:05084596198634dd2a670a752d5c451edfe268e16e3bae511db52184f895366f
-      lastVerified: '2026-05-17T10:02:45.361Z'
+      lastVerified: '2026-05-17T14:15:04.618Z'
   tools: {}
   infra-scripts:
     aiox-validator:
@@ -16033,12 +16129,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5a91cc8b54ccd58955dbbb5925f878d9e507dc2a9358f642c62f7ee84a6156a0
-      lastVerified: '2026-05-17T10:02:45.363Z'
+      lastVerified: '2026-05-17T14:15:04.622Z'
     approach-manager:
       path: .aiox-core/infrastructure/scripts/approach-manager.js
       layer: L2
       type: script
-      purpose: approachData.summary || '',
+      purpose: Entity at .aiox-core/infrastructure/scripts/approach-manager.js
       keywords:
         - approach
         - manager
@@ -16053,12 +16149,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:22ee604ca42094f5b7939ec129c52cb1fc362ae70688cc1ef7a921c956ab38d2
-      lastVerified: '2026-05-17T10:02:45.364Z'
+      lastVerified: '2026-05-17T14:15:04.622Z'
     approval-workflow:
       path: .aiox-core/infrastructure/scripts/approval-workflow.js
       layer: L2
       type: script
-      purpose: impactReport.summary,
+      purpose: Entity at .aiox-core/infrastructure/scripts/approval-workflow.js
       keywords:
         - approval
         - workflow
@@ -16073,16 +16169,17 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4d744a8d08cadf09bf368a1457c1bd3bc68ccef0885c324b2527222da816544b
-      lastVerified: '2026-05-17T10:02:45.364Z'
+      lastVerified: '2026-05-17T14:15:04.623Z'
     asset-inventory:
       path: .aiox-core/infrastructure/scripts/asset-inventory.js
       layer: L2
       type: script
-      purpose: generateSummary(inventory, orphans),
+      purpose: Entity at .aiox-core/infrastructure/scripts/asset-inventory.js
       keywords:
         - asset
         - inventory
-      usedBy: []
+      usedBy:
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -16092,12 +16189,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:25ad926a05af465389b6fb92f7c9c79c453c54047b4ebe9629ee1c153a6b3373
-      lastVerified: '2026-05-17T10:02:45.365Z'
+      lastVerified: '2026-05-17T14:15:04.623Z'
     atomic-layer-classifier:
       path: .aiox-core/infrastructure/scripts/atomic-layer-classifier.js
       layer: L2
       type: script
-      purpose: 'Resolve {TODO: Atom|Molecule|Organism} placeholders in all 114 task files'
+      purpose: Entity at .aiox-core/infrastructure/scripts/atomic-layer-classifier.js
       keywords:
         - atomic
         - layer
@@ -16112,7 +16209,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ecdb368d80a69c8da7cc507aff0b18bd2e58d8bd94b9fb0ba1e074595a19e884
-      lastVerified: '2026-05-17T10:02:45.365Z'
+      lastVerified: '2026-05-17T14:15:04.623Z'
     backup-manager:
       path: .aiox-core/infrastructure/scripts/backup-manager.js
       layer: L2
@@ -16133,12 +16230,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e7d0173f107c0576f443a7f4bc83387cdbb625518ce5749ca9059ffbf3070f44
-      lastVerified: '2026-05-17T10:02:45.365Z'
+      lastVerified: '2026-05-17T14:15:04.624Z'
     batch-creator:
       path: .aiox-core/infrastructure/scripts/batch-creator.js
       layer: L2
       type: script
-      purpose: '''Create multiple related components'','
+      purpose: Entity at .aiox-core/infrastructure/scripts/batch-creator.js
       keywords:
         - batch
         - creator
@@ -16156,7 +16253,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b91ca0e5d8af3d47658bc5bd754e72e654e68446c17c5e50e45ebd581535fe7d
-      lastVerified: '2026-05-17T10:02:45.366Z'
+      lastVerified: '2026-05-17T14:15:04.624Z'
     branch-manager:
       path: .aiox-core/infrastructure/scripts/branch-manager.js
       layer: L2
@@ -16176,12 +16273,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:49f3a7a7aa36347c3e3dbc998847913c829216c71a1c659bf7a55d67a940d1c3
-      lastVerified: '2026-05-17T10:02:45.366Z'
+      lastVerified: '2026-05-17T14:15:04.624Z'
     capability-analyzer:
       path: .aiox-core/infrastructure/scripts/capability-analyzer.js
       layer: L2
       type: script
-      purpose: metricResult.description,
+      purpose: Entity at .aiox-core/infrastructure/scripts/capability-analyzer.js
       keywords:
         - capability
         - analyzer
@@ -16197,7 +16294,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:92f55a27e60fd6aba2a0203f1c28aa12d6f70200097ec44d849db2653f758a17
-      lastVerified: '2026-05-17T10:02:45.366Z'
+      lastVerified: '2026-05-17T14:15:04.625Z'
     changelog-generator:
       path: .aiox-core/infrastructure/scripts/changelog-generator.js
       layer: L2
@@ -16216,12 +16313,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c2d6b203d39fe2ef8d6b7108beb59a03da0986f9331c22ce539d9857c7cc3612
-      lastVerified: '2026-05-17T10:02:45.367Z'
+      lastVerified: '2026-05-17T14:15:04.625Z'
     cicd-discovery:
       path: .aiox-core/infrastructure/scripts/cicd-discovery.js
       layer: L2
       type: script
-      purpose: '''Integrate AIOX build orchestrator for intelligent parallel builds'','
+      purpose: Entity at .aiox-core/infrastructure/scripts/cicd-discovery.js
       keywords:
         - cicd
         - discovery
@@ -16235,12 +16332,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:04b5efa659f9d3baa998ca4b09f7fc6ec4800d0b165ecf118a8f10df93642228
-      lastVerified: '2026-05-17T10:02:45.367Z'
+      lastVerified: '2026-05-17T14:15:04.625Z'
     clickup-helpers:
       path: .aiox-core/infrastructure/scripts/clickup-helpers.js
       layer: L2
       type: script
-      purpose: markdown,
+      purpose: Entity at .aiox-core/infrastructure/scripts/clickup-helpers.js
       keywords:
         - clickup
         - helpers
@@ -16257,12 +16354,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:043ceb5b712903e6b78be83c997575e8de64d5815dccef88355c20d8153af9a6
-      lastVerified: '2026-05-17T10:02:45.368Z'
+      lastVerified: '2026-05-17T14:15:04.626Z'
     code-quality-improver:
       path: .aiox-core/infrastructure/scripts/code-quality-improver.js
       layer: L2
       type: script
-      purpose: '''Apply consistent code formatting'','
+      purpose: Entity at .aiox-core/infrastructure/scripts/code-quality-improver.js
       keywords:
         - code
         - quality
@@ -16278,12 +16375,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:765dd10a367656b330a659b2245ef2eb9a947905fee71555198837743fc1483f
-      lastVerified: '2026-05-17T10:02:45.368Z'
+      lastVerified: '2026-05-17T14:15:04.626Z'
     codebase-mapper:
       path: .aiox-core/infrastructure/scripts/codebase-mapper.js
       layer: L2
       type: script
-      purpose: this._inferPurpose(path.basename(dirPath)),
+      purpose: Entity at .aiox-core/infrastructure/scripts/codebase-mapper.js
       keywords:
         - codebase
         - mapper
@@ -16298,12 +16395,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b72ae317c81c01ed1d6d518d64cf18fdecb9d408ab45dba6ad45cb39c6e3a1d
-      lastVerified: '2026-05-17T10:02:45.369Z'
+      lastVerified: '2026-05-17T14:15:04.627Z'
     collect-tool-usage:
       path: .aiox-core/infrastructure/scripts/collect-tool-usage.js
       layer: L2
       type: script
-      purpose: Collect tool usage data per session, store in .aiox/analytics/,
+      purpose: Entity at .aiox-core/infrastructure/scripts/collect-tool-usage.js
       keywords:
         - collect
         - tool
@@ -16318,12 +16415,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8a739b79182dc41e28b7e02aeb9ec1dde5ec49f3ca534399acc59711b3b92bbf
-      lastVerified: '2026-05-17T10:02:45.370Z'
+      lastVerified: '2026-05-17T14:15:04.627Z'
     commit-message-generator:
       path: .aiox-core/infrastructure/scripts/commit-message-generator.js
       layer: L2
       type: script
-      purpose: ''';'
+      purpose: Entity at .aiox-core/infrastructure/scripts/commit-message-generator.js
       keywords:
         - commit
         - message
@@ -16340,12 +16437,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:611b0f27acd02e49aff7a2d91b48823dc4a2d788440fff2f32bf500a1bc84132
-      lastVerified: '2026-05-17T10:02:45.370Z'
+      lastVerified: '2026-05-17T14:15:04.628Z'
     component-generator:
       path: .aiox-core/infrastructure/scripts/component-generator.js
       layer: L2
       type: script
-      purpose: '`Create ${componentType}`,'
+      purpose: Entity at .aiox-core/infrastructure/scripts/component-generator.js
       keywords:
         - component
         - generator
@@ -16355,6 +16452,7 @@ entities:
         - create-brownfield-story
         - create-deep-research-prompt
         - create-doc
+        - create-next-story
         - create-suite
         - create-task
         - create-workflow
@@ -16381,12 +16479,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c74da9a766aeca878568a0e70f78141e7a772322d428f99e90fcd7b9a5fd7edc
-      lastVerified: '2026-05-17T10:02:45.371Z'
+      lastVerified: '2026-05-17T14:15:04.628Z'
     component-metadata:
       path: .aiox-core/infrastructure/scripts/component-metadata.js
       layer: L2
       type: script
-      purpose: null,
+      purpose: Entity at .aiox-core/infrastructure/scripts/component-metadata.js
       keywords:
         - component
         - metadata
@@ -16403,7 +16501,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0ad8034533561b13187072eaa611510117463bacbaff12f9ae48008128560000
-      lastVerified: '2026-05-17T10:02:45.371Z'
+      lastVerified: '2026-05-17T14:15:04.629Z'
     component-search:
       path: .aiox-core/infrastructure/scripts/component-search.js
       layer: L2
@@ -16424,7 +16522,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:08feb4672de885f140527e460614cbc90d90544753581f36afeec71ee8614703
-      lastVerified: '2026-05-17T10:02:45.372Z'
+      lastVerified: '2026-05-17T14:15:04.629Z'
     config-cache:
       path: .aiox-core/infrastructure/scripts/config-cache.js
       layer: L2
@@ -16447,7 +16545,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:363383dbf90df90d69b8ba769db4f9749b0ae91b4fe95ee15be633941906f8a2
-      lastVerified: '2026-05-17T10:02:45.372Z'
+      lastVerified: '2026-05-17T14:15:04.629Z'
     config-loader:
       path: .aiox-core/infrastructure/scripts/config-loader.js
       layer: L2
@@ -16469,12 +16567,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8f9489f7c57e775bfbb750761d9714505d5df3938b664cbbdf6701f9e18e240b
-      lastVerified: '2026-05-17T10:02:45.372Z'
+      lastVerified: '2026-05-17T14:15:04.630Z'
     conflict-resolver:
       path: .aiox-core/infrastructure/scripts/conflict-resolver.js
       layer: L2
       type: script
-      purpose: '''No conflicts detected'','
+      purpose: Entity at .aiox-core/infrastructure/scripts/conflict-resolver.js
       keywords:
         - conflict
         - resolver
@@ -16489,12 +16587,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3d2794a66f16fcea95b096386dc9c2dcd31e5938d862030e7ac1f38c00a2c0bd
-      lastVerified: '2026-05-17T10:02:45.372Z'
+      lastVerified: '2026-05-17T14:15:04.630Z'
     coverage-analyzer:
       path: .aiox-core/infrastructure/scripts/coverage-analyzer.js
       layer: L2
       type: script
-      purpose: '''Component has no test files'','
+      purpose: Entity at .aiox-core/infrastructure/scripts/coverage-analyzer.js
       keywords:
         - coverage
         - analyzer
@@ -16509,7 +16607,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:95e70563eadf720ce4c6aa6349ace311cf34c63bc5044f71565f328a2dc9a706
-      lastVerified: '2026-05-17T10:02:45.373Z'
+      lastVerified: '2026-05-17T14:15:04.631Z'
     dashboard-status-writer:
       path: .aiox-core/infrastructure/scripts/dashboard-status-writer.js
       layer: L2
@@ -16529,12 +16627,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a01bc8e74ce40206bbb49453af46896388754f412961b6f6585927a382338f01
-      lastVerified: '2026-05-17T10:02:45.373Z'
+      lastVerified: '2026-05-17T14:15:04.631Z'
     dependency-analyzer:
       path: .aiox-core/infrastructure/scripts/dependency-analyzer.js
       layer: L2
       type: script
-      purpose: '`Dependency task for ${id}`,'
+      purpose: Entity at .aiox-core/infrastructure/scripts/dependency-analyzer.js
       keywords:
         - dependency
         - analyzer
@@ -16550,14 +16648,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:af326d5d70a097cc255171d8f30b1d99a302b07d96d94528cfaad3f97bdea479
-      lastVerified: '2026-05-17T10:02:45.374Z'
+      lastVerified: '2026-05-17T14:15:04.631Z'
     dependency-impact-analyzer:
       path: .aiox-core/infrastructure/scripts/dependency-impact-analyzer.js
       layer: L2
       type: script
-      purpose: >-
-        `${criticalComponents.length} components have critical dependency on the target. Consider gradual migration or
-        deprecation strategy.`,
+      purpose: Entity at .aiox-core/infrastructure/scripts/dependency-impact-analyzer.js
       keywords:
         - dependency
         - impact
@@ -16575,7 +16671,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3c9d87250845f7def63a2230d4af43ed2d6ae84cfba6b6d72a5b9e285a66f5ed
-      lastVerified: '2026-05-17T10:02:45.374Z'
+      lastVerified: '2026-05-17T14:15:04.632Z'
     diff-generator:
       path: .aiox-core/infrastructure/scripts/diff-generator.js
       layer: L2
@@ -16596,12 +16692,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:569387c1dd8ee00d0ebc34b9f463438150ed9c96af2e5728fde83c36626211cf
-      lastVerified: '2026-05-17T10:02:45.375Z'
+      lastVerified: '2026-05-17T14:15:04.632Z'
     documentation-synchronizer:
       path: .aiox-core/infrastructure/scripts/documentation-synchronizer.js
       layer: L2
       type: script
-      purpose: '''Sync JSDoc comments with markdown documentation'','
+      purpose: Entity at .aiox-core/infrastructure/scripts/documentation-synchronizer.js
       keywords:
         - documentation
         - synchronizer
@@ -16616,12 +16712,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:94fc482ef0182608a3433824d02cb24fe0d7ab4aaa256853b9b79e603bf28e9e
-      lastVerified: '2026-05-17T10:02:45.375Z'
+      lastVerified: '2026-05-17T14:15:04.633Z'
     framework-analyzer:
       path: .aiox-core/infrastructure/scripts/framework-analyzer.js
       layer: L2
       type: script
-      purpose: metadata.description || this.extractDescription(markdownContent),
+      purpose: Entity at .aiox-core/infrastructure/scripts/framework-analyzer.js
       keywords:
         - framework
         - analyzer
@@ -16638,12 +16734,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8bd86d50f5a3f050191a49e22e8348bbefa72e3df396313064239a2f1a4a9856
-      lastVerified: '2026-05-17T10:02:45.376Z'
+      lastVerified: '2026-05-17T14:15:04.633Z'
     generate-optimization-report:
       path: .aiox-core/infrastructure/scripts/generate-optimization-report.js
       layer: L2
       type: script
-      purpose: //   - Compare post-optimization metrics against TOK-1.5 baseline (ACs 4-6)
+      purpose: Entity at .aiox-core/infrastructure/scripts/generate-optimization-report.js
       keywords:
         - generate
         - optimization
@@ -16658,7 +16754,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b57357bc4120529381b811fd7c1aab901d3b67dd765d043eefc61bb22f5b8df1
-      lastVerified: '2026-05-17T10:02:45.376Z'
+      lastVerified: '2026-05-17T14:15:04.633Z'
     generate-settings-json:
       path: .aiox-core/infrastructure/scripts/generate-settings-json.js
       layer: L2
@@ -16678,7 +16774,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dc5b8803825ed749080925d7c17ece39b33a7faf3b02d08a445e8cc7408048a1
-      lastVerified: '2026-05-17T10:02:45.376Z'
+      lastVerified: '2026-05-17T14:15:04.634Z'
     git-config-detector:
       path: .aiox-core/infrastructure/scripts/git-config-detector.js
       layer: L2
@@ -16700,7 +16796,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:52ed96d98fc6f9e83671d7d27f78dcff4f2475f3b8e339dc31922f6b2814ad78
-      lastVerified: '2026-05-17T10:02:45.376Z'
+      lastVerified: '2026-05-17T14:15:04.634Z'
     git-wrapper:
       path: .aiox-core/infrastructure/scripts/git-wrapper.js
       layer: L2
@@ -16721,12 +16817,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7130442ca72ba89e397be77000b44e2431b92a8af44d1fac63c869807641e587
-      lastVerified: '2026-05-17T10:02:45.376Z'
+      lastVerified: '2026-05-17T14:15:04.634Z'
     gotchas-documenter:
       path: .aiox-core/infrastructure/scripts/gotchas-documenter.js
       layer: L2
       type: script
-      purpose: discovery.description,
+      purpose: Entity at .aiox-core/infrastructure/scripts/gotchas-documenter.js
       keywords:
         - gotchas
         - documenter
@@ -16741,12 +16837,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ef42171b57775622977a9221db8a7d994a33f3acaa0a72c2908d13943d45d796
-      lastVerified: '2026-05-17T10:02:45.377Z'
+      lastVerified: '2026-05-17T14:15:04.635Z'
     improvement-engine:
       path: .aiox-core/infrastructure/scripts/improvement-engine.js
       layer: L2
       type: script
-      purpose: '`Framework has ${components.length} components. Consider organizing into logical categories.`,'
+      purpose: Entity at .aiox-core/infrastructure/scripts/improvement-engine.js
       keywords:
         - improvement
         - engine
@@ -16761,12 +16857,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4fed61115f4148eb6b8c42ebd9d5b05732695ab1b4343e2466383baf4883d58d
-      lastVerified: '2026-05-17T10:02:45.377Z'
+      lastVerified: '2026-05-17T14:15:04.635Z'
     improvement-validator:
       path: .aiox-core/infrastructure/scripts/improvement-validator.js
       layer: L2
       type: script
-      purpose: mod.description,
+      purpose: Entity at .aiox-core/infrastructure/scripts/improvement-validator.js
       keywords:
         - improvement
         - validator
@@ -16783,7 +16879,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b63362e7ac1c4dbf17655be6609cab666f9f1970821da79609890f76a906c02b
-      lastVerified: '2026-05-17T10:02:45.377Z'
+      lastVerified: '2026-05-17T14:15:04.635Z'
     migrate-agent:
       path: .aiox-core/infrastructure/scripts/migrate-agent.js
       layer: L2
@@ -16792,7 +16888,8 @@ entities:
       keywords:
         - migrate
         - agent
-      usedBy: []
+      usedBy:
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -16802,12 +16899,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0b7330c4a7dccfe028aea2d99e4d3c2f3acface55b79c32bd51ab3bc00e33a86
-      lastVerified: '2026-05-17T10:02:45.378Z'
+      lastVerified: '2026-05-17T14:15:04.636Z'
     modification-risk-assessment:
       path: .aiox-core/infrastructure/scripts/modification-risk-assessment.js
       layer: L2
       type: script
-      purpose: '''Risk from component dependencies and dependents'','
+      purpose: Entity at .aiox-core/infrastructure/scripts/modification-risk-assessment.js
       keywords:
         - modification
         - risk
@@ -16823,7 +16920,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:974dfb83d3bfbb56f4a02385d8edb735c0acab62acb8a1a4e7c69f5ecf10c810
-      lastVerified: '2026-05-17T10:02:45.378Z'
+      lastVerified: '2026-05-17T14:15:04.636Z'
     modification-validator:
       path: .aiox-core/infrastructure/scripts/modification-validator.js
       layer: L2
@@ -16847,7 +16944,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0853fbe9e628510a0e6f8b95ac3c467d49df5cd7b15637f374928c1d3f9e2b87
-      lastVerified: '2026-05-17T10:02:45.379Z'
+      lastVerified: '2026-05-17T14:15:04.637Z'
     output-formatter:
       path: .aiox-core/infrastructure/scripts/output-formatter.js
       layer: L2
@@ -16869,7 +16966,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6f28092d0dabf3b0b486ef06a1836d47c3247a3c331ed6cfbcd597d45496ddb6
-      lastVerified: '2026-05-17T10:02:45.379Z'
+      lastVerified: '2026-05-17T14:15:04.637Z'
     path-analyzer:
       path: .aiox-core/infrastructure/scripts/path-analyzer.js
       layer: L2
@@ -16878,7 +16975,8 @@ entities:
       keywords:
         - path
         - analyzer
-      usedBy: []
+      usedBy:
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -16888,12 +16986,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:47250c416f8090278b4a81de7be4a3f2592f4a20b6afc9c9e30c9cafd292e166
-      lastVerified: '2026-05-17T10:02:45.379Z'
+      lastVerified: '2026-05-17T14:15:04.637Z'
     pattern-extractor:
       path: .aiox-core/infrastructure/scripts/pattern-extractor.js
       layer: L2
       type: script
-      purpose: '''State management with persistence across browser sessions using Zustand and persist middleware.'','
+      purpose: Entity at .aiox-core/infrastructure/scripts/pattern-extractor.js
       keywords:
         - pattern
         - extractor
@@ -16909,7 +17007,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9edc6aabdb32431466c5c8db9da883bc0a5f4457cfc74ccc6c10ed687f8e1e52
-      lastVerified: '2026-05-17T10:02:45.380Z'
+      lastVerified: '2026-05-17T14:15:04.638Z'
     performance-analyzer:
       path: .aiox-core/infrastructure/scripts/performance-analyzer.js
       layer: L2
@@ -16929,12 +17027,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6d925acfbaf3cedae2b17ec262f8436c2d38d7eacd4513acfa0a6b3ebb600337
-      lastVerified: '2026-05-17T10:02:45.380Z'
+      lastVerified: '2026-05-17T14:15:04.638Z'
     performance-and-error-resolver:
       path: .aiox-core/infrastructure/scripts/performance-and-error-resolver.js
       layer: L2
       type: script
-      purpose: Resolve performance metrics and error handling strategy TODOs
+      purpose: Entity at .aiox-core/infrastructure/scripts/performance-and-error-resolver.js
       keywords:
         - performance
         - and
@@ -16950,12 +17048,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de4246a4f01f6da08c8de8a3595505ad8837524db39458f4e6c163cb671b6097
-      lastVerified: '2026-05-17T10:02:45.381Z'
+      lastVerified: '2026-05-17T14:15:04.638Z'
     performance-optimizer:
       path: .aiox-core/infrastructure/scripts/performance-optimizer.js
       layer: L2
       type: script
-      purpose: '''Optimize algorithms with high time complexity'','
+      purpose: Entity at .aiox-core/infrastructure/scripts/performance-optimizer.js
       keywords:
         - performance
         - optimizer
@@ -16970,7 +17068,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:80be8b0599b24f3f21f27ac5e53a4f3ecbb69c7b928ba101c6d1912fb19f7156
-      lastVerified: '2026-05-17T10:02:45.381Z'
+      lastVerified: '2026-05-17T14:15:04.639Z'
     performance-tracker:
       path: .aiox-core/infrastructure/scripts/performance-tracker.js
       layer: L2
@@ -16990,12 +17088,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3c98129cc1597bb637634f566f3440a47c31820e66580a65ebebca5d5771ee6f
-      lastVerified: '2026-05-17T10:02:45.382Z'
+      lastVerified: '2026-05-17T14:15:04.639Z'
     plan-tracker:
       path: .aiox-core/infrastructure/scripts/plan-tracker.js
       layer: L2
       type: script
-      purpose: subtask.description,
+      purpose: Entity at .aiox-core/infrastructure/scripts/plan-tracker.js
       keywords:
         - plan
         - tracker
@@ -17012,7 +17110,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:12bdcdb1b05e1d36686c7ae3cd4c080e592fe41b0807d64ee08ed089d4e257da
-      lastVerified: '2026-05-17T10:02:45.382Z'
+      lastVerified: '2026-05-17T14:15:04.640Z'
     pm-adapter-factory:
       path: .aiox-core/infrastructure/scripts/pm-adapter-factory.js
       layer: L2
@@ -17039,12 +17137,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:72ceafb9cf559d619951f95d62a7fd645c95258eca27248985fbb2afb20aa257
-      lastVerified: '2026-05-17T10:02:45.383Z'
+      lastVerified: '2026-05-17T14:15:04.640Z'
     pm-adapter:
       path: .aiox-core/infrastructure/scripts/pm-adapter.js
       layer: L2
       type: script
-      purpose: '''Remove hard-coded ClickUp dependency'''
+      purpose: Entity at .aiox-core/infrastructure/scripts/pm-adapter.js
       keywords:
         - pm
         - adapter
@@ -17058,12 +17156,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d8383516f70e1641be210dd4b033541fb6bfafd39fd5976361b8e322cdcb1058
-      lastVerified: '2026-05-17T10:02:45.383Z'
+      lastVerified: '2026-05-17T14:15:04.640Z'
     pr-review-ai:
       path: .aiox-core/infrastructure/scripts/pr-review-ai.js
       layer: L2
       type: script
-      purpose: '''AI review failed'','
+      purpose: Entity at .aiox-core/infrastructure/scripts/pr-review-ai.js
       keywords:
         - pr
         - review
@@ -17078,7 +17176,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8872f4ddc23184ea3305cae682741a6a02c1efc170afaa20793c3a9951b374fc
-      lastVerified: '2026-05-17T10:02:45.383Z'
+      lastVerified: '2026-05-17T14:15:04.641Z'
     project-status-loader:
       path: .aiox-core/infrastructure/scripts/project-status-loader.js
       layer: L2
@@ -17102,7 +17200,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:33d753efad0658a702b08f9422406423a9aceac4c88479622fc660c8e0c8eccb
-      lastVerified: '2026-05-17T10:02:45.384Z'
+      lastVerified: '2026-05-17T14:15:04.641Z'
     qa-loop-orchestrator:
       path: .aiox-core/infrastructure/scripts/qa-loop-orchestrator.js
       layer: L2
@@ -17123,12 +17221,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cadd573d7667f6aecd77940ec48c9c8af5e09685877002625faa14a68f5568c2
-      lastVerified: '2026-05-17T10:02:45.385Z'
+      lastVerified: '2026-05-17T14:15:04.642Z'
     qa-report-generator:
       path: .aiox-core/infrastructure/scripts/qa-report-generator.js
       layer: L2
       type: script
-      purpose: issue.description || '',
+      purpose: Entity at .aiox-core/infrastructure/scripts/qa-report-generator.js
       keywords:
         - qa
         - report
@@ -17143,12 +17241,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:23756fafc80bc0b6a6926a7436cf6653df02be1d28a68cf6628f203f778ce201
-      lastVerified: '2026-05-17T10:02:45.385Z'
+      lastVerified: '2026-05-17T14:15:04.643Z'
     recovery-tracker:
       path: .aiox-core/infrastructure/scripts/recovery-tracker.js
       layer: L2
       type: script
-      purpose: ${this.storyId}`));
+      purpose: Entity at .aiox-core/infrastructure/scripts/recovery-tracker.js
       keywords:
         - recovery
         - tracker
@@ -17166,12 +17264,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:09eb60cdd5b6a42a93b5f7450448899bf83e704ecec7d56ea27b560f063e2d1a
-      lastVerified: '2026-05-17T10:02:45.386Z'
+      lastVerified: '2026-05-17T14:15:04.643Z'
     refactoring-suggester:
       path: .aiox-core/infrastructure/scripts/refactoring-suggester.js
       layer: L2
       type: script
-      purpose: '''Extract long methods into smaller, focused methods'','
+      purpose: Entity at .aiox-core/infrastructure/scripts/refactoring-suggester.js
       keywords:
         - refactoring
         - suggester
@@ -17186,7 +17284,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:118d4cdbc64cf3238065f2fb98958305ae81e1384bc68f5a6c7b768f1232cd1e
-      lastVerified: '2026-05-17T10:02:45.386Z'
+      lastVerified: '2026-05-17T14:15:04.644Z'
     repair-agent-references:
       path: .aiox-core/infrastructure/scripts/repair-agent-references.js
       layer: L2
@@ -17209,7 +17307,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:63b5f580b783d5098c3ab3d8da11af9871306b3a1fc0f986f25c813eb4c4dd75
-      lastVerified: '2026-05-17T10:02:45.387Z'
+      lastVerified: '2026-05-17T14:15:04.644Z'
     repository-detector:
       path: .aiox-core/infrastructure/scripts/repository-detector.js
       layer: L2
@@ -17231,7 +17329,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:10ffca7f57d24d3729c71a9104a154500a3c72328d67884e26e38d22199af332
-      lastVerified: '2026-05-17T10:02:45.387Z'
+      lastVerified: '2026-05-17T14:15:04.644Z'
     rollback-manager:
       path: .aiox-core/infrastructure/scripts/rollback-manager.js
       layer: L2
@@ -17253,7 +17351,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fe14a4c0b55f35c30f76daf12712fb97308171683bf81d2566e0d01838d57a6e
-      lastVerified: '2026-05-17T10:02:45.387Z'
+      lastVerified: '2026-05-17T14:15:04.644Z'
     sandbox-tester:
       path: .aiox-core/infrastructure/scripts/sandbox-tester.js
       layer: L2
@@ -17273,12 +17371,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:019af2e23de70d7dacb49faf031ba0c1f5553ecebe52f361bab74bfca73ba609
-      lastVerified: '2026-05-17T10:02:45.388Z'
+      lastVerified: '2026-05-17T14:15:04.645Z'
     security-checker:
       path: .aiox-core/infrastructure/scripts/security-checker.js
       layer: L2
       type: script
-      purpose: '{'
+      purpose: Entity at .aiox-core/infrastructure/scripts/security-checker.js
       keywords:
         - security
         - checker
@@ -17297,12 +17395,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d14d9376e3044e61eba40c03931a05dc518f7b8a10618d4f8c9c8a4b300e71fc
-      lastVerified: '2026-05-17T10:02:45.388Z'
+      lastVerified: '2026-05-17T14:15:04.645Z'
     spot-check-validator:
       path: .aiox-core/infrastructure/scripts/spot-check-validator.js
       layer: L2
       type: script
-      purpose: Validate 20 random tasks for Phase 1 completion accuracy
+      purpose: Entity at .aiox-core/infrastructure/scripts/spot-check-validator.js
       keywords:
         - spot
         - check
@@ -17317,7 +17415,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4bf2d20ded322312aef98291d2a23913da565e1622bc97366c476793c6792c81
-      lastVerified: '2026-05-17T10:02:45.388Z'
+      lastVerified: '2026-05-17T14:15:04.645Z'
     status-mapper:
       path: .aiox-core/infrastructure/scripts/status-mapper.js
       layer: L2
@@ -17337,7 +17435,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6ce6d7324350997b3e1b112aabfbbd0612ebde753ca9ed03e494869b3bb57b1f
-      lastVerified: '2026-05-17T10:02:45.388Z'
+      lastVerified: '2026-05-17T14:15:04.645Z'
     story-worktree-hooks:
       path: .aiox-core/infrastructure/scripts/story-worktree-hooks.js
       layer: L2
@@ -17358,12 +17456,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3e719f61633200d116260931d93925197c7d2d5d857492f87974c6aae160e1a4
-      lastVerified: '2026-05-17T10:02:45.389Z'
+      lastVerified: '2026-05-17T14:15:04.646Z'
     stuck-detector:
       path: .aiox-core/infrastructure/scripts/stuck-detector.js
       layer: L2
       type: script
-      purpose: '{'
+      purpose: Entity at .aiox-core/infrastructure/scripts/stuck-detector.js
       keywords:
         - stuck
         - detector
@@ -17381,7 +17479,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d1afb4d6d17c06075d43e2327d4f84fce1a4e57a46374b0250a3028c211b1c66
-      lastVerified: '2026-05-17T10:02:45.389Z'
+      lastVerified: '2026-05-17T14:15:04.646Z'
     subtask-verifier:
       path: .aiox-core/infrastructure/scripts/subtask-verifier.js
       layer: L2
@@ -17401,7 +17499,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ceb0450fa12fa48f0255bb4565858eb1a97b28c30b98d36cb61d52d72e08b054
-      lastVerified: '2026-05-17T10:02:45.389Z'
+      lastVerified: '2026-05-17T14:15:04.646Z'
     template-engine:
       path: .aiox-core/infrastructure/scripts/template-engine.js
       layer: L2
@@ -17422,7 +17520,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec62a12ff9ad140d32fcbdfc9b5eef636101b75f0835469f1193fee8db0a7d55
-      lastVerified: '2026-05-17T10:02:45.390Z'
+      lastVerified: '2026-05-17T14:15:04.646Z'
     template-validator:
       path: .aiox-core/infrastructure/scripts/template-validator.js
       layer: L2
@@ -17443,12 +17541,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de989116d2f895b58e10355b8853e7b96af6fde151d2612616f18842b9cc56c4
-      lastVerified: '2026-05-17T10:02:45.390Z'
+      lastVerified: '2026-05-17T14:15:04.647Z'
     test-discovery:
       path: .aiox-core/infrastructure/scripts/test-discovery.js
       layer: L2
       type: script
-      purpose: this.parseOutput(stdout + stderr),
+      purpose: Entity at .aiox-core/infrastructure/scripts/test-discovery.js
       keywords:
         - test
         - discovery
@@ -17462,7 +17560,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:04038aa49ae515697084fcdacaf0ef8bc36029fc114f5a1206065d7928870449
-      lastVerified: '2026-05-17T10:02:45.390Z'
+      lastVerified: '2026-05-17T14:15:04.647Z'
     test-generator:
       path: .aiox-core/infrastructure/scripts/test-generator.js
       layer: L2
@@ -17482,7 +17580,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f3146896fbcbc99563cc015b828f097167642e24c919c7c9bf6bbfee9ea87cc1
-      lastVerified: '2026-05-17T10:02:45.391Z'
+      lastVerified: '2026-05-17T14:15:04.647Z'
     test-quality-assessment:
       path: .aiox-core/infrastructure/scripts/test-quality-assessment.js
       layer: L2
@@ -17503,7 +17601,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:08c49331641c0fb1873e37fd14a41d88cec7b40f4b16267ae26b4cadc4d292b6
-      lastVerified: '2026-05-17T10:02:45.391Z'
+      lastVerified: '2026-05-17T14:15:04.648Z'
     test-utilities-fast:
       path: .aiox-core/infrastructure/scripts/test-utilities-fast.js
       layer: L2
@@ -17523,7 +17621,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:70d87a74dac153c65d622afa4d62816e41d8d81eee6d42e1c0e498999bec7c40
-      lastVerified: '2026-05-17T10:02:45.392Z'
+      lastVerified: '2026-05-17T14:15:04.648Z'
     test-utilities:
       path: .aiox-core/infrastructure/scripts/test-utilities.js
       layer: L2
@@ -17542,7 +17640,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2df35a1706b1389809226fde3c4e0bc72e4d5cebacab3cb98beaa70768049061
-      lastVerified: '2026-05-17T10:02:45.392Z'
+      lastVerified: '2026-05-17T14:15:04.649Z'
     tool-resolver:
       path: .aiox-core/infrastructure/scripts/tool-resolver.js
       layer: L2
@@ -17564,12 +17662,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2fa44e4a940d4c33570fd9b4495b5c39792c52ca91b98c4be2fb55cb974ad095
-      lastVerified: '2026-05-17T10:02:45.392Z'
+      lastVerified: '2026-05-17T14:15:04.649Z'
     transaction-manager:
       path: .aiox-core/infrastructure/scripts/transaction-manager.js
       layer: L2
       type: script
-      purpose: options.description || 'Component operation',
+      purpose: Entity at .aiox-core/infrastructure/scripts/transaction-manager.js
       keywords:
         - transaction
         - manager
@@ -17587,7 +17685,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bed375a4d72928ecfa670626c3e504194c4bf4439eab399fc5b31c919e873e86
-      lastVerified: '2026-05-17T10:02:45.392Z'
+      lastVerified: '2026-05-17T14:15:04.649Z'
     usage-analytics:
       path: .aiox-core/infrastructure/scripts/usage-analytics.js
       layer: L2
@@ -17607,12 +17705,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5328370f603d7601e7e69b2c19646fad8557394068955fc029b9bc4f70d66bfe
-      lastVerified: '2026-05-17T10:02:45.393Z'
+      lastVerified: '2026-05-17T14:15:04.649Z'
     validate-agents:
       path: .aiox-core/infrastructure/scripts/validate-agents.js
       layer: L2
       type: script
-      purpose: '''...'' } - explicit format (preferred)'
+      purpose: Entity at .aiox-core/infrastructure/scripts/validate-agents.js
       keywords:
         - validate
         - agents
@@ -17627,7 +17725,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5f5f89a1fcf02ba340772ed30ade56fc346114d7a4d43e6d69af40858c64b180
-      lastVerified: '2026-05-17T10:02:45.393Z'
+      lastVerified: '2026-05-17T14:15:04.650Z'
     validate-claude-integration:
       path: .aiox-core/infrastructure/scripts/validate-claude-integration.js
       layer: L2
@@ -17648,7 +17746,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0174d5e5e38eb8aa5aaa0a44d87f0f8dda623a24f318855c1e50e9d04f7596d6
-      lastVerified: '2026-05-17T10:02:45.393Z'
+      lastVerified: '2026-05-17T14:15:04.650Z'
     validate-codex-integration:
       path: .aiox-core/infrastructure/scripts/validate-codex-integration.js
       layer: L2
@@ -17669,7 +17767,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0f45a49898528d708ef17871bf6abae4f60483ef8520ce30a9bd4f5e507c585f
-      lastVerified: '2026-05-17T10:02:45.393Z'
+      lastVerified: '2026-05-17T14:15:04.650Z'
     validate-gemini-integration:
       path: .aiox-core/infrastructure/scripts/validate-gemini-integration.js
       layer: L2
@@ -17690,7 +17788,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:57a31b8a4b8c129189afaad961ed0261a205c02b55028d61146a9e599c112883
-      lastVerified: '2026-05-17T10:02:45.394Z'
+      lastVerified: '2026-05-17T14:15:04.650Z'
     validate-output-pattern:
       path: .aiox-core/infrastructure/scripts/validate-output-pattern.js
       layer: L2
@@ -17710,7 +17808,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:91111d656e8d7b38a20a1bda753e663b74318f75cdab2025c7e0b84c775fc83d
-      lastVerified: '2026-05-17T10:02:45.394Z'
+      lastVerified: '2026-05-17T14:15:04.650Z'
     validate-parity:
       path: .aiox-core/infrastructure/scripts/validate-parity.js
       layer: L2
@@ -17734,7 +17832,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7f651b869bd501e97d6dccb51dab434818492bc5b02f5eaea00db808cd17cd4c
-      lastVerified: '2026-05-17T10:02:45.394Z'
+      lastVerified: '2026-05-17T14:15:04.651Z'
     validate-paths:
       path: .aiox-core/infrastructure/scripts/validate-paths.js
       layer: L2
@@ -17754,7 +17852,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fb37d099b52eda54e47dec07259687bec6049941cad37281f1de9c3f4095bfd9
-      lastVerified: '2026-05-17T10:02:45.394Z'
+      lastVerified: '2026-05-17T14:15:04.651Z'
     validate-user-profile:
       path: .aiox-core/infrastructure/scripts/validate-user-profile.js
       layer: L2
@@ -17775,12 +17873,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a67e6385bb77d6359e91d87882c0641b1444a1f7acd1086203f20953a4f16a37
-      lastVerified: '2026-05-17T10:02:45.395Z'
+      lastVerified: '2026-05-17T14:15:04.651Z'
     visual-impact-generator:
       path: .aiox-core/infrastructure/scripts/visual-impact-generator.js
       layer: L2
       type: script
-      purpose: data.description,
+      purpose: Entity at .aiox-core/infrastructure/scripts/visual-impact-generator.js
       keywords:
         - visual
         - impact
@@ -17796,7 +17894,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7771eb4d93b1d371149c15adf83db205c7bf600be6d098fc4364af2886776686
-      lastVerified: '2026-05-17T10:02:45.395Z'
+      lastVerified: '2026-05-17T14:15:04.651Z'
     worktree-manager:
       path: .aiox-core/infrastructure/scripts/worktree-manager.js
       layer: L2
@@ -17824,7 +17922,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:76ac6c2638b5ddf9d8a359ac9db887b926ca0993d77220f6511c58255f0cfbd3
-      lastVerified: '2026-05-17T10:02:45.396Z'
+      lastVerified: '2026-05-17T14:15:04.652Z'
     yaml-validator:
       path: .aiox-core/infrastructure/scripts/yaml-validator.js
       layer: L2
@@ -17847,12 +17945,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2039ecb9a9d3f639c734c65704018efd2c4656c4995f0b0e537670f7417bf23b
-      lastVerified: '2026-05-17T10:02:45.396Z'
+      lastVerified: '2026-05-17T14:15:04.652Z'
     bootstrap:
       path: .aiox-core/infrastructure/scripts/codex-skills-sync/bootstrap.js
       layer: L2
       type: script
-      purpose: '* - Generate `.codex/skills/aiox-*` for each core AIOX agent in'
+      purpose: ${title} Activator
       keywords:
         - bootstrap
         - ${title}
@@ -17867,12 +17965,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:56f4518586591d809cda89183e1af3b05c4e4c7369df992e7fdd7214ea5c6072
-      lastVerified: '2026-05-17T10:02:45.397Z'
+      lastVerified: '2026-05-17T14:15:04.653Z'
     index:
       path: .aiox-core/infrastructure/scripts/codex-skills-sync/index.js
       layer: L2
       type: script
-      purpose: Sync local Codex skills for core AIOX agents.
+      purpose: AIOX ${title} Activator
       keywords:
         - index
         - aiox
@@ -17897,7 +17995,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2dc8637ba0095921e3cb5e99791dc05da61a12e375407b05f199696bcce7ea61
-      lastVerified: '2026-05-17T10:02:45.397Z'
+      lastVerified: '2026-05-17T14:15:04.653Z'
     validate:
       path: .aiox-core/infrastructure/scripts/codex-skills-sync/validate.js
       layer: L2
@@ -17919,12 +18017,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c8f98f49e433fc3aa648034457d5273a2ca667b8c7e492157a89ed6d0582c96
-      lastVerified: '2026-05-17T10:02:45.397Z'
+      lastVerified: '2026-05-17T14:15:04.653Z'
     brownfield-analyzer:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/brownfield-analyzer.js
       layer: L2
       type: script
-      purpose: ''''','
+      purpose: Entity at .aiox-core/infrastructure/scripts/documentation-integrity/brownfield-analyzer.js
       keywords:
         - brownfield
         - analyzer
@@ -17940,12 +18038,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a5d1a200767592554778f12cfd3594b89dd11d25e1668e81876c34753753df04
-      lastVerified: '2026-05-17T10:02:45.398Z'
+      lastVerified: '2026-05-17T14:15:04.654Z'
     config-generator:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/config-generator.js
       layer: L2
       type: script
-      purpose: analysisResults.summary || 'No analysis performed',
+      purpose: Entity at .aiox-core/infrastructure/scripts/documentation-integrity/config-generator.js
       keywords:
         - config
         - generator
@@ -17961,7 +18059,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bed3eb82140bf4ed547ec1f5c8992cbcd3ce8587a8814f7bef0962c7788965ee
-      lastVerified: '2026-05-17T10:02:45.398Z'
+      lastVerified: '2026-05-17T14:15:04.654Z'
     deployment-config-loader:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/deployment-config-loader.js
       layer: L2
@@ -17983,7 +18081,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c58e84348a50a7587de3068fe7dcf69a22478cd4e96a5c44d9b9f7f814c64925
-      lastVerified: '2026-05-17T10:02:45.398Z'
+      lastVerified: '2026-05-17T14:15:04.654Z'
     doc-generator:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/doc-generator.js
       layer: L2
@@ -18004,7 +18102,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6e58a80fc61b5af4780e98ac5c0c7070b1ed6281a776303d7550ad717b933afb
-      lastVerified: '2026-05-17T10:02:45.398Z'
+      lastVerified: '2026-05-17T14:15:04.654Z'
     gitignore-generator:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/gitignore-generator.js
       layer: L2
@@ -18026,7 +18124,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fc79c0c5311f3043a07a9e08480a70c8a1328ac6e00679a5141de8226c5dd4ca
-      lastVerified: '2026-05-17T10:02:45.399Z'
+      lastVerified: '2026-05-17T14:15:04.655Z'
     documentation-integrity-index:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/index.js
       layer: L2
@@ -18050,12 +18148,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8e51de74ca904fccc4650df494e6a202766b57cba1883d3a1b5ef90d2831d7f7
-      lastVerified: '2026-05-17T10:02:45.399Z'
+      lastVerified: '2026-05-17T14:15:04.655Z'
     mode-detector:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/mode-detector.js
       layer: L2
       type: script
-      purpose: '''For AIOX contributors working on the framework'','
+      purpose: Entity at .aiox-core/infrastructure/scripts/documentation-integrity/mode-detector.js
       keywords:
         - mode
         - detector
@@ -18072,7 +18170,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:955af283f28d088d844b6e3f388b48caf265d746ff499599973196cb07612730
-      lastVerified: '2026-05-17T10:02:45.399Z'
+      lastVerified: '2026-05-17T14:15:04.655Z'
     post-commit:
       path: .aiox-core/infrastructure/scripts/git-hooks/post-commit.js
       layer: L2
@@ -18091,12 +18189,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a7eea0e43a254804a09fc09a94c9c44d8da0b285ce5dc2ea6149d426732fd917
-      lastVerified: '2026-05-17T10:02:45.400Z'
+      lastVerified: '2026-05-17T14:15:04.655Z'
     agent-parser:
       path: .aiox-core/infrastructure/scripts/ide-sync/agent-parser.js
       layer: L2
       type: script
-      purpose: value"
+      purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/agent-parser.js
       keywords:
         - agent
         - parser
@@ -18117,12 +18215,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f1ed4d0e6dda1a616efb0cb31157fe36063cf9481c19ee7b4bada26cb12e0e80
-      lastVerified: '2026-05-17T10:02:45.400Z'
+      lastVerified: '2026-05-17T14:15:04.655Z'
     gemini-commands:
       path: .aiox-core/infrastructure/scripts/ide-sync/gemini-commands.js
       layer: L2
       type: script
-      purpose: buildAgentDescription(agent),
+      purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/gemini-commands.js
       keywords:
         - gemini
         - commands
@@ -18137,7 +18235,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ba02b21af0d485b14d6e248b6d5644090646dc792f78eac515d17b88680d8549
-      lastVerified: '2026-05-17T10:02:45.400Z'
+      lastVerified: '2026-05-17T14:15:04.656Z'
     ide-sync-index:
       path: .aiox-core/infrastructure/scripts/ide-sync/index.js
       layer: L2
@@ -18163,12 +18261,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2ea2fe3a070010da33be2fed3d75c305d3414cf515c1bf5fbafb334e0a7da5fa
-      lastVerified: '2026-05-17T10:02:45.401Z'
+      lastVerified: '2026-05-17T14:15:04.656Z'
     redirect-generator:
       path: .aiox-core/infrastructure/scripts/ide-sync/redirect-generator.js
       layer: L2
       type: script
-      purpose: '''AIOX redirect from @${safeOldId} to @${safeNewId}'''
+      purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/redirect-generator.js
       keywords:
         - redirect
         - generator
@@ -18185,12 +18283,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5bebf478e331716b4fb42d624076eb2570c90c4aa829427c700995d6b9ec361e
-      lastVerified: '2026-05-17T10:02:45.401Z'
+      lastVerified: '2026-05-17T14:15:04.657Z'
     validator:
       path: .aiox-core/infrastructure/scripts/ide-sync/validator.js
       layer: L2
       type: script
-      purpose: '{'
+      purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/validator.js
       keywords:
         - validator
       usedBy:
@@ -18205,7 +18303,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:768eba65a0f8ff937c34f6f43fe1b4dc990f2d406e592bc1cda0f8ab5b4f7e0b
-      lastVerified: '2026-05-17T10:02:45.401Z'
+      lastVerified: '2026-05-17T14:15:04.657Z'
     install-llm-routing:
       path: .aiox-core/infrastructure/scripts/llm-routing/install-llm-routing.js
       layer: L2
@@ -18226,7 +18324,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c9faab7f6149a8046abe5c9a026055c5f386cfef700136b76e5fa579e60bed8
-      lastVerified: '2026-05-17T10:02:45.401Z'
+      lastVerified: '2026-05-17T14:15:04.657Z'
     antigravity:
       path: .aiox-core/infrastructure/scripts/ide-sync/transformers/antigravity.js
       layer: L2
@@ -18246,12 +18344,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e00910c008c8547a1943f79c676d0a4c0d014b638fc15c8a68e2574d6949744b
-      lastVerified: '2026-05-17T10:02:45.402Z'
+      lastVerified: '2026-05-17T14:15:04.657Z'
     claude-code:
       path: .aiox-core/infrastructure/scripts/ide-sync/transformers/claude-code.js
       layer: L2
       type: script
-      purpose: ${quoteYamlString(description)}
+      purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/transformers/claude-code.js
       keywords:
         - claude
         - code
@@ -18267,12 +18365,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:364ef939d1392397d13942dfc2360a3a75ff8edd77cd0ba88fc29622d5f75fd5
-      lastVerified: '2026-05-17T10:02:45.402Z'
+      lastVerified: '2026-05-17T14:15:04.657Z'
     cursor:
       path: .aiox-core/infrastructure/scripts/ide-sync/transformers/cursor.js
       layer: L2
       type: script
-      purpose: '''${description}'''
+      purpose: ${name} (@${agentData.id})
       keywords:
         - cursor
         - ${name}
@@ -18290,12 +18388,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a38f664747ea71472585d4f8c3e52b844dc75a39a526f5873e6bf97370a4723
-      lastVerified: '2026-05-17T10:02:45.402Z'
+      lastVerified: '2026-05-17T14:15:04.658Z'
     github-copilot:
       path: .aiox-core/infrastructure/scripts/ide-sync/transformers/github-copilot.js
       layer: L2
       type: script
-      purpose: '''${description}''`,'
+      purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/transformers/github-copilot.js
       keywords:
         - github
         - copilot
@@ -18311,12 +18409,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6d365be4a55e2f5ced316a0efbfa50fb925562f3e145d47a86c57a2c685343ac
-      lastVerified: '2026-05-17T10:02:45.402Z'
+      lastVerified: '2026-05-17T14:15:04.658Z'
     kimi:
       path: .aiox-core/infrastructure/scripts/ide-sync/transformers/kimi.js
       layer: L2
       type: script
-      purpose: ${JSON.stringify(description)}
+      purpose: '${icon} @${id} — ${name}${archetype !== ''Specialist'' ? ` (${archetype})` : ''''} | ${title}'
       keywords:
         - kimi
         - ${icon}
@@ -18334,7 +18432,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:69a6b34e81ba956242ff38cfce4063d9a0d9e32818a5f36e0246d80e41940def
-      lastVerified: '2026-05-17T10:02:45.403Z'
+      lastVerified: '2026-05-17T14:15:04.658Z'
     llm-routing-usage-tracker-index:
       path: .aiox-core/infrastructure/scripts/llm-routing/usage-tracker/index.js
       layer: L2
@@ -18352,13 +18450,13 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b49216115de498113a754f9c87fe9834f6262abaa6db3b54c87c06fbdc632905
-      lastVerified: '2026-05-17T10:02:45.403Z'
+      lastVerified: '2026-05-17T14:15:04.658Z'
   infra-tools:
     README:
       path: .aiox-core/infrastructure/tools/README.md
       layer: L2
       type: tool
-      purpose: '"What this tool does"'
+      purpose: AIOX Tools - Integrations Directory
       keywords:
         - readme
         - aiox
@@ -18378,14 +18476,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2f8f4141b9f4a71ad51668d28fc9a12362835dd40eb45992c645f9bfe28f8a48
-      lastVerified: '2026-05-17T10:02:45.405Z'
+      lastVerified: '2026-05-17T14:15:04.660Z'
     github-cli:
       path: .aiox-core/infrastructure/tools/cli/github-cli.yaml
       layer: L2
       type: tool
-      purpose: >-
-        Official GitHub command-line interface for repository management, PR operations, issue tracking, and GitHub
-        Actions
+      purpose: Entity at .aiox-core/infrastructure/tools/cli/github-cli.yaml
       keywords:
         - github
         - cli
@@ -18393,6 +18489,7 @@ entities:
         - environment-bootstrap
         - setup-github
         - health-check-checks-services-index
+        - devops
         - po
       dependencies: []
       externalDeps: []
@@ -18403,12 +18500,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:222ca6016e9487d2da13bead0af5cee6099885ea438b359ff5fa5a73c7cd4820
-      lastVerified: '2026-05-17T10:02:45.405Z'
+      lastVerified: '2026-05-17T14:15:04.660Z'
     llm-routing:
       path: .aiox-core/infrastructure/tools/cli/llm-routing.yaml
       layer: L2
       type: tool
-      purpose: '|'
+      purpose: LLM Routing Tool Definition
       keywords:
         - llm
         - routing
@@ -18425,12 +18522,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d97183f254876933de02d9ad2c793ad7d06e37dd0c4f9da9fb68097a5d0eedb3
-      lastVerified: '2026-05-17T10:02:45.405Z'
+      lastVerified: '2026-05-17T14:15:04.660Z'
     railway-cli:
       path: .aiox-core/infrastructure/tools/cli/railway-cli.yaml
       layer: L2
       type: tool
-      purpose: Official Railway command-line interface for deploying and managing cloud applications, databases, and services
+      purpose: Entity at .aiox-core/infrastructure/tools/cli/railway-cli.yaml
       keywords:
         - railway
         - cli
@@ -18446,14 +18543,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cab769df07cfd0a65bfed0e7140dfde3bf3c54cd6940452d2d18e18f99a63e4a
-      lastVerified: '2026-05-17T10:02:45.405Z'
+      lastVerified: '2026-05-17T14:15:04.661Z'
     supabase-cli:
       path: .aiox-core/infrastructure/tools/cli/supabase-cli.yaml
       layer: L2
       type: tool
-      purpose: >-
-        Official Supabase command-line interface for local development, database migrations, Edge Functions, and project
-        management
+      purpose: Entity at .aiox-core/infrastructure/tools/cli/supabase-cli.yaml
       keywords:
         - supabase
         - cli
@@ -18470,12 +18565,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:659fefd3d8b182dd06fc5be560fcf386a028156386b2029cd51bbd7d3b5e6bfd
-      lastVerified: '2026-05-17T10:02:45.406Z'
+      lastVerified: '2026-05-17T14:15:04.661Z'
     ffmpeg:
       path: .aiox-core/infrastructure/tools/local/ffmpeg.yaml
       layer: L2
       type: tool
-      purpose: Complete, cross-platform solution for recording, converting, and streaming audio and video
+      purpose: Entity at .aiox-core/infrastructure/tools/local/ffmpeg.yaml
       keywords:
         - ffmpeg
       usedBy:
@@ -18489,14 +18584,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d481a548e0eb327513412c7ac39e4a92ac27a283f4b9e6c43211fed52281df44
-      lastVerified: '2026-05-17T10:02:45.406Z'
+      lastVerified: '2026-05-17T14:15:04.661Z'
     21st-dev-magic:
       path: .aiox-core/infrastructure/tools/mcp/21st-dev-magic.yaml
       layer: L2
       type: tool
-      purpose: >-
-        AI-powered UI component builder and design system for creating React components, finding UI inspiration, and
-        searching for logos
+      purpose: Entity at .aiox-core/infrastructure/tools/mcp/21st-dev-magic.yaml
       keywords:
         - 21st
         - dev
@@ -18512,12 +18605,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5e1b575bdb51c6b5d446a2255fa068194d2010bce56c8c0dd0b2e98e3cf61f18
-      lastVerified: '2026-05-17T10:02:45.406Z'
+      lastVerified: '2026-05-17T14:15:04.661Z'
     browser:
       path: .aiox-core/infrastructure/tools/mcp/browser.yaml
       layer: L2
       type: tool
-      purpose: Puppeteer-based browser automation for web scraping, testing, and interaction with web applications
+      purpose: Entity at .aiox-core/infrastructure/tools/mcp/browser.yaml
       keywords:
         - browser
       usedBy:
@@ -18533,12 +18626,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c28206d92a6127d299ca60955cd6f6d03c940ac8b221f1e9fc620dd7efd7b471
-      lastVerified: '2026-05-17T10:02:45.406Z'
+      lastVerified: '2026-05-17T14:15:04.661Z'
     clickup:
       path: .aiox-core/infrastructure/tools/mcp/clickup.yaml
       layer: L2
       type: tool
-      purpose: ClickUp project management with pre-execution validation and API complexity handling
+      purpose: Entity at .aiox-core/infrastructure/tools/mcp/clickup.yaml
       keywords:
         - clickup
       usedBy:
@@ -18552,12 +18645,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:aa7c34786e8e332a3486b136f40ec997dcc2a7e408bbc99a8899b0653baac6ee
-      lastVerified: '2026-05-17T10:02:45.407Z'
+      lastVerified: '2026-05-17T14:15:04.662Z'
     context7:
       path: .aiox-core/infrastructure/tools/mcp/context7.yaml
       layer: L2
       type: tool
-      purpose: Retrieve up-to-date documentation and code examples for any software library via Context7 AI
+      purpose: Entity at .aiox-core/infrastructure/tools/mcp/context7.yaml
       keywords:
         - context7
       usedBy:
@@ -18578,12 +18671,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:321e0e23a787c36260efdbb1a3953235fa7dc57e77b211610ffaf33bc21fca02
-      lastVerified: '2026-05-17T10:02:45.407Z'
+      lastVerified: '2026-05-17T14:15:04.662Z'
     desktop-commander:
       path: .aiox-core/infrastructure/tools/mcp/desktop-commander.yaml
       layer: L2
       type: tool
-      purpose: Powerful file system operations, process management, and system command execution
+      purpose: Entity at .aiox-core/infrastructure/tools/mcp/desktop-commander.yaml
       keywords:
         - desktop
         - commander
@@ -18597,14 +18690,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec1a5db7def48d1762e68d4477ad0574bbb54a6783256870f5451c666ebdc213
-      lastVerified: '2026-05-17T10:02:45.407Z'
+      lastVerified: '2026-05-17T14:15:04.662Z'
     exa:
       path: .aiox-core/infrastructure/tools/mcp/exa.yaml
       layer: L2
       type: tool
-      purpose: >-
-        Advanced web search and research using Exa AI - performs real-time web searches, academic paper searches,
-        company research, and content crawling
+      purpose: Entity at .aiox-core/infrastructure/tools/mcp/exa.yaml
       keywords:
         - exa
       usedBy:
@@ -18619,14 +18710,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:02576ff68b8de8a2d4e6aaffaeade78d5c208b95380feeacb37e2105c6f83541
-      lastVerified: '2026-05-17T10:02:45.407Z'
+      lastVerified: '2026-05-17T14:15:04.662Z'
     google-workspace:
       path: .aiox-core/infrastructure/tools/mcp/google-workspace.yaml
       layer: L2
       type: tool
-      purpose: >-
-        Google Workspace integration with multi-service support (Drive, Docs, Sheets, Calendar, Gmail) and OAuth
-        authentication
+      purpose: Entity at .aiox-core/infrastructure/tools/mcp/google-workspace.yaml
       keywords:
         - google
         - workspace
@@ -18641,12 +18730,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f017c3154e9d480f37d94c7ddd7c3d24766b4fa7e0ee9e722600e85da75734b4
-      lastVerified: '2026-05-17T10:02:45.407Z'
+      lastVerified: '2026-05-17T14:15:04.663Z'
     n8n:
       path: .aiox-core/infrastructure/tools/mcp/n8n.yaml
       layer: L2
       type: tool
-      purpose: n8n workflow management with execution validation and credential handling
+      purpose: Entity at .aiox-core/infrastructure/tools/mcp/n8n.yaml
       keywords:
         - n8n
       usedBy:
@@ -18660,14 +18749,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f9d9536ec47f9911e634083c3ac15cb920214ea0f052e78d4c6a27a17e9ec408
-      lastVerified: '2026-05-17T10:02:45.408Z'
+      lastVerified: '2026-05-17T14:15:04.663Z'
     supabase:
       path: .aiox-core/infrastructure/tools/mcp/supabase.yaml
       layer: L2
       type: tool
-      purpose: >-
-        Supabase project and database management with SQL execution, migrations, RLS policies, and real-time
-        subscriptions
+      purpose: Entity at .aiox-core/infrastructure/tools/mcp/supabase.yaml
       keywords:
         - supabase
       usedBy:
@@ -18682,13 +18769,13 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:350bd31537dfef9c3df55bd477434ccbe644cdf0dd3408bf5a8a6d0c5ba78aa2
-      lastVerified: '2026-05-17T10:02:45.408Z'
+      lastVerified: '2026-05-17T14:15:04.664Z'
   product-checklists:
     accessibility-wcag-checklist:
       path: .aiox-core/product/checklists/accessibility-wcag-checklist.md
       layer: L2
       type: checklist
-      purpose: '** Ensure WCAG AA compliance for design system components'
+      purpose: Accessibility WCAG AA Checklist
       keywords:
         - accessibility
         - wcag
@@ -18704,7 +18791,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:56126182b25e9b7bdde43f75315e33167eb49b1f9a9cb0e9a37bc068af40aeab
-      lastVerified: '2026-05-17T10:02:45.409Z'
+      lastVerified: '2026-05-17T14:15:04.664Z'
     architect-checklist:
       path: .aiox-core/product/checklists/architect-checklist.md
       layer: L2
@@ -18727,14 +18814,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ecbcc8e6b34f813bc73ebcc28482c045ef12c6b17808ee6f70a808eee1818911
-      lastVerified: '2026-05-17T10:02:45.410Z'
+      lastVerified: '2026-05-17T14:15:04.665Z'
     change-checklist:
       path: .aiox-core/product/checklists/change-checklist.md
       layer: L2
       type: checklist
-      purpose: >-
-        ** To systematically guide the selected Agent and user through the analysis and planning required when a
-        significant change (pivot, tech issue, missing requirement, failed story) is identified during 
+      purpose: Change Navigation Checklist
       keywords:
         - change
         - checklist
@@ -18742,6 +18827,8 @@ entities:
       usedBy:
         - brownfield-create-epic
         - correct-course
+        - modify-agent
+        - modify-task
         - modify-workflow
         - propose-modification
         - qa-review-proposal
@@ -18758,12 +18845,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:edaa126d5db726fce3a422be6441928b1177fe13e5e8defe2d2cb8959acd1439
-      lastVerified: '2026-05-17T10:02:45.410Z'
+      lastVerified: '2026-05-17T14:15:04.665Z'
     component-quality-checklist:
       path: .aiox-core/product/checklists/component-quality-checklist.md
       layer: L2
       type: checklist
-      purpose: '** Validate component before marking complete'
+      purpose: Component Quality Checklist
       keywords:
         - component
         - quality
@@ -18779,7 +18866,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec4e34a3fc4a071d346a8ba473f521d2a38e5eb07d1656fee6ff108e5cd7b62f
-      lastVerified: '2026-05-17T10:02:45.410Z'
+      lastVerified: '2026-05-17T14:15:04.666Z'
     database-design-checklist:
       path: .aiox-core/product/checklists/database-design-checklist.md
       layer: L2
@@ -18800,7 +18887,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6d3cf038f0320db0e6daf9dba61e4c29269ed73c793df5618e155ebd07b6c200
-      lastVerified: '2026-05-17T10:02:45.411Z'
+      lastVerified: '2026-05-17T14:15:04.666Z'
     dba-predeploy-checklist:
       path: .aiox-core/product/checklists/dba-predeploy-checklist.md
       layer: L2
@@ -18822,7 +18909,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:482136936a2414600b59d4d694526c008287e3376ed73c9a93de78d7d7bd3285
-      lastVerified: '2026-05-17T10:02:45.411Z'
+      lastVerified: '2026-05-17T14:15:04.666Z'
     dba-rollback-checklist:
       path: .aiox-core/product/checklists/dba-rollback-checklist.md
       layer: L2
@@ -18843,12 +18930,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:060847cba7ef223591c2c1830c65994fd6cf8135625d6953a3a5b874301129c5
-      lastVerified: '2026-05-17T10:02:45.411Z'
+      lastVerified: '2026-05-17T14:15:04.666Z'
     migration-readiness-checklist:
       path: .aiox-core/product/checklists/migration-readiness-checklist.md
       layer: L2
       type: checklist
-      purpose: '** Validate system ready for production migration'
+      purpose: Migration Readiness Checklist
       keywords:
         - migration
         - readiness
@@ -18864,12 +18951,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6231576966f24b30c00fe7cc836359e10c870c266a30e5d88c6b3349ad2f1d17
-      lastVerified: '2026-05-17T10:02:45.411Z'
+      lastVerified: '2026-05-17T14:15:04.666Z'
     pattern-audit-checklist:
       path: .aiox-core/product/checklists/pattern-audit-checklist.md
       layer: L2
       type: checklist
-      purpose: '** Validate audit results before consolidation'
+      purpose: Pattern Audit Checklist
       keywords:
         - pattern
         - audit
@@ -18885,7 +18972,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2eb28cb0e7abd8900170123c1d080c1bbb81ccb857eeb162c644f40616b0875e
-      lastVerified: '2026-05-17T10:02:45.411Z'
+      lastVerified: '2026-05-17T14:15:04.667Z'
     pm-checklist:
       path: .aiox-core/product/checklists/pm-checklist.md
       layer: L2
@@ -18910,7 +18997,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6828efd3acf32638e31b8081ca0c6f731aa5710c8413327db5a8096b004aeb2b
-      lastVerified: '2026-05-17T10:02:45.412Z'
+      lastVerified: '2026-05-17T14:15:04.667Z'
     po-master-checklist:
       path: .aiox-core/product/checklists/po-master-checklist.md
       layer: L2
@@ -18928,9 +19015,13 @@ entities:
         - brownfield-create-epic
         - brownfield-create-story
         - create-brownfield-story
+        - create-next-story
+        - dev-validate-next-story
         - po-pull-story-from-clickup
         - po-sync-story-to-clickup
         - qa-trace-requirements
+        - sm-create-next-story
+        - validate-next-story
         - aiox-master
         - po
       dependencies: []
@@ -18942,7 +19033,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:506a3032f461c7ae96c338600208575be4f4823d2fe7c92fe304a4ff07cc5390
-      lastVerified: '2026-05-17T10:02:45.412Z'
+      lastVerified: '2026-05-17T14:15:04.667Z'
     pre-push-checklist:
       path: .aiox-core/product/checklists/pre-push-checklist.md
       layer: L2
@@ -18955,7 +19046,8 @@ entities:
         - pre-push
         - quality
         - gate
-      usedBy: []
+      usedBy:
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -18965,7 +19057,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8b96f7216101676b86b314c347fa8c6d616cde21dbc77ef8f77b8d0b5770af2a
-      lastVerified: '2026-05-17T10:02:45.413Z'
+      lastVerified: '2026-05-17T14:15:04.667Z'
     release-checklist:
       path: .aiox-core/product/checklists/release-checklist.md
       layer: L2
@@ -18974,7 +19066,9 @@ entities:
       keywords:
         - release
         - checklist
-      usedBy: []
+      usedBy:
+        - publish-npm
+        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -18984,12 +19078,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a5e66e27d115abd544834a70f3dda429bc486fbcb569870031c4f79fd8ac6187
-      lastVerified: '2026-05-17T10:02:45.413Z'
+      lastVerified: '2026-05-17T14:15:04.668Z'
     self-critique-checklist:
       path: .aiox-core/product/checklists/self-critique-checklist.md
       layer: L2
       type: checklist
-      purpose: '** Mandatory self-review checkpoints to catch issues before they propagate'
+      purpose: 'This checklist is executed TWICE during subtask execution:'
       keywords:
         - self
         - critique
@@ -19008,7 +19102,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9f257660bb386ea315fe4ab8b259897058d279e66338801db234c25750be9c2c
-      lastVerified: '2026-05-17T10:02:45.414Z'
+      lastVerified: '2026-05-17T14:15:04.668Z'
     story-dod-checklist:
       path: .aiox-core/product/checklists/story-dod-checklist.md
       layer: L2
@@ -19033,7 +19127,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:725b60a16a41886a92794e54b9efa8359eab5f09813cd584fa9e8e1519c78dc4
-      lastVerified: '2026-05-17T10:02:45.414Z'
+      lastVerified: '2026-05-17T14:15:04.668Z'
     story-draft-checklist:
       path: .aiox-core/product/checklists/story-draft-checklist.md
       layer: L2
@@ -19058,7 +19152,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cf500e2a8a471573d25f3d73439a41fffea9f5351963c598fd2285ec909f96ce
-      lastVerified: '2026-05-17T10:02:45.415Z'
+      lastVerified: '2026-05-17T14:15:04.669Z'
   product-data:
     atomic-design-principles:
       path: .aiox-core/product/data/atomic-design-principles.md
@@ -19079,7 +19173,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:66153135e28394178c4f8f33441c45a2404587c2f07d25ad09dde54f3f5e1746
-      lastVerified: '2026-05-17T10:02:45.416Z'
+      lastVerified: '2026-05-17T14:15:04.669Z'
     brainstorming-techniques:
       path: .aiox-core/product/data/brainstorming-techniques.md
       layer: L2
@@ -19099,12 +19193,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c5a558d21eb620a8c820d8ca9807b2d12c299375764289482838f81ef63dbce
-      lastVerified: '2026-05-17T10:02:45.416Z'
+      lastVerified: '2026-05-17T14:15:04.670Z'
     consolidation-algorithms:
       path: .aiox-core/product/data/consolidation-algorithms.md
       layer: L2
       type: data
-      purpose: '** How Brad reduces 176 patterns to 32'
+      purpose: Pattern Consolidation Algorithms
       keywords:
         - consolidation
         - algorithms
@@ -19119,12 +19213,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2f2561be9e6281f6352f05e1c672954001f919c4664e3fecd6fcde24fdd4d240
-      lastVerified: '2026-05-17T10:02:45.416Z'
+      lastVerified: '2026-05-17T14:15:04.670Z'
     database-best-practices:
       path: .aiox-core/product/data/database-best-practices.md
       layer: L2
       type: data
-      purpose: '** Reference guide for database design and implementation patterns'
+      purpose: Database Best Practices Guide
       keywords:
         - database
         - best
@@ -19140,12 +19234,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8331f001e903283633f0123d123546ef3d4682ed0e0f9516b4df391fe57b9b7d
-      lastVerified: '2026-05-17T10:02:45.417Z'
+      lastVerified: '2026-05-17T14:15:04.670Z'
     design-token-best-practices:
       path: .aiox-core/product/data/design-token-best-practices.md
       layer: L2
       type: data
-      purpose: '** Token naming and organization standards'
+      purpose: Design Token Best Practices
       keywords:
         - design
         - token
@@ -19161,7 +19255,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:10cf3c824bba452ee598e2325b8bfb2068f188d9ac3058b9e034ddf34bf4791a
-      lastVerified: '2026-05-17T10:02:45.417Z'
+      lastVerified: '2026-05-17T14:15:04.670Z'
     elicitation-methods:
       path: .aiox-core/product/data/elicitation-methods.md
       layer: L2
@@ -19181,12 +19275,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f8e46f90bd0acc1e9697086d7a2008c7794bc767e99d0037c64e6800e9d17ef4
-      lastVerified: '2026-05-17T10:02:45.417Z'
+      lastVerified: '2026-05-17T14:15:04.670Z'
     integration-patterns:
       path: .aiox-core/product/data/integration-patterns.md
       layer: L2
       type: data
-      purpose: '** How design system integrates with MMOS, CreatorOS, InnerLens'
+      purpose: Integration Patterns with Squads
       keywords:
         - integration
         - patterns
@@ -19201,12 +19295,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b771f999fb452dcabf835d5f5e5ae3982c48cece5941cc5a276b6f280062db43
-      lastVerified: '2026-05-17T10:02:45.417Z'
+      lastVerified: '2026-05-17T14:15:04.670Z'
     migration-safety-guide:
       path: .aiox-core/product/data/migration-safety-guide.md
       layer: L2
       type: data
-      purpose: '** Reference guide for safe database migrations in production'
+      purpose: Database Migration Safety Guide
       keywords:
         - migration
         - safety
@@ -19222,7 +19316,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:42200ca180d4586447304dfc7f8035ccd09860b6ac34c72b63d284e57c94d2db
-      lastVerified: '2026-05-17T10:02:45.418Z'
+      lastVerified: '2026-05-17T14:15:04.671Z'
     mode-selection-best-practices:
       path: .aiox-core/product/data/mode-selection-best-practices.md
       layer: L2
@@ -19243,12 +19337,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4ed5ee7aaeadb2e3c12029b7cae9a6063f3a7b016fdd0d53f9319d461ddf3ea1
-      lastVerified: '2026-05-17T10:02:45.418Z'
+      lastVerified: '2026-05-17T14:15:04.671Z'
     postgres-tuning-guide:
       path: .aiox-core/product/data/postgres-tuning-guide.md
       layer: L2
       type: data
-      purpose: '** Reference guide for PostgreSQL performance optimization'
+      purpose: PostgreSQL Performance Tuning Guide
       keywords:
         - postgres
         - tuning
@@ -19265,12 +19359,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4715262241ae6ba2da311865506781bd7273fa6ee1bd55e15968dfda542c2bec
-      lastVerified: '2026-05-17T10:02:45.418Z'
+      lastVerified: '2026-05-17T14:15:04.671Z'
     rls-security-patterns:
       path: .aiox-core/product/data/rls-security-patterns.md
       layer: L2
       type: data
-      purpose: '** Reference guide for implementing secure RLS policies'
+      purpose: Row Level Security (RLS) Patterns Guide
       keywords:
         - rls
         - security
@@ -19288,12 +19382,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e3e12a06b483c1bda645e7eb361a230bdef106cc5d1140a69b443a4fc2ad70ef
-      lastVerified: '2026-05-17T10:02:45.418Z'
+      lastVerified: '2026-05-17T14:15:04.671Z'
     roi-calculation-guide:
       path: .aiox-core/product/data/roi-calculation-guide.md
       layer: L2
       type: data
-      purpose: '** How to calculate real cost savings from design system'
+      purpose: ROI Calculation Guide
       keywords:
         - roi
         - calculation
@@ -19308,12 +19402,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f00a3c039297b3cb6e00f68d5feb6534a27c2a0ad02afd14df50e4e0cf285aa4
-      lastVerified: '2026-05-17T10:02:45.419Z'
+      lastVerified: '2026-05-17T14:15:04.671Z'
     supabase-patterns:
       path: .aiox-core/product/data/supabase-patterns.md
       layer: L2
       type: data
-      purpose: '** Reference guide for Supabase implementation patterns'
+      purpose: Supabase Architecture Patterns
       keywords:
         - supabase
         - patterns
@@ -19328,7 +19422,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9ed119bc89f859125a0489036d747ff13b6c475a9db53946fdb7f3be02b41e0a
-      lastVerified: '2026-05-17T10:02:45.419Z'
+      lastVerified: '2026-05-17T14:15:04.671Z'
     test-levels-framework:
       path: .aiox-core/product/data/test-levels-framework.md
       layer: L2
@@ -19348,7 +19442,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b9a50f9c3b5b153280c93ea30f823f30deb2ba7aea588039b5a2bdea0b23891e
-      lastVerified: '2026-05-17T10:02:45.419Z'
+      lastVerified: '2026-05-17T14:15:04.671Z'
     test-priorities-matrix:
       path: .aiox-core/product/data/test-priorities-matrix.md
       layer: L2
@@ -19368,12 +19462,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c97c7279f23ed42ea2588814f204432a93d658d9b5a9914e34647db796a70a60
-      lastVerified: '2026-05-17T10:02:45.419Z'
+      lastVerified: '2026-05-17T14:15:04.672Z'
     wcag-compliance-guide:
       path: .aiox-core/product/data/wcag-compliance-guide.md
       layer: L2
       type: data
-      purpose: '** Ensure design system components meet accessibility standards'
+      purpose: WCAG Compliance Guide
       keywords:
         - wcag
         - compliance
@@ -19388,7 +19482,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8f5a97e1522da2193e2a2eae18dc68c4477acf3e2471b50b46885163cefa40e6
-      lastVerified: '2026-05-17T10:02:45.419Z'
+      lastVerified: '2026-05-17T14:15:04.672Z'
 categories:
   - id: tasks
     description: Executable task workflows for agent operations

--- a/.aiox-core/data/entity-registry.yaml
+++ b/.aiox-core/data/entity-registry.yaml
@@ -1,6 +1,6 @@
 metadata:
   version: 1.0.0
-  lastUpdated: '2026-05-17T14:15:04.693Z'
+  lastUpdated: '2026-05-17T15:04:27.495Z'
   entityCount: 815
   checksumAlgorithm: sha256
   resolutionRate: 100
@@ -28,7 +28,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:badc8a9859cb313e908d4ea0f4c4d7bc1be723214e38f26d55c366689fe5e3f0
-      lastVerified: '2026-05-17T14:15:04.334Z'
+      lastVerified: '2026-05-17T15:04:27.053Z'
     advanced-elicitation:
       path: .aiox-core/development/tasks/advanced-elicitation.md
       layer: L2
@@ -53,7 +53,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:897f36c94fc1e4e40c9e5728f3c7780515b40742d6a99366a5fdb5df109f6636
-      lastVerified: '2026-05-17T14:15:04.336Z'
+      lastVerified: '2026-05-17T15:04:27.055Z'
     analyst-facilitate-brainstorming:
       path: .aiox-core/development/tasks/analyst-facilitate-brainstorming.md
       layer: L2
@@ -80,7 +80,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:85bef3ab05f3e3422ff450e7d39f04f49e59fa981df2f126eeb0f8395e4a1625
-      lastVerified: '2026-05-17T14:15:04.336Z'
+      lastVerified: '2026-05-17T15:04:27.056Z'
     analyze-brownfield:
       path: .aiox-core/development/tasks/analyze-brownfield.md
       layer: L2
@@ -108,7 +108,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0d1c35b32db5ae058ee29c125b1a7ce6d39bfd37d82711aad3abe780ef99cef3
-      lastVerified: '2026-05-17T14:15:04.337Z'
+      lastVerified: '2026-05-17T15:04:27.056Z'
     analyze-cross-artifact:
       path: .aiox-core/development/tasks/analyze-cross-artifact.md
       layer: L2
@@ -134,7 +134,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ce335d997ddd6438c298b18386ab72414959f24e6176736f12ee26ea5764432b
-      lastVerified: '2026-05-17T14:15:04.337Z'
+      lastVerified: '2026-05-17T15:04:27.057Z'
     analyze-framework:
       path: .aiox-core/development/tasks/analyze-framework.md
       layer: L2
@@ -163,7 +163,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6f3bb2f12ad42600cb38d6a1677608772bf8cb63a1e5971c987400ebf3e1d685
-      lastVerified: '2026-05-17T14:15:04.338Z'
+      lastVerified: '2026-05-17T15:04:27.058Z'
     analyze-performance:
       path: .aiox-core/development/tasks/analyze-performance.md
       layer: L2
@@ -187,7 +187,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c3a78a8794d2edfbf44525e1bbe286bb957dcc0fbbee5d9b8a7876a8d0cdce4
-      lastVerified: '2026-05-17T14:15:04.339Z'
+      lastVerified: '2026-05-17T15:04:27.058Z'
     analyze-project-structure:
       path: .aiox-core/development/tasks/analyze-project-structure.md
       layer: L2
@@ -217,7 +217,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0f6acf877e5fa93796418576c239ea300226c4fb6fe28639239da8cc8225a57e
-      lastVerified: '2026-05-17T14:15:04.339Z'
+      lastVerified: '2026-05-17T15:04:27.058Z'
     apply-qa-fixes:
       path: .aiox-core/development/tasks/apply-qa-fixes.md
       layer: L2
@@ -243,7 +243,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:614731439a27c15ecc02d84abf3d320c2cf18f016075c222ca1d7bfda12d6625
-      lastVerified: '2026-05-17T14:15:04.340Z'
+      lastVerified: '2026-05-17T15:04:27.059Z'
     architect-analyze-impact:
       path: .aiox-core/development/tasks/architect-analyze-impact.md
       layer: L2
@@ -274,7 +274,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73ad65e2263dac7a5a3aa64736d2c803c8a532c269b83fb98a61cb5729b689db
-      lastVerified: '2026-05-17T14:15:04.341Z'
+      lastVerified: '2026-05-17T15:04:27.060Z'
     audit-codebase:
       path: .aiox-core/development/tasks/audit-codebase.md
       layer: L2
@@ -299,7 +299,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:11a136d6e7cd6d5238a06a9298eff28d381799667612aa7668d923cc40c74ff7
-      lastVerified: '2026-05-17T14:15:04.341Z'
+      lastVerified: '2026-05-17T15:04:27.060Z'
     audit-tailwind-config:
       path: .aiox-core/development/tasks/audit-tailwind-config.md
       layer: L2
@@ -324,7 +324,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6a555a7b86f2b447b0393b9ac1a7f2be84f5705c293259c83c082b25ec849fbb
-      lastVerified: '2026-05-17T14:15:04.341Z'
+      lastVerified: '2026-05-17T15:04:27.061Z'
     audit-utilities:
       path: .aiox-core/development/tasks/audit-utilities.md
       layer: L2
@@ -349,7 +349,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1a1e4cb6be031f144d223321c6977a88108843b05b933143784ce8340198acd3
-      lastVerified: '2026-05-17T14:15:04.342Z'
+      lastVerified: '2026-05-17T15:04:27.061Z'
     bootstrap-shadcn-library:
       path: .aiox-core/development/tasks/bootstrap-shadcn-library.md
       layer: L2
@@ -375,7 +375,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3fe06f13e2ff550bab6b74cf2105f5902800e568fd7afc982dd3987c5579e769
-      lastVerified: '2026-05-17T14:15:04.342Z'
+      lastVerified: '2026-05-17T15:04:27.063Z'
     brownfield-create-epic:
       path: .aiox-core/development/tasks/brownfield-create-epic.md
       layer: L2
@@ -414,7 +414,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:554a403bdd14fdc0aa6236818d47b273e275f73b39971c3918e74978e28d9b68
-      lastVerified: '2026-05-17T14:15:04.343Z'
+      lastVerified: '2026-05-17T15:04:27.064Z'
     brownfield-create-story:
       path: .aiox-core/development/tasks/brownfield-create-story.md
       layer: L2
@@ -444,7 +444,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:29ba1fe81cda46bdece3e698cc797370c63df56903e38ca71523352b98e08dd2
-      lastVerified: '2026-05-17T14:15:04.343Z'
+      lastVerified: '2026-05-17T15:04:27.064Z'
     build-autonomous:
       path: .aiox-core/development/tasks/build-autonomous.md
       layer: L2
@@ -470,7 +470,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:90ea4c17a6a131082df1546fbe1f30817b951bba7a8b9a41a371578ce8034b39
-      lastVerified: '2026-05-17T14:15:04.343Z'
+      lastVerified: '2026-05-17T15:04:27.065Z'
     build-component:
       path: .aiox-core/development/tasks/build-component.md
       layer: L2
@@ -495,7 +495,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:026adaf174a29692f4eef293a94f5909de9c79d25d7ed226740db1708cde4389
-      lastVerified: '2026-05-17T14:15:04.344Z'
+      lastVerified: '2026-05-17T15:04:27.065Z'
     build-resume:
       path: .aiox-core/development/tasks/build-resume.md
       layer: L2
@@ -518,7 +518,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:920b1faa39d021fd7c0013b5d2ac4f66ac6de844723821b65dfaceba41d37885
-      lastVerified: '2026-05-17T14:15:04.344Z'
+      lastVerified: '2026-05-17T15:04:27.066Z'
     build-status:
       path: .aiox-core/development/tasks/build-status.md
       layer: L2
@@ -540,7 +540,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:47a5f95ab59ff99532adf442700f4b949e32bd5bd2131998d8f271327108e4e1
-      lastVerified: '2026-05-17T14:15:04.344Z'
+      lastVerified: '2026-05-17T15:04:27.066Z'
     build:
       path: .aiox-core/development/tasks/build.md
       layer: L2
@@ -562,7 +562,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2f09d24cc0e5f9e4cf527fcb5341461a7ac30fcadf82e4f78f98be161e0ea4ec
-      lastVerified: '2026-05-17T14:15:04.345Z'
+      lastVerified: '2026-05-17T15:04:27.066Z'
     calculate-roi:
       path: .aiox-core/development/tasks/calculate-roi.md
       layer: L2
@@ -588,7 +588,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa8c2073ee845a42b30eea44e2452898ebb8e5d4fceb207c9b42984f817732cc
-      lastVerified: '2026-05-17T14:15:04.345Z'
+      lastVerified: '2026-05-17T15:04:27.066Z'
     check-docs-links:
       path: .aiox-core/development/tasks/check-docs-links.md
       layer: L2
@@ -610,7 +610,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a7e1400d894777caa607486ff78b77ea454e4ace1c16d54308533ecc7f2c015
-      lastVerified: '2026-05-17T14:15:04.345Z'
+      lastVerified: '2026-05-17T15:04:27.067Z'
     ci-cd-configuration:
       path: .aiox-core/development/tasks/ci-cd-configuration.md
       layer: L2
@@ -638,7 +638,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:115634392c1838eac80c7a5b760f43f96c92ad69c7a88d9932debed64e5ad23a
-      lastVerified: '2026-05-17T14:15:04.345Z'
+      lastVerified: '2026-05-17T15:04:27.067Z'
     cleanup-utilities:
       path: .aiox-core/development/tasks/cleanup-utilities.md
       layer: L2
@@ -666,7 +666,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8945dee3b0ea9afcab4aba1f4651be00d79ae236710a36821cf04238bee3890f
-      lastVerified: '2026-05-17T14:15:04.346Z'
+      lastVerified: '2026-05-17T15:04:27.067Z'
     cleanup-worktrees:
       path: .aiox-core/development/tasks/cleanup-worktrees.md
       layer: L2
@@ -689,7 +689,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:10d9fab42ba133a03f76094829ab467d2ef53b80bcc3de39245805679cedfbbd
-      lastVerified: '2026-05-17T14:15:04.346Z'
+      lastVerified: '2026-05-17T15:04:27.068Z'
     collaborative-edit:
       path: .aiox-core/development/tasks/collaborative-edit.md
       layer: L2
@@ -717,7 +717,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9295eae7a7c8731ff06131f76dcd695d30641d714a64c164989b98d8631532d8
-      lastVerified: '2026-05-17T14:15:04.346Z'
+      lastVerified: '2026-05-17T15:04:27.068Z'
     compose-molecule:
       path: .aiox-core/development/tasks/compose-molecule.md
       layer: L2
@@ -744,7 +744,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:596b8a8e1a6068e02aceeb9d1164d64fe8686b492ff39d25ec8dcd67ad1f9c09
-      lastVerified: '2026-05-17T14:15:04.347Z'
+      lastVerified: '2026-05-17T15:04:27.069Z'
     consolidate-patterns:
       path: .aiox-core/development/tasks/consolidate-patterns.md
       layer: L2
@@ -770,7 +770,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c45d9337c0aac9fcea56e216e172234a4f09a09f45db311f013973f9d5efc05a
-      lastVerified: '2026-05-17T14:15:04.347Z'
+      lastVerified: '2026-05-17T15:04:27.069Z'
     correct-course:
       path: .aiox-core/development/tasks/correct-course.md
       layer: L2
@@ -798,7 +798,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec55430908fb25c99bd0ae0bbf8aad6b1aff36306488abb07cf6e8f2e03306cc
-      lastVerified: '2026-05-17T14:15:04.347Z'
+      lastVerified: '2026-05-17T15:04:27.069Z'
     create-agent:
       path: .aiox-core/development/tasks/create-agent.md
       layer: L2
@@ -822,7 +822,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:538954ecee93c0b4467d4dc00ce4315b2fac838ad298a11c6bc4e45366430e17
-      lastVerified: '2026-05-17T14:15:04.348Z'
+      lastVerified: '2026-05-17T15:04:27.070Z'
     create-brownfield-story:
       path: .aiox-core/development/tasks/create-brownfield-story.md
       layer: L2
@@ -852,7 +852,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:88dc7949dbfde53773135650a6864c2b7a36cbfe93239cee8edf8a9c082b0fcf
-      lastVerified: '2026-05-17T14:15:04.348Z'
+      lastVerified: '2026-05-17T15:04:27.070Z'
     create-deep-research-prompt:
       path: .aiox-core/development/tasks/create-deep-research-prompt.md
       layer: L2
@@ -887,7 +887,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c432fad72d00722db2525b3b68555ab02bb38e80f85e55b7354b389771ed943b
-      lastVerified: '2026-05-17T14:15:04.349Z'
+      lastVerified: '2026-05-17T15:04:27.071Z'
     create-doc:
       path: .aiox-core/development/tasks/create-doc.md
       layer: L2
@@ -922,7 +922,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:078b2e5ac900f5d48fc82792198e59108a32891c77ed18aa062d87db442d155e
-      lastVerified: '2026-05-17T14:15:04.349Z'
+      lastVerified: '2026-05-17T15:04:27.071Z'
     create-next-story:
       path: .aiox-core/development/tasks/create-next-story.md
       layer: L2
@@ -964,7 +964,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c8ce97f47ad9b0fb316bee47eae46fe7c9fbacb897f3062eaedd8a925511afc
-      lastVerified: '2026-05-17T14:15:04.350Z'
+      lastVerified: '2026-05-17T15:04:27.072Z'
     create-service:
       path: .aiox-core/development/tasks/create-service.md
       layer: L2
@@ -989,7 +989,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dd9467f3e646ca4058f0cc524f99ae102c91750fa70f412f41f50f89d8f4b4e9
-      lastVerified: '2026-05-17T14:15:04.350Z'
+      lastVerified: '2026-05-17T15:04:27.072Z'
     create-suite:
       path: .aiox-core/development/tasks/create-suite.md
       layer: L2
@@ -1019,7 +1019,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0c5e7fa10bcb37d571ae3003f79fb6f98f46ed26c35234912b23b13d47091cb1
-      lastVerified: '2026-05-17T14:15:04.350Z'
+      lastVerified: '2026-05-17T15:04:27.072Z'
     create-task:
       path: .aiox-core/development/tasks/create-task.md
       layer: L2
@@ -1048,7 +1048,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2adfe4c3c8b73fbe3998444e24af796542342265b102ce52d3fc85d69d5e12af
-      lastVerified: '2026-05-17T14:15:04.351Z'
+      lastVerified: '2026-05-17T15:04:27.073Z'
     create-workflow:
       path: .aiox-core/development/tasks/create-workflow.md
       layer: L2
@@ -1077,7 +1077,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:76f47a9fa54b9690a10ddf4544c96f8d732c658550fd8487f9defd2339b8e222
-      lastVerified: '2026-05-17T14:15:04.351Z'
+      lastVerified: '2026-05-17T15:04:27.073Z'
     create-worktree:
       path: .aiox-core/development/tasks/create-worktree.md
       layer: L2
@@ -1108,7 +1108,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:143b9bdf87a4eed0faac612e137965483dec1224a7579399a68b68b6bc0689b7
-      lastVerified: '2026-05-17T14:15:04.351Z'
+      lastVerified: '2026-05-17T15:04:27.073Z'
     db-analyze-hotpaths:
       path: .aiox-core/development/tasks/db-analyze-hotpaths.md
       layer: L2
@@ -1134,7 +1134,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0993cb6e5d0c4fb22f081060e47f303c3c745889cf7b583ea2a29ab0f3b0ac6e
-      lastVerified: '2026-05-17T14:15:04.352Z'
+      lastVerified: '2026-05-17T15:04:27.074Z'
     db-apply-migration:
       path: .aiox-core/development/tasks/db-apply-migration.md
       layer: L2
@@ -1160,7 +1160,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73ca77d0858dde76a1979d6c0dce1cd6760666ea67fdc60283da0d027d73eaa2
-      lastVerified: '2026-05-17T14:15:04.352Z'
+      lastVerified: '2026-05-17T15:04:27.074Z'
     db-bootstrap:
       path: .aiox-core/development/tasks/db-bootstrap.md
       layer: L2
@@ -1185,7 +1185,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b50effd8d5d63bcbb7f42a02223678306c4b10a3d7cdbd94b024e0dc716d1e69
-      lastVerified: '2026-05-17T14:15:04.352Z'
+      lastVerified: '2026-05-17T15:04:27.074Z'
     db-domain-modeling:
       path: .aiox-core/development/tasks/db-domain-modeling.md
       layer: L2
@@ -1212,7 +1212,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:afd2911ebdb4d4164885efb6d71cb2578da1e60ca3c37397f19261a99e5bb22b
-      lastVerified: '2026-05-17T14:15:04.352Z'
+      lastVerified: '2026-05-17T15:04:27.075Z'
     db-dry-run:
       path: .aiox-core/development/tasks/db-dry-run.md
       layer: L2
@@ -1238,7 +1238,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ce848fdf956175b5dd96d6864376011972d2a7512ce37519592589eca442ec2b
-      lastVerified: '2026-05-17T14:15:04.353Z'
+      lastVerified: '2026-05-17T15:04:27.075Z'
     db-env-check:
       path: .aiox-core/development/tasks/db-env-check.md
       layer: L2
@@ -1262,7 +1262,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8a4674f5858ee709186690b45dd51fe5cbb28097a641f178e0e624e2a5331a44
-      lastVerified: '2026-05-17T14:15:04.353Z'
+      lastVerified: '2026-05-17T15:04:27.076Z'
     db-explain:
       path: .aiox-core/development/tasks/db-explain.md
       layer: L2
@@ -1286,7 +1286,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b96391756f45fc99b5cbd129921541060dc9ced1d1c269b820109d36fcd53530
-      lastVerified: '2026-05-17T14:15:04.354Z'
+      lastVerified: '2026-05-17T15:04:27.076Z'
     db-impersonate:
       path: .aiox-core/development/tasks/db-impersonate.md
       layer: L2
@@ -1311,7 +1311,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:31891339b082706882c3529d5fbae5a77e566dbe94dfb2cc011a70aef6721abd
-      lastVerified: '2026-05-17T14:15:04.354Z'
+      lastVerified: '2026-05-17T15:04:27.076Z'
     db-load-csv:
       path: .aiox-core/development/tasks/db-load-csv.md
       layer: L2
@@ -1337,7 +1337,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a4cf24a705ad7669aef945a71dcc95b7e156e2c41ee20be9d63819818422bd23
-      lastVerified: '2026-05-17T14:15:04.354Z'
+      lastVerified: '2026-05-17T15:04:27.076Z'
     db-policy-apply:
       path: .aiox-core/development/tasks/db-policy-apply.md
       layer: L2
@@ -1363,7 +1363,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5069a7786ac2f5c032f9b4aeedaa90808bccb0ecc01456d72b11d111281c8497
-      lastVerified: '2026-05-17T14:15:04.354Z'
+      lastVerified: '2026-05-17T15:04:27.077Z'
     db-rls-audit:
       path: .aiox-core/development/tasks/db-rls-audit.md
       layer: L2
@@ -1386,7 +1386,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b25183564fe08abdb5c563a19eac526ebbe14c10397cfb27e9b2f2c53f1c189b
-      lastVerified: '2026-05-17T14:15:04.354Z'
+      lastVerified: '2026-05-17T15:04:27.077Z'
     db-rollback:
       path: .aiox-core/development/tasks/db-rollback.md
       layer: L2
@@ -1410,7 +1410,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cc8b5ccbfb8184724452bd4fbaf93a5e43b137428f7cd1c6562b8bc7c10887e2
-      lastVerified: '2026-05-17T14:15:04.355Z'
+      lastVerified: '2026-05-17T15:04:27.077Z'
     db-run-sql:
       path: .aiox-core/development/tasks/db-run-sql.md
       layer: L2
@@ -1434,7 +1434,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:90b771db8d68c2cc3236aa371d24c2553175c4d39931fe3eb690cdd2ebaded1e
-      lastVerified: '2026-05-17T14:15:04.355Z'
+      lastVerified: '2026-05-17T15:04:27.078Z'
     db-schema-audit:
       path: .aiox-core/development/tasks/db-schema-audit.md
       layer: L2
@@ -1457,7 +1457,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4a70508b9d6bbe2b2e62265231682df371dc3a9295e285ef2e4356f81ed941e9
-      lastVerified: '2026-05-17T14:15:04.356Z'
+      lastVerified: '2026-05-17T15:04:27.078Z'
     db-seed:
       path: .aiox-core/development/tasks/db-seed.md
       layer: L2
@@ -1482,7 +1482,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e3553aff9781731e75c2017a7038cbb843a6945d69fb26365300aae3fd68d97e
-      lastVerified: '2026-05-17T14:15:04.356Z'
+      lastVerified: '2026-05-17T15:04:27.078Z'
     db-smoke-test:
       path: .aiox-core/development/tasks/db-smoke-test.md
       layer: L2
@@ -1506,7 +1506,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7f0672e95bedf5d5ac83f34acdd07f32d88bab743a2f210a49b6bea9bcdd04c7
-      lastVerified: '2026-05-17T14:15:04.356Z'
+      lastVerified: '2026-05-17T15:04:27.079Z'
     db-snapshot:
       path: .aiox-core/development/tasks/db-snapshot.md
       layer: L2
@@ -1531,7 +1531,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:60955c4ec4894233ef891424900d134ff4ac987ccf6fa2521f704e476865ef79
-      lastVerified: '2026-05-17T14:15:04.356Z'
+      lastVerified: '2026-05-17T15:04:27.079Z'
     db-squad-integration:
       path: .aiox-core/development/tasks/db-squad-integration.md
       layer: L2
@@ -1555,7 +1555,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:13ce5e3226dadffad490752064169e124e2c989514e2e7b3c249445b9ad3485c
-      lastVerified: '2026-05-17T14:15:04.357Z'
+      lastVerified: '2026-05-17T15:04:27.079Z'
     db-supabase-setup:
       path: .aiox-core/development/tasks/db-supabase-setup.md
       layer: L2
@@ -1582,7 +1582,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:64e02b6c69bb87d0082590484fadc0510cb88e4a6dc01b3c7015e5e6e6bcb585
-      lastVerified: '2026-05-17T14:15:04.357Z'
+      lastVerified: '2026-05-17T15:04:27.080Z'
     db-verify-order:
       path: .aiox-core/development/tasks/db-verify-order.md
       layer: L2
@@ -1608,7 +1608,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:478a1f94e0e4d9da5488ce5df41538308454a64e534d587d5d8361dbd9cff701
-      lastVerified: '2026-05-17T14:15:04.358Z'
+      lastVerified: '2026-05-17T15:04:27.080Z'
     delegate-to-external-executor:
       path: .aiox-core/development/tasks/delegate-to-external-executor.md
       layer: L2
@@ -1631,7 +1631,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:68c73a78e4eeebcb551f69bc8c13f37157be253b91a3d3d80ea9bc52c5330808
-      lastVerified: '2026-05-17T14:15:04.358Z'
+      lastVerified: '2026-05-17T15:04:27.080Z'
     deprecate-component:
       path: .aiox-core/development/tasks/deprecate-component.md
       layer: L2
@@ -1662,7 +1662,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:72dfca4d222b990ed868e5fd4c0d5793848cd1a9fda6d48fb7caec93e02c59ed
-      lastVerified: '2026-05-17T14:15:04.359Z'
+      lastVerified: '2026-05-17T15:04:27.081Z'
     dev-apply-qa-fixes:
       path: .aiox-core/development/tasks/dev-apply-qa-fixes.md
       layer: L2
@@ -1687,7 +1687,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a5b993cbc89e46f3669748da0f33e5cae28af4e6552d7f492b7f640f735736ba
-      lastVerified: '2026-05-17T14:15:04.359Z'
+      lastVerified: '2026-05-17T15:04:27.081Z'
     dev-backlog-debt:
       path: .aiox-core/development/tasks/dev-backlog-debt.md
       layer: L2
@@ -1716,7 +1716,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e5aa74b0fb90697be71cb5c1914d8b632d7edac0b9e42d87539a4ea1519c7ed3
-      lastVerified: '2026-05-17T14:15:04.359Z'
+      lastVerified: '2026-05-17T15:04:27.081Z'
     dev-develop-story:
       path: .aiox-core/development/tasks/dev-develop-story.md
       layer: L2
@@ -1746,7 +1746,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:be8924aa0de759ca92a177b0ea12a5b076a3095ee2a9f530b74b3de19e996954
-      lastVerified: '2026-05-17T14:15:04.360Z'
+      lastVerified: '2026-05-17T15:04:27.084Z'
     dev-improve-code-quality:
       path: .aiox-core/development/tasks/dev-improve-code-quality.md
       layer: L2
@@ -1779,7 +1779,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6cf78aed6cca48bf13cc1f677f2cde86aea591785f428f9f56733de478107e2f
-      lastVerified: '2026-05-17T14:15:04.361Z'
+      lastVerified: '2026-05-17T15:04:27.086Z'
     dev-optimize-performance:
       path: .aiox-core/development/tasks/dev-optimize-performance.md
       layer: L2
@@ -1810,7 +1810,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:acd5a1b14732f4d2526ebee2571897eb5ccb4c106d2388eb3560298ed85ce20d
-      lastVerified: '2026-05-17T14:15:04.362Z'
+      lastVerified: '2026-05-17T15:04:27.087Z'
     dev-suggest-refactoring:
       path: .aiox-core/development/tasks/dev-suggest-refactoring.md
       layer: L2
@@ -1841,7 +1841,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:51eebcbb72786df561ee0f25176ee4534166d71f2cfd4db1ea6eae7e8f3f6188
-      lastVerified: '2026-05-17T14:15:04.362Z'
+      lastVerified: '2026-05-17T15:04:27.088Z'
     dev-validate-next-story:
       path: .aiox-core/development/tasks/dev-validate-next-story.md
       layer: L2
@@ -1869,7 +1869,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b3c533f925077c73d18d8c9b4b69783493f1c690fd562df9546f9169f82bbe14
-      lastVerified: '2026-05-17T14:15:04.363Z'
+      lastVerified: '2026-05-17T15:04:27.088Z'
     devops-pro-access-grant:
       path: .aiox-core/development/tasks/devops-pro-access-grant.md
       layer: L2
@@ -1895,7 +1895,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:11d2b342a39a95acfbd5dbb7abe9c25a9511035b9ca46abac86ec40f60d6a011
-      lastVerified: '2026-05-17T14:15:04.363Z'
+      lastVerified: '2026-05-17T15:04:27.088Z'
     devops-pro-activate:
       path: .aiox-core/development/tasks/devops-pro-activate.md
       layer: L2
@@ -1918,7 +1918,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:910a62a5dc9c9780a774da3d79b1b3fe3b5834ecf7f1c074775774a8bdfebd65
-      lastVerified: '2026-05-17T14:15:04.363Z'
+      lastVerified: '2026-05-17T15:04:27.088Z'
     devops-pro-check-access:
       path: .aiox-core/development/tasks/devops-pro-check-access.md
       layer: L2
@@ -1942,7 +1942,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4dcff883a824899c531841bcdcda8bb5767a57fb49e8ca242a14875f41e7c694
-      lastVerified: '2026-05-17T14:15:04.363Z'
+      lastVerified: '2026-05-17T15:04:27.088Z'
     devops-pro-request-reset:
       path: .aiox-core/development/tasks/devops-pro-request-reset.md
       layer: L2
@@ -1966,7 +1966,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fdb5710a9c85e39750016cb3ac3e60a69396f2edaa1fc3180f0ebbf71e2c470c
-      lastVerified: '2026-05-17T14:15:04.363Z'
+      lastVerified: '2026-05-17T15:04:27.089Z'
     devops-pro-resend-verification:
       path: .aiox-core/development/tasks/devops-pro-resend-verification.md
       layer: L2
@@ -1990,7 +1990,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e6ed30bb1bd15d1d138f09e991ec227fda48f7b2bfef6be2f7a49bcb95ab9cd4
-      lastVerified: '2026-05-17T14:15:04.363Z'
+      lastVerified: '2026-05-17T15:04:27.089Z'
     devops-pro-reset-password:
       path: .aiox-core/development/tasks/devops-pro-reset-password.md
       layer: L2
@@ -2014,7 +2014,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1f48dd5d1110529cc20b91f41c3ad4ac2e4a095040f0bbc1aa2641955fb2559c
-      lastVerified: '2026-05-17T14:15:04.363Z'
+      lastVerified: '2026-05-17T15:04:27.089Z'
     devops-pro-validate-login:
       path: .aiox-core/development/tasks/devops-pro-validate-login.md
       layer: L2
@@ -2038,7 +2038,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b9321e184b4a1c7e003b363a857be01f953aebd467b898891b701880243265fe
-      lastVerified: '2026-05-17T14:15:04.363Z'
+      lastVerified: '2026-05-17T15:04:27.089Z'
     devops-pro-verify-status:
       path: .aiox-core/development/tasks/devops-pro-verify-status.md
       layer: L2
@@ -2062,7 +2062,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c6fff732a41370c125e5507f9284a3b567b5472a788df0cd874ad4e6c801150d
-      lastVerified: '2026-05-17T14:15:04.364Z'
+      lastVerified: '2026-05-17T15:04:27.089Z'
     document-gotchas:
       path: .aiox-core/development/tasks/document-gotchas.md
       layer: L2
@@ -2088,7 +2088,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:84858f6252bc2a85beda75971fed74e087edee3bdd537eb29f43132f0141fbf5
-      lastVerified: '2026-05-17T14:15:04.364Z'
+      lastVerified: '2026-05-17T15:04:27.090Z'
     document-project:
       path: .aiox-core/development/tasks/document-project.md
       layer: L2
@@ -2120,7 +2120,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8123a2c9105391b46857cfb3e236a912f47bfb598fb21df1cea0a12eabbf7337
-      lastVerified: '2026-05-17T14:15:04.364Z'
+      lastVerified: '2026-05-17T15:04:27.090Z'
     environment-bootstrap:
       path: .aiox-core/development/tasks/environment-bootstrap.md
       layer: L2
@@ -2158,7 +2158,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:02ed701bea38ee11ad7e83a310ad55b3d84f36f37a344fda6b252fe3230d50cb
-      lastVerified: '2026-05-17T14:15:04.365Z'
+      lastVerified: '2026-05-17T15:04:27.091Z'
     execute-checklist:
       path: .aiox-core/development/tasks/execute-checklist.md
       layer: L2
@@ -2195,7 +2195,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9bd751605efd593e0708bac6e3f1c66a91ba5f33a5069c655b6d16cf6621859c
-      lastVerified: '2026-05-17T14:15:04.365Z'
+      lastVerified: '2026-05-17T15:04:27.091Z'
     execute-epic-plan:
       path: .aiox-core/development/tasks/execute-epic-plan.md
       layer: L2
@@ -2225,7 +2225,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0c3ee4e1802927fb8f21be172daeb356797033ff082fea07523025a373bea387
-      lastVerified: '2026-05-17T14:15:04.366Z'
+      lastVerified: '2026-05-17T15:04:27.092Z'
     export-design-tokens-dtcg:
       path: .aiox-core/development/tasks/export-design-tokens-dtcg.md
       layer: L2
@@ -2251,7 +2251,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8819918bd7c4b6b0b0b0aadd66f5aecb2d6ca0b949206c16cb497d6d1d7a72f9
-      lastVerified: '2026-05-17T14:15:04.366Z'
+      lastVerified: '2026-05-17T15:04:27.092Z'
     extend-pattern:
       path: .aiox-core/development/tasks/extend-pattern.md
       layer: L2
@@ -2275,7 +2275,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7eaccc1d33f806bbcd2e7a90e701d6c88c00e4e98f14c14b4f705ff618ef17f8
-      lastVerified: '2026-05-17T14:15:04.366Z'
+      lastVerified: '2026-05-17T15:04:27.092Z'
     extract-patterns:
       path: .aiox-core/development/tasks/extract-patterns.md
       layer: L2
@@ -2299,7 +2299,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:aa8981c254d00a76c66c6c4f9569b0be1785f4537137ee23129049abae92f3b4
-      lastVerified: '2026-05-17T14:15:04.366Z'
+      lastVerified: '2026-05-17T15:04:27.092Z'
     extract-tokens:
       path: .aiox-core/development/tasks/extract-tokens.md
       layer: L2
@@ -2325,7 +2325,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8266d4caf51507fe82510c04a54b6a33c7e2d1f10862e4e242f009b214edd7ee
-      lastVerified: '2026-05-17T14:15:04.367Z'
+      lastVerified: '2026-05-17T15:04:27.093Z'
     facilitate-brainstorming-session:
       path: .aiox-core/development/tasks/facilitate-brainstorming-session.md
       layer: L2
@@ -2350,7 +2350,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c351428e7aa1af079046bbf357af98668675943fd13920b98b7ecfd9f87a6081
-      lastVerified: '2026-05-17T14:15:04.367Z'
+      lastVerified: '2026-05-17T15:04:27.093Z'
     fast-path-gate:
       path: .aiox-core/development/tasks/fast-path-gate.md
       layer: L2
@@ -2372,7 +2372,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d28e2def9134ffe79e04ebcfa25de651d659471eab07367fa4c7992245f79fe2
-      lastVerified: '2026-05-17T14:15:04.368Z'
+      lastVerified: '2026-05-17T15:04:27.093Z'
     generate-ai-frontend-prompt:
       path: .aiox-core/development/tasks/generate-ai-frontend-prompt.md
       layer: L2
@@ -2404,7 +2404,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d4c2abf28b065922f1e67c95fa2a69dd792c9828c6dd31d2fc173a5361b021aa
-      lastVerified: '2026-05-17T14:15:04.368Z'
+      lastVerified: '2026-05-17T15:04:27.094Z'
     generate-documentation:
       path: .aiox-core/development/tasks/generate-documentation.md
       layer: L2
@@ -2430,7 +2430,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec03841e1f72b8b55a156e03a7d6ef061f0cf942beb7d66f61d3bf6bdbaaa93b
-      lastVerified: '2026-05-17T14:15:04.368Z'
+      lastVerified: '2026-05-17T15:04:27.094Z'
     generate-migration-strategy:
       path: .aiox-core/development/tasks/generate-migration-strategy.md
       layer: L2
@@ -2455,7 +2455,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a944f9294553cad38c4e2a13143388a48dc330667e5b1b04dfcd1f5a2644541
-      lastVerified: '2026-05-17T14:15:04.368Z'
+      lastVerified: '2026-05-17T15:04:27.094Z'
     generate-shock-report:
       path: .aiox-core/development/tasks/generate-shock-report.md
       layer: L2
@@ -2480,7 +2480,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:04ebdca5f8bad14504f76d3e1fde4b426a4cd4ce8fe8dc4f9391f3c711bb6970
-      lastVerified: '2026-05-17T14:15:04.369Z'
+      lastVerified: '2026-05-17T15:04:27.095Z'
     github-devops-github-pr-automation:
       path: .aiox-core/development/tasks/github-devops-github-pr-automation.md
       layer: L2
@@ -2513,7 +2513,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2149c952074e661e77cfe6caa1bc2cb7366c930c9782eb308a8513a54f3d1629
-      lastVerified: '2026-05-17T14:15:04.369Z'
+      lastVerified: '2026-05-17T15:04:27.095Z'
     github-devops-pre-push-quality-gate:
       path: .aiox-core/development/tasks/github-devops-pre-push-quality-gate.md
       layer: L2
@@ -2544,7 +2544,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3709049cefce2dc03f54a16830114e67fa6b4cf37f0f999638d5d1521f0979d8
-      lastVerified: '2026-05-17T14:15:04.370Z'
+      lastVerified: '2026-05-17T15:04:27.096Z'
     github-devops-repository-cleanup:
       path: .aiox-core/development/tasks/github-devops-repository-cleanup.md
       layer: L2
@@ -2570,7 +2570,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:34135e86820be5218daf7031f4daa115d6ef9a727c7c0cb3a6f28c59f8e694c1
-      lastVerified: '2026-05-17T14:15:04.370Z'
+      lastVerified: '2026-05-17T15:04:27.096Z'
     github-devops-version-management:
       path: .aiox-core/development/tasks/github-devops-version-management.md
       layer: L2
@@ -2597,7 +2597,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1e217bea7df36731cfa5c3fb5a3b97399a57fef5989e59c303c3163bb3e5ecd7
-      lastVerified: '2026-05-17T14:15:04.370Z'
+      lastVerified: '2026-05-17T15:04:27.097Z'
     github-issue-triage:
       path: .aiox-core/development/tasks/github-issue-triage.md
       layer: L2
@@ -2618,7 +2618,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:61178caa7bc647dcae5e53d3f0515d6dab0cdc927e245b2db5844dc35d9e3d6f
-      lastVerified: '2026-05-17T14:15:04.371Z'
+      lastVerified: '2026-05-17T15:04:27.097Z'
     gotcha:
       path: .aiox-core/development/tasks/gotcha.md
       layer: L2
@@ -2643,7 +2643,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a9117d8a4c85c1be044975d829c936be0037c1751ef42b0fb2d19861702aecc6
-      lastVerified: '2026-05-17T14:15:04.371Z'
+      lastVerified: '2026-05-17T15:04:27.097Z'
     gotchas:
       path: .aiox-core/development/tasks/gotchas.md
       layer: L2
@@ -2669,7 +2669,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ecf526697d6c55416aaea97939cd2002e8f32eaa7001d31e823d7766688d2bf5
-      lastVerified: '2026-05-17T14:15:04.371Z'
+      lastVerified: '2026-05-17T15:04:27.097Z'
     ids-governor:
       path: .aiox-core/development/tasks/ids-governor.md
       layer: L2
@@ -2695,7 +2695,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cfb1aefffdf2db0d35cae8fdde2f5afbcea62b9b616e78a43390756c9b8e6b9c
-      lastVerified: '2026-05-17T14:15:04.371Z'
+      lastVerified: '2026-05-17T15:04:27.097Z'
     ids-health:
       path: .aiox-core/development/tasks/ids-health.md
       layer: L2
@@ -2718,7 +2718,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d5196b3741fb537707e1a99c71514e439447121df500002644dfebe43da4a70f
-      lastVerified: '2026-05-17T14:15:04.371Z'
+      lastVerified: '2026-05-17T15:04:27.098Z'
     ids-query:
       path: .aiox-core/development/tasks/ids-query.md
       layer: L2
@@ -2742,7 +2742,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c15596fdfc0bf86e4b6053313e7e91195c073d6c9066df4d626c5a3e2c13e99b
-      lastVerified: '2026-05-17T14:15:04.371Z'
+      lastVerified: '2026-05-17T15:04:27.098Z'
     improve-self:
       path: .aiox-core/development/tasks/improve-self.md
       layer: L2
@@ -2776,7 +2776,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ccabfaad3cdba01a151b313afdf0e1c41c8a981ec2140531f24500149b4a7646
-      lastVerified: '2026-05-17T14:15:04.372Z'
+      lastVerified: '2026-05-17T15:04:27.099Z'
     index-docs:
       path: .aiox-core/development/tasks/index-docs.md
       layer: L2
@@ -2807,7 +2807,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d8553b437ad8a4dc9dc37bd38939164ee0d0f76f2bb46d30a8318cf4413415f5
-      lastVerified: '2026-05-17T14:15:04.372Z'
+      lastVerified: '2026-05-17T15:04:27.099Z'
     init-project-status:
       path: .aiox-core/development/tasks/init-project-status.md
       layer: L2
@@ -2835,7 +2835,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0c2f801d30da8f926542e8d29507886cb79ec324e717c75607b9fbb5555dc16b
-      lastVerified: '2026-05-17T14:15:04.372Z'
+      lastVerified: '2026-05-17T15:04:27.099Z'
     integrate-squad:
       path: .aiox-core/development/tasks/integrate-squad.md
       layer: L2
@@ -2857,7 +2857,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c1dbded4048033ea0a5f10c8bb53e045e14930d8442a1bf35c67bb16c0c8939a
-      lastVerified: '2026-05-17T14:15:04.373Z'
+      lastVerified: '2026-05-17T15:04:27.099Z'
     kb-mode-interaction:
       path: .aiox-core/development/tasks/kb-mode-interaction.md
       layer: L2
@@ -2887,7 +2887,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73ef3d164b2576f80f37bfc5bc6ea2276a59778f9bcc41a77fd288fab7f2e61f
-      lastVerified: '2026-05-17T14:15:04.373Z'
+      lastVerified: '2026-05-17T15:04:27.100Z'
     learn-patterns:
       path: .aiox-core/development/tasks/learn-patterns.md
       layer: L2
@@ -2913,7 +2913,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0042edaa7d638aa4e476607d026a406411a6b9177f3a29a25d78773ee27e9c0f
-      lastVerified: '2026-05-17T14:15:04.373Z'
+      lastVerified: '2026-05-17T15:04:27.100Z'
     list-mcps:
       path: .aiox-core/development/tasks/list-mcps.md
       layer: L2
@@ -2934,7 +2934,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c2eca1a9c8d0be7c83a3e2eea59b33155bf7955f534eb0b36b27ed3852ea7dd1
-      lastVerified: '2026-05-17T14:15:04.373Z'
+      lastVerified: '2026-05-17T15:04:27.100Z'
     list-worktrees:
       path: .aiox-core/development/tasks/list-worktrees.md
       layer: L2
@@ -2963,7 +2963,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a29055766b289c22597532b5623e6e56dbbf6ca8d59193da6e6a0159213cb00b
-      lastVerified: '2026-05-17T14:15:04.374Z'
+      lastVerified: '2026-05-17T15:04:27.101Z'
     mcp-workflow:
       path: .aiox-core/development/tasks/mcp-workflow.md
       layer: L2
@@ -2985,7 +2985,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c09227efc590cc68ae9d32fe010de2dd8db621a2102b36d92a6fbb30f8f27cf
-      lastVerified: '2026-05-17T14:15:04.374Z'
+      lastVerified: '2026-05-17T15:04:27.101Z'
     merge-worktree:
       path: .aiox-core/development/tasks/merge-worktree.md
       layer: L2
@@ -3007,7 +3007,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e33a96e1961bbaba60f2258f4a98b8c9d384754a07eba705732f41d61ed2d4f4
-      lastVerified: '2026-05-17T14:15:04.374Z'
+      lastVerified: '2026-05-17T15:04:27.101Z'
     modify-agent:
       path: .aiox-core/development/tasks/modify-agent.md
       layer: L2
@@ -3035,7 +3035,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:31d7d543b8994605e10fbbdce3ca52d5d6d0938832f053baa5a0ca50238f7e33
-      lastVerified: '2026-05-17T14:15:04.374Z'
+      lastVerified: '2026-05-17T15:04:27.101Z'
     modify-task:
       path: .aiox-core/development/tasks/modify-task.md
       layer: L2
@@ -3061,7 +3061,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b02ca96a6ffebac281a6f0640228c39a62d723414a50481bf6ef8ad05c92cfd3
-      lastVerified: '2026-05-17T14:15:04.374Z'
+      lastVerified: '2026-05-17T15:04:27.102Z'
     modify-workflow:
       path: .aiox-core/development/tasks/modify-workflow.md
       layer: L2
@@ -3088,7 +3088,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7cbfc3488912240b0782d116b27c5410d724c7822f94efe6cd64df954c3b4b50
-      lastVerified: '2026-05-17T14:15:04.375Z'
+      lastVerified: '2026-05-17T15:04:27.102Z'
     next:
       path: .aiox-core/development/tasks/next.md
       layer: L2
@@ -3114,7 +3114,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bc65cd39c47607cef82f4d72e21f80b69ee4d5b1c42f3ffc317d91910fbae4ae
-      lastVerified: '2026-05-17T14:15:04.375Z'
+      lastVerified: '2026-05-17T15:04:27.102Z'
     orchestrate-resume:
       path: .aiox-core/development/tasks/orchestrate-resume.md
       layer: L2
@@ -3135,7 +3135,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c15ca8e699269246cc48a581ca6a956acf6ba9b717024274836d6447cfbccc76
-      lastVerified: '2026-05-17T14:15:04.375Z'
+      lastVerified: '2026-05-17T15:04:27.103Z'
     orchestrate-status:
       path: .aiox-core/development/tasks/orchestrate-status.md
       layer: L2
@@ -3156,7 +3156,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fe47c904e6329f758c001f6cc56383ea32059ce988c3d190e8d6ebcc42376ec9
-      lastVerified: '2026-05-17T14:15:04.376Z'
+      lastVerified: '2026-05-17T15:04:27.103Z'
     orchestrate-stop:
       path: .aiox-core/development/tasks/orchestrate-stop.md
       layer: L2
@@ -3177,7 +3177,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:87f82b66a711ed468ea2f97ce5201469c2990010fed95ddbd975bb8ab49a3547
-      lastVerified: '2026-05-17T14:15:04.376Z'
+      lastVerified: '2026-05-17T15:04:27.103Z'
     orchestrate:
       path: .aiox-core/development/tasks/orchestrate.md
       layer: L2
@@ -3197,7 +3197,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ca30ad1efa28ea5c7eeebd07f944fa0202ab9522ae6c32c8a19ca9ff2d30a8ce
-      lastVerified: '2026-05-17T14:15:04.376Z'
+      lastVerified: '2026-05-17T15:04:27.103Z'
     patterns:
       path: .aiox-core/development/tasks/patterns.md
       layer: L2
@@ -3221,7 +3221,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:99dc215422f88e1dafa138e577c2c96bc65cf9657ca99b9ca00e72b3d17ec843
-      lastVerified: '2026-05-17T14:15:04.376Z'
+      lastVerified: '2026-05-17T15:04:27.104Z'
     plan-create-context:
       path: .aiox-core/development/tasks/plan-create-context.md
       layer: L2
@@ -3252,7 +3252,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2374473d1984288dc37c80c298fc564facadf0b8b886b8a98520c8b39c9bc82a
-      lastVerified: '2026-05-17T14:15:04.377Z'
+      lastVerified: '2026-05-17T15:04:27.104Z'
     plan-create-implementation:
       path: .aiox-core/development/tasks/plan-create-implementation.md
       layer: L2
@@ -3281,7 +3281,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3c186ead114afe21638b933d2e312538ed3a7bb9ee3dfee0ee0dc86fcc0025cc
-      lastVerified: '2026-05-17T14:15:04.377Z'
+      lastVerified: '2026-05-17T15:04:27.105Z'
     plan-execute-subtask:
       path: .aiox-core/development/tasks/plan-execute-subtask.md
       layer: L2
@@ -3312,7 +3312,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a6c9c283579d0b5d3f337816ed192f4dda99c3634ac55da98fa0c0d332e4d963
-      lastVerified: '2026-05-17T14:15:04.378Z'
+      lastVerified: '2026-05-17T15:04:27.105Z'
     po-backlog-add:
       path: .aiox-core/development/tasks/po-backlog-add.md
       layer: L2
@@ -3339,7 +3339,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6f553ba9bf2638c183c4a59caa56d73baa641263080125ed0f9d87a18e9f376f
-      lastVerified: '2026-05-17T14:15:04.378Z'
+      lastVerified: '2026-05-17T15:04:27.106Z'
     po-close-story:
       path: .aiox-core/development/tasks/po-close-story.md
       layer: L2
@@ -3367,7 +3367,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:df93883e8af967351586dff250f79748008f6dc2ac15b78ac85715023a8d3ba4
-      lastVerified: '2026-05-17T14:15:04.378Z'
+      lastVerified: '2026-05-17T15:04:27.106Z'
     po-manage-story-backlog:
       path: .aiox-core/development/tasks/po-manage-story-backlog.md
       layer: L2
@@ -3395,7 +3395,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ed619e87c9753428eaea969d05d046b7f26af4f825d792ffcf026dc4f475b6e5
-      lastVerified: '2026-05-17T14:15:04.379Z'
+      lastVerified: '2026-05-17T15:04:27.107Z'
     po-pull-story-from-clickup:
       path: .aiox-core/development/tasks/po-pull-story-from-clickup.md
       layer: L2
@@ -3424,7 +3424,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:27fa2887a3da901319bafd7bd714c0abb31c638554aecaf924d412d25a7072bc
-      lastVerified: '2026-05-17T14:15:04.379Z'
+      lastVerified: '2026-05-17T15:04:27.107Z'
     po-pull-story:
       path: .aiox-core/development/tasks/po-pull-story.md
       layer: L2
@@ -3451,7 +3451,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d6f23501d4f35011fddf5242ed739208e9ec4d767210cd961e6d48373f33a2a3
-      lastVerified: '2026-05-17T14:15:04.380Z'
+      lastVerified: '2026-05-17T15:04:27.107Z'
     po-stories-index:
       path: .aiox-core/development/tasks/po-stories-index.md
       layer: L2
@@ -3479,7 +3479,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9e078929826bdec66e9cddbc9f0883568d32cc130e119e3a1da3345b54121dd3
-      lastVerified: '2026-05-17T14:15:04.380Z'
+      lastVerified: '2026-05-17T15:04:27.108Z'
     po-sync-story-to-clickup:
       path: .aiox-core/development/tasks/po-sync-story-to-clickup.md
       layer: L2
@@ -3508,7 +3508,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:03f25fea39d33c6f4febd1dfd467b643bef5cd3d89ceb4766282c173ce810698
-      lastVerified: '2026-05-17T14:15:04.380Z'
+      lastVerified: '2026-05-17T15:04:27.108Z'
     po-sync-story:
       path: .aiox-core/development/tasks/po-sync-story.md
       layer: L2
@@ -3535,7 +3535,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:67c5e1b02c0d499f12c6727d88a18407f926f440741fb5f8f6e2afa937adec2e
-      lastVerified: '2026-05-17T14:15:04.381Z'
+      lastVerified: '2026-05-17T15:04:27.109Z'
     pr-automation:
       path: .aiox-core/development/tasks/pr-automation.md
       layer: L2
@@ -3565,7 +3565,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:956147dfb7f42983b249041173b85fd75419f71b9018f9991f2b3aa7e59e3885
-      lastVerified: '2026-05-17T14:15:04.381Z'
+      lastVerified: '2026-05-17T15:04:27.109Z'
     project-status:
       path: .aiox-core/development/tasks/project-status.md
       layer: L2
@@ -3592,7 +3592,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3cb76eeb42b7e0b46a06ce0827bc68d2f507a7f4021174b1bd9e68d82463e5e6
-      lastVerified: '2026-05-17T14:15:04.381Z'
+      lastVerified: '2026-05-17T15:04:27.109Z'
     propose-modification:
       path: .aiox-core/development/tasks/propose-modification.md
       layer: L2
@@ -3622,7 +3622,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa340dc0749f40ba7f1ed12ebe107c53f212f764cf7318ee7a816d059528f69e
-      lastVerified: '2026-05-17T14:15:04.382Z'
+      lastVerified: '2026-05-17T15:04:27.110Z'
     publish-npm:
       path: .aiox-core/development/tasks/publish-npm.md
       layer: L2
@@ -3646,7 +3646,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:60ce8f90fbe932294dd103f507240413ad75bc2ea9be01a6224de65a9e282f54
-      lastVerified: '2026-05-17T14:15:04.383Z'
+      lastVerified: '2026-05-17T15:04:27.110Z'
     qa-after-creation:
       path: .aiox-core/development/tasks/qa-after-creation.md
       layer: L2
@@ -3667,7 +3667,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e9f6ceff7a0bc00d4fc035e890b7f1178c6ea43f447d135774b46a00713450e6
-      lastVerified: '2026-05-17T14:15:04.383Z'
+      lastVerified: '2026-05-17T15:04:27.111Z'
     qa-backlog-add-followup:
       path: .aiox-core/development/tasks/qa-backlog-add-followup.md
       layer: L2
@@ -3697,7 +3697,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:167e6f253eaf69e5751c294eec6a677153996b148ce70ba242506c2812f41535
-      lastVerified: '2026-05-17T14:15:04.383Z'
+      lastVerified: '2026-05-17T15:04:27.111Z'
     qa-browser-console-check:
       path: .aiox-core/development/tasks/qa-browser-console-check.md
       layer: L2
@@ -3720,7 +3720,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:deddbb5aed026e5b8b4d100a84baea6f4f85b3a249e56033f6e35e7ac08e2f80
-      lastVerified: '2026-05-17T14:15:04.384Z'
+      lastVerified: '2026-05-17T15:04:27.111Z'
     qa-create-fix-request:
       path: .aiox-core/development/tasks/qa-create-fix-request.md
       layer: L2
@@ -3749,7 +3749,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:709ed6f4c0260bf95e9801e22ef75f2b02958f967aaf6b1b6ffc4b7ee34b3e03
-      lastVerified: '2026-05-17T14:15:04.384Z'
+      lastVerified: '2026-05-17T15:04:27.112Z'
     qa-evidence-requirements:
       path: .aiox-core/development/tasks/qa-evidence-requirements.md
       layer: L2
@@ -3772,7 +3772,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cfa30b79bf1eac27511c94de213dbae761f3fb5544da07cc38563bcbd9187569
-      lastVerified: '2026-05-17T14:15:04.384Z'
+      lastVerified: '2026-05-17T15:04:27.112Z'
     qa-false-positive-detection:
       path: .aiox-core/development/tasks/qa-false-positive-detection.md
       layer: L2
@@ -3796,7 +3796,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f1a816365c588e7521617fc3aa7435e6f08d1ed06f4f51cce86f9529901d86ce
-      lastVerified: '2026-05-17T14:15:04.385Z'
+      lastVerified: '2026-05-17T15:04:27.112Z'
     qa-fix-issues:
       path: .aiox-core/development/tasks/qa-fix-issues.md
       layer: L2
@@ -3826,7 +3826,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b5db49f2709dbe27bb50d68f46f48b2d1c9a6b176a6025158d8f299e552eb2c3
-      lastVerified: '2026-05-17T14:15:04.385Z'
+      lastVerified: '2026-05-17T15:04:27.112Z'
     qa-gate:
       path: .aiox-core/development/tasks/qa-gate.md
       layer: L2
@@ -3856,7 +3856,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b151ea672e7ad0e9229807f86430e4f3483395ee4beae40f2f17d7f6228aee24
-      lastVerified: '2026-05-17T14:15:04.385Z'
+      lastVerified: '2026-05-17T15:04:27.113Z'
     qa-generate-tests:
       path: .aiox-core/development/tasks/qa-generate-tests.md
       layer: L2
@@ -3891,7 +3891,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:245885950328b086ffbe9320bba2e814b3f6b5e3e5342bac904ccd814d4e8519
-      lastVerified: '2026-05-17T14:15:04.386Z'
+      lastVerified: '2026-05-17T15:04:27.114Z'
     qa-library-validation:
       path: .aiox-core/development/tasks/qa-library-validation.md
       layer: L2
@@ -3914,7 +3914,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:366df913fe32f08ec4bf883c4b6f9781af22cc4bfa23ce25cfdbe56f562b013e
-      lastVerified: '2026-05-17T14:15:04.387Z'
+      lastVerified: '2026-05-17T15:04:27.114Z'
     qa-migration-validation:
       path: .aiox-core/development/tasks/qa-migration-validation.md
       layer: L2
@@ -3936,7 +3936,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2f855a1b918066755b8b16d0db7c347b32df372996217542905713459eb29bc4
-      lastVerified: '2026-05-17T14:15:04.387Z'
+      lastVerified: '2026-05-17T15:04:27.114Z'
     qa-nfr-assess:
       path: .aiox-core/development/tasks/qa-nfr-assess.md
       layer: L2
@@ -3961,7 +3961,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f2816ad58335c6d3b68bfc18d95f58b75358f8cb2cab844c7712ef36635a5e37
-      lastVerified: '2026-05-17T14:15:04.388Z'
+      lastVerified: '2026-05-17T15:04:27.115Z'
     qa-review-build:
       path: .aiox-core/development/tasks/qa-review-build.md
       layer: L2
@@ -3991,7 +3991,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9fcc1fd52b5cd18cf0039478c817e17aacf93e09f3e06de4ed308dc36075b5d5
-      lastVerified: '2026-05-17T14:15:04.388Z'
+      lastVerified: '2026-05-17T15:04:27.115Z'
     qa-review-proposal:
       path: .aiox-core/development/tasks/qa-review-proposal.md
       layer: L2
@@ -4022,7 +4022,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:928c0c1929f9935966ba24c27e590ae98b402095f3f54de6aa209d0e5ec9220c
-      lastVerified: '2026-05-17T14:15:04.389Z'
+      lastVerified: '2026-05-17T15:04:27.116Z'
     qa-review-story:
       path: .aiox-core/development/tasks/qa-review-story.md
       layer: L2
@@ -4052,7 +4052,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cc3e189824c656ff6ed2db04bd0a2a03d6293bccbec7e9b7a321daf64b9f1563
-      lastVerified: '2026-05-17T14:15:04.389Z'
+      lastVerified: '2026-05-17T15:04:27.116Z'
     qa-risk-profile:
       path: .aiox-core/development/tasks/qa-risk-profile.md
       layer: L2
@@ -4079,7 +4079,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:69b2b6edb38330234766bef8ed3c27469843e88fb30e130837922541c717432d
-      lastVerified: '2026-05-17T14:15:04.390Z'
+      lastVerified: '2026-05-17T15:04:27.117Z'
     qa-run-tests:
       path: .aiox-core/development/tasks/qa-run-tests.md
       layer: L2
@@ -4107,7 +4107,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f40850e70ffea9aecfb266e784575e0aa0483ea390ab8aae59df3829fd5fa6d8
-      lastVerified: '2026-05-17T14:15:04.390Z'
+      lastVerified: '2026-05-17T15:04:27.117Z'
     qa-security-checklist:
       path: .aiox-core/development/tasks/qa-security-checklist.md
       layer: L2
@@ -4129,7 +4129,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e155fba83e78f55830558def7ffe03b23c65dd6c2bbe63733b3966d1df6946ab
-      lastVerified: '2026-05-17T14:15:04.390Z'
+      lastVerified: '2026-05-17T15:04:27.117Z'
     qa-test-design:
       path: .aiox-core/development/tasks/qa-test-design.md
       layer: L2
@@ -4156,7 +4156,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:00e2aac4ec1587949b4bbdbd52f84adb8dc10a06395e9f68cc339c4a6fdb7405
-      lastVerified: '2026-05-17T14:15:04.391Z'
+      lastVerified: '2026-05-17T15:04:27.118Z'
     qa-trace-requirements:
       path: .aiox-core/development/tasks/qa-trace-requirements.md
       layer: L2
@@ -4183,7 +4183,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5c4a95d42d33b16ab77606d7a2dd5b18bb78f81f3872150454f10950bc0ee047
-      lastVerified: '2026-05-17T14:15:04.391Z'
+      lastVerified: '2026-05-17T15:04:27.118Z'
     release-management:
       path: .aiox-core/development/tasks/release-management.md
       layer: L2
@@ -4209,7 +4209,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fc4dd795b0ebc886a0de09452a70764eab5958eae894da639ae2df1829c9dd50
-      lastVerified: '2026-05-17T14:15:04.391Z'
+      lastVerified: '2026-05-17T15:04:27.118Z'
     remove-mcp:
       path: .aiox-core/development/tasks/remove-mcp.md
       layer: L2
@@ -4230,7 +4230,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3f4bf3f8d4d651109dc783e95598ab21569447295f22a7b868d3973f0848aa4c
-      lastVerified: '2026-05-17T14:15:04.391Z'
+      lastVerified: '2026-05-17T15:04:27.118Z'
     remove-worktree:
       path: .aiox-core/development/tasks/remove-worktree.md
       layer: L2
@@ -4259,7 +4259,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0ac9497e0a85e16f9e0a5357da43ae8571d1bf2ba98028f9968d2656df3ee36f
-      lastVerified: '2026-05-17T14:15:04.392Z'
+      lastVerified: '2026-05-17T15:04:27.119Z'
     resolve-github-issue:
       path: .aiox-core/development/tasks/resolve-github-issue.md
       layer: L2
@@ -4286,7 +4286,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d1e8f775eee3367f0a553f3e767477bad1833e72a731a2df94cde56d5b5eda97
-      lastVerified: '2026-05-17T14:15:04.392Z'
+      lastVerified: '2026-05-17T15:04:27.119Z'
     review-contributor-pr:
       path: .aiox-core/development/tasks/review-contributor-pr.md
       layer: L2
@@ -4308,7 +4308,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dfb5f03fae16171777742b06a9e54ee25711d1d94cedc2152ef9c9331310b608
-      lastVerified: '2026-05-17T14:15:04.392Z'
+      lastVerified: '2026-05-17T15:04:27.120Z'
     run-design-system-pipeline:
       path: .aiox-core/development/tasks/run-design-system-pipeline.md
       layer: L2
@@ -4334,7 +4334,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ff4c225b922da347b63aeb6d8aa95484c1c9281eb1e4b4c4ab0ecef0a1a54c26
-      lastVerified: '2026-05-17T14:15:04.393Z'
+      lastVerified: '2026-05-17T15:04:27.120Z'
     run-workflow-engine:
       path: .aiox-core/development/tasks/run-workflow-engine.md
       layer: L2
@@ -4364,7 +4364,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c1f10d20c25283675ca8b7f3644699c17298d7ffd2745640e252aa40bb654397
-      lastVerified: '2026-05-17T14:15:04.393Z'
+      lastVerified: '2026-05-17T15:04:27.121Z'
     run-workflow:
       path: .aiox-core/development/tasks/run-workflow.md
       layer: L2
@@ -4391,7 +4391,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:484bb719fc4b4584875370647c59c04bdc24b57eaaf6b99460404b57f80772b1
-      lastVerified: '2026-05-17T14:15:04.394Z'
+      lastVerified: '2026-05-17T15:04:27.121Z'
     search-mcp:
       path: .aiox-core/development/tasks/search-mcp.md
       layer: L2
@@ -4413,7 +4413,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c7d9239c740b250baf9d82a5aa3baf1cd0bb8c671f0889c9a6fc6c0a668ac9c
-      lastVerified: '2026-05-17T14:15:04.394Z'
+      lastVerified: '2026-05-17T15:04:27.121Z'
     security-audit:
       path: .aiox-core/development/tasks/security-audit.md
       layer: L2
@@ -4435,7 +4435,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8ae6068628080d67c4c981d0c6e87d6347ddcc2e363d985ef578de22e94d6ae1
-      lastVerified: '2026-05-17T14:15:04.394Z'
+      lastVerified: '2026-05-17T15:04:27.122Z'
     security-scan:
       path: .aiox-core/development/tasks/security-scan.md
       layer: L2
@@ -4458,7 +4458,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2232ced35524452c49197fb4c09099dfc61c4980f31a8cd7fda3cc1b152068ca
-      lastVerified: '2026-05-17T14:15:04.395Z'
+      lastVerified: '2026-05-17T15:04:27.122Z'
     session-resume:
       path: .aiox-core/development/tasks/session-resume.md
       layer: L2
@@ -4481,7 +4481,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0130ea9c24b5c74a7803985f485663dd373edd366c8cbaa5d0143119a4e3cc3e
-      lastVerified: '2026-05-17T14:15:04.395Z'
+      lastVerified: '2026-05-17T15:04:27.122Z'
     setup-database:
       path: .aiox-core/development/tasks/setup-database.md
       layer: L2
@@ -4505,7 +4505,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3240013a44d42143a63280f0a1d6a8756a2572027e39b6fe913c1ed956442a38
-      lastVerified: '2026-05-17T14:15:04.395Z'
+      lastVerified: '2026-05-17T15:04:27.123Z'
     setup-design-system:
       path: .aiox-core/development/tasks/setup-design-system.md
       layer: L2
@@ -4530,7 +4530,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9cb43d28c66a6b7a8d36a16fc0256ea25c9bb49e214e37bce42cae4908450677
-      lastVerified: '2026-05-17T14:15:04.396Z'
+      lastVerified: '2026-05-17T15:04:27.123Z'
     setup-github:
       path: .aiox-core/development/tasks/setup-github.md
       layer: L2
@@ -4557,7 +4557,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:515cc5f26383c6fde61e38acb4678ead15d701ddc32c668a9b9bcfc9a02f2850
-      lastVerified: '2026-05-17T14:15:04.396Z'
+      lastVerified: '2026-05-17T15:04:27.124Z'
     setup-llm-routing:
       path: .aiox-core/development/tasks/setup-llm-routing.md
       layer: L2
@@ -4583,7 +4583,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:97334fdf1e679d9bd1deecf048f54760c3efdebf38af4daafe82094323f05865
-      lastVerified: '2026-05-17T14:15:04.397Z'
+      lastVerified: '2026-05-17T15:04:27.124Z'
     setup-mcp-docker:
       path: .aiox-core/development/tasks/setup-mcp-docker.md
       layer: L2
@@ -4609,7 +4609,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b65a663641b6667ac46848eab02ecb75da28e09e2cfa4d7d12f979c423eef999
-      lastVerified: '2026-05-17T14:15:04.397Z'
+      lastVerified: '2026-05-17T15:04:27.124Z'
     setup-project-docs:
       path: .aiox-core/development/tasks/setup-project-docs.md
       layer: L2
@@ -4641,7 +4641,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5e2969779d62d05a26fb49d5959d25224de748d2c70aaa72b6f219fb149decee
-      lastVerified: '2026-05-17T14:15:04.397Z'
+      lastVerified: '2026-05-17T15:04:27.125Z'
     shard-doc:
       path: .aiox-core/development/tasks/shard-doc.md
       layer: L2
@@ -4674,7 +4674,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:614fb73a40c4569d30e42a6a5536fbb374f2174bd709a73ad1026df595f50f52
-      lastVerified: '2026-05-17T14:15:04.398Z'
+      lastVerified: '2026-05-17T15:04:27.125Z'
     sm-create-next-story:
       path: .aiox-core/development/tasks/sm-create-next-story.md
       layer: L2
@@ -4712,7 +4712,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e5ee6bc856fba12867557c0684d566d520516b4ff0c96e9df91f260786106bd0
-      lastVerified: '2026-05-17T14:15:04.398Z'
+      lastVerified: '2026-05-17T15:04:27.126Z'
     spec-assess-complexity:
       path: .aiox-core/development/tasks/spec-assess-complexity.md
       layer: L2
@@ -4738,7 +4738,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:860d6c4641282a426840ccea8bed766c8eddeb9806e4e0a806a330f70e5b6eca
-      lastVerified: '2026-05-17T14:15:04.398Z'
+      lastVerified: '2026-05-17T15:04:27.126Z'
     spec-critique:
       path: .aiox-core/development/tasks/spec-critique.md
       layer: L2
@@ -4767,7 +4767,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d2c3615b84dff942bb1c36fe1d89d025a5c52eedf15a382e75bba6cee085e7dd
-      lastVerified: '2026-05-17T14:15:04.399Z'
+      lastVerified: '2026-05-17T15:04:27.126Z'
     spec-gather-requirements:
       path: .aiox-core/development/tasks/spec-gather-requirements.md
       layer: L2
@@ -4794,7 +4794,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b2ae9cd6da1233bd610a0a8023dcf1dfece81ab75a1cb6da6b9016e0351a7d40
-      lastVerified: '2026-05-17T14:15:04.400Z'
+      lastVerified: '2026-05-17T15:04:27.127Z'
     spec-research-dependencies:
       path: .aiox-core/development/tasks/spec-research-dependencies.md
       layer: L2
@@ -4821,7 +4821,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c13f6fed7af8e1f8e20295e697637fc6831e559ba9d67d7649786626f2619a43
-      lastVerified: '2026-05-17T14:15:04.400Z'
+      lastVerified: '2026-05-17T15:04:27.128Z'
     spec-write-spec:
       path: .aiox-core/development/tasks/spec-write-spec.md
       layer: L2
@@ -4853,7 +4853,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1ecef348cf83403243398c362629e016ff299b4e0634d7a0581b39d779a113bf
-      lastVerified: '2026-05-17T14:15:04.400Z'
+      lastVerified: '2026-05-17T15:04:27.128Z'
     squad-creator-analyze:
       path: .aiox-core/development/tasks/squad-creator-analyze.md
       layer: L2
@@ -4880,7 +4880,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8aeeae86b0afd75c4f79e8a5f1cca02b3633c9d925ee39725a66795befecc8a8
-      lastVerified: '2026-05-17T14:15:04.401Z'
+      lastVerified: '2026-05-17T15:04:27.128Z'
     squad-creator-create:
       path: .aiox-core/development/tasks/squad-creator-create.md
       layer: L2
@@ -4908,7 +4908,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e4a8b8799837fb0ea60eb9baf3bbe57a27f1c1c7dd67ec8fd0c9d5d8a17bbce2
-      lastVerified: '2026-05-17T14:15:04.401Z'
+      lastVerified: '2026-05-17T15:04:27.129Z'
     squad-creator-design:
       path: .aiox-core/development/tasks/squad-creator-design.md
       layer: L2
@@ -4933,7 +4933,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b5851f22a2466107bf506707a01be7ff857b27b19d5d4ec4c5d0506cb6719e80
-      lastVerified: '2026-05-17T14:15:04.401Z'
+      lastVerified: '2026-05-17T15:04:27.129Z'
     squad-creator-download:
       path: .aiox-core/development/tasks/squad-creator-download.md
       layer: L2
@@ -4955,7 +4955,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5d75af6d41624a4c40d6734031ebc2a8f7eb4eb3ec22f10de32c92d600ddf332
-      lastVerified: '2026-05-17T14:15:04.402Z'
+      lastVerified: '2026-05-17T15:04:27.129Z'
     squad-creator-extend:
       path: .aiox-core/development/tasks/squad-creator-extend.md
       layer: L2
@@ -4984,7 +4984,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2d4a0bbe65d21aea5869b8df3a1e1d81a67e027402c4270b8dd1cc8b7c595573
-      lastVerified: '2026-05-17T14:15:04.402Z'
+      lastVerified: '2026-05-17T15:04:27.130Z'
     squad-creator-list:
       path: .aiox-core/development/tasks/squad-creator-list.md
       layer: L2
@@ -5008,7 +5008,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6bc04c23b31daa2f4e8448a5c28540ed8c35903c1b2c77e3ce7b0986268c8710
-      lastVerified: '2026-05-17T14:15:04.402Z'
+      lastVerified: '2026-05-17T15:04:27.130Z'
     squad-creator-migrate:
       path: .aiox-core/development/tasks/squad-creator-migrate.md
       layer: L2
@@ -5034,7 +5034,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:69a15d3db12cc1268740378fcd411a0a011c3f441e3eea6feaaf0b95f4bf8c1e
-      lastVerified: '2026-05-17T14:15:04.402Z'
+      lastVerified: '2026-05-17T15:04:27.130Z'
     squad-creator-publish:
       path: .aiox-core/development/tasks/squad-creator-publish.md
       layer: L2
@@ -5056,7 +5056,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9f744f0c1e70e18945bfdc22ea48a103862cdb7fffcbc36ac61d44473248b124
-      lastVerified: '2026-05-17T14:15:04.402Z'
+      lastVerified: '2026-05-17T15:04:27.130Z'
     squad-creator-sync-ide-command:
       path: .aiox-core/development/tasks/squad-creator-sync-ide-command.md
       layer: L2
@@ -5079,7 +5079,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4221574f07adb5fb53c7c0c9f85656222a97e623b5e4072cee37e34b82f3f379
-      lastVerified: '2026-05-17T14:15:04.403Z'
+      lastVerified: '2026-05-17T15:04:27.131Z'
     squad-creator-sync-synkra:
       path: .aiox-core/development/tasks/squad-creator-sync-synkra.md
       layer: L2
@@ -5102,7 +5102,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dd03f844de8aa1f1caac31b7791ae96b4a221a650728fb13ff6a6245f2e5f75a
-      lastVerified: '2026-05-17T14:15:04.403Z'
+      lastVerified: '2026-05-17T15:04:27.131Z'
     squad-creator-validate:
       path: .aiox-core/development/tasks/squad-creator-validate.md
       layer: L2
@@ -5128,7 +5128,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:782cc7e67b8d061475d94eff8312d5ec23d3ea84630797d9190384d3b3fafd8e
-      lastVerified: '2026-05-17T14:15:04.403Z'
+      lastVerified: '2026-05-17T15:04:27.131Z'
     story-checkpoint:
       path: .aiox-core/development/tasks/story-checkpoint.md
       layer: L2
@@ -5154,7 +5154,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:467fabe8b0c0c7fcd1bd122fdbdc883992a54656c6774c8cea2963789873ee4a
-      lastVerified: '2026-05-17T14:15:04.403Z'
+      lastVerified: '2026-05-17T15:04:27.132Z'
     sync-documentation:
       path: .aiox-core/development/tasks/sync-documentation.md
       layer: L2
@@ -5178,7 +5178,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8be6c2123aa935ddab5e845375c28213f70476cc9dfb10fd0e444c6d40a7e4ae
-      lastVerified: '2026-05-17T14:15:04.404Z'
+      lastVerified: '2026-05-17T15:04:27.132Z'
     sync-registry-intel:
       path: .aiox-core/development/tasks/sync-registry-intel.md
       layer: L2
@@ -5202,7 +5202,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:908df7d093442ccfd15805dabbd9f16e1f34b92ddb692f408a77484bb3d69a53
-      lastVerified: '2026-05-17T14:15:04.404Z'
+      lastVerified: '2026-05-17T15:04:27.132Z'
     tailwind-upgrade:
       path: .aiox-core/development/tasks/tailwind-upgrade.md
       layer: L2
@@ -5227,7 +5227,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa0bea0fc5513e13782bbb0bdb0564f15d7cc2d30b7954f26e52c980767d4469
-      lastVerified: '2026-05-17T14:15:04.404Z'
+      lastVerified: '2026-05-17T15:04:27.133Z'
     test-as-user:
       path: .aiox-core/development/tasks/test-as-user.md
       layer: L2
@@ -5254,7 +5254,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9117f1cf85c63be672b0e0f7207274ad73f384cf0299f5c32f9c2f7ad092a701
-      lastVerified: '2026-05-17T14:15:04.404Z'
+      lastVerified: '2026-05-17T15:04:27.133Z'
     test-validation-task:
       path: .aiox-core/development/tasks/test-validation-task.md
       layer: L2
@@ -5276,7 +5276,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2868bd169192b345cba423f2134d46a0d0337f9fe7135476b593e8e9b81617db
-      lastVerified: '2026-05-17T14:15:04.405Z'
+      lastVerified: '2026-05-17T15:04:27.133Z'
     triage-github-issues:
       path: .aiox-core/development/tasks/triage-github-issues.md
       layer: L2
@@ -5301,7 +5301,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73e1e42f0998a701f8855de6e8666150a284e44efd41878927defa17eded4cfe
-      lastVerified: '2026-05-17T14:15:04.405Z'
+      lastVerified: '2026-05-17T15:04:27.134Z'
     undo-last:
       path: .aiox-core/development/tasks/undo-last.md
       layer: L2
@@ -5328,7 +5328,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c038fd862dadcf7a4ad62e347ffa66e6335bc9bbd63d2e675a810381fb257f8a
-      lastVerified: '2026-05-17T14:15:04.405Z'
+      lastVerified: '2026-05-17T15:04:27.134Z'
     update-aiox:
       path: .aiox-core/development/tasks/update-aiox.md
       layer: L2
@@ -5352,7 +5352,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a88b1f79f52aad5aaaf2c7d385314718fd5f09316f37b65553b838b2cb445f95
-      lastVerified: '2026-05-17T14:15:04.405Z'
+      lastVerified: '2026-05-17T15:04:27.134Z'
     update-manifest:
       path: .aiox-core/development/tasks/update-manifest.md
       layer: L2
@@ -5378,7 +5378,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0ef0a5ed8638d1fa00317796acbd8419ca1bbbfa0c5e42109dda3d82300d8c12
-      lastVerified: '2026-05-17T14:15:04.406Z'
+      lastVerified: '2026-05-17T15:04:27.134Z'
     update-source-tree:
       path: .aiox-core/development/tasks/update-source-tree.md
       layer: L2
@@ -5402,7 +5402,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1d7eb7cbc8fa582375edc0275e98415f110e0507cb77744954fa342592ac1c56
-      lastVerified: '2026-05-17T14:15:04.406Z'
+      lastVerified: '2026-05-17T15:04:27.135Z'
     ux-create-wireframe:
       path: .aiox-core/development/tasks/ux-create-wireframe.md
       layer: L2
@@ -5427,7 +5427,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d3fe6c03050d98d0a46024c6c6aae32d4fb5e6d7b4a06b01401c54b0853469ce
-      lastVerified: '2026-05-17T14:15:04.406Z'
+      lastVerified: '2026-05-17T15:04:27.135Z'
     ux-ds-scan-artifact:
       path: .aiox-core/development/tasks/ux-ds-scan-artifact.md
       layer: L2
@@ -5455,7 +5455,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5a6eb9d40350c3cc15099f8f42beb8a15d64021916e4ec2e82142b33cecb1635
-      lastVerified: '2026-05-17T14:15:04.407Z'
+      lastVerified: '2026-05-17T15:04:27.135Z'
     ux-user-research:
       path: .aiox-core/development/tasks/ux-user-research.md
       layer: L2
@@ -5481,7 +5481,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0c497783693c6b49d71a99c136f3c016f94afe1fd7556eb6c050aa05a60adade
-      lastVerified: '2026-05-17T14:15:04.407Z'
+      lastVerified: '2026-05-17T15:04:27.136Z'
     validate-agents:
       path: .aiox-core/development/tasks/validate-agents.md
       layer: L2
@@ -5501,7 +5501,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b278ba27cf8171d143aba30bd2f708b9226526dae70e9b881f52b5e1e908525f
-      lastVerified: '2026-05-17T14:15:04.407Z'
+      lastVerified: '2026-05-17T15:04:27.136Z'
     validate-next-story:
       path: .aiox-core/development/tasks/validate-next-story.md
       layer: L2
@@ -5540,7 +5540,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:277faba94cba30ac3773159d641fc2b8a345efd70dcfef6bae15f8a6280128ea
-      lastVerified: '2026-05-17T14:15:04.407Z'
+      lastVerified: '2026-05-17T15:04:27.136Z'
     validate-tech-preset:
       path: .aiox-core/development/tasks/validate-tech-preset.md
       layer: L2
@@ -5563,7 +5563,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:50a65289c223c1a79b0bebe4120f3f703df45d42522309e658f6d0f5c9fdb54e
-      lastVerified: '2026-05-17T14:15:04.408Z'
+      lastVerified: '2026-05-17T15:04:27.137Z'
     validate-workflow:
       path: .aiox-core/development/tasks/validate-workflow.md
       layer: L2
@@ -5588,7 +5588,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e01147feb106d803a298447e5a4988d5310e65cd5b5e291f771923d457056008
-      lastVerified: '2026-05-17T14:15:04.408Z'
+      lastVerified: '2026-05-17T15:04:27.137Z'
     verify-subtask:
       path: .aiox-core/development/tasks/verify-subtask.md
       layer: L2
@@ -5612,7 +5612,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4ad9d89256ed9c34f104ae951e7d3b3739f6c5611f22fcf98ab5b666b60cc39f
-      lastVerified: '2026-05-17T14:15:04.408Z'
+      lastVerified: '2026-05-17T15:04:27.137Z'
     waves:
       path: .aiox-core/development/tasks/waves.md
       layer: L2
@@ -5639,7 +5639,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f5bfc1c3d03bf9fbf7c7ac859dd5c388d327abc154f6c064e33dcbae3f94dbd9
-      lastVerified: '2026-05-17T14:15:04.408Z'
+      lastVerified: '2026-05-17T15:04:27.137Z'
     yolo-toggle:
       path: .aiox-core/development/tasks/yolo-toggle.md
       layer: L2
@@ -5662,12 +5662,14 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4fd6b6d8b2dc0130377ab66fcdf328e48df7701fb621cf919932245886642405
-      lastVerified: '2026-05-17T14:15:04.408Z'
+      lastVerified: '2026-05-17T15:04:27.138Z'
     README:
       path: .aiox-core/development/tasks/blocks/README.md
       layer: L2
       type: task
-      purpose: '{One-line description}'
+      purpose: >-
+        Blocks are small, focused units of functionality that can be included in multiple tasks. They follow the DRY
+        (Don't Repeat Yourself) principle and provide consistent behavior across the AIOX framework
       keywords:
         - readme
         - aiox
@@ -5685,7 +5687,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:484409d3b069c30a14ba28873388567f06d613e6feb9acb14537434d1db03446
-      lastVerified: '2026-05-17T14:15:04.409Z'
+      lastVerified: '2026-05-17T15:04:27.138Z'
     agent-prompt-template:
       path: .aiox-core/development/tasks/blocks/agent-prompt-template.md
       layer: L2
@@ -5709,7 +5711,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7f61c142e66622159ed2ef119ed0abbc95ed514f21749a957f1aaa3babc57b36
-      lastVerified: '2026-05-17T14:15:04.409Z'
+      lastVerified: '2026-05-17T15:04:27.138Z'
     context-loading:
       path: .aiox-core/development/tasks/blocks/context-loading.md
       layer: L2
@@ -5732,7 +5734,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:281c958fa18a2a104c41a3b4b0d0338298034e4bf4e4f5b5085d10d8f603d797
-      lastVerified: '2026-05-17T14:15:04.409Z'
+      lastVerified: '2026-05-17T15:04:27.138Z'
     execution-pattern:
       path: .aiox-core/development/tasks/blocks/execution-pattern.md
       layer: L2
@@ -5754,7 +5756,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a29498d6f59be665a1fe494f3d2ce138da1b7f7eb62028f60acbe7a577bb2bd
-      lastVerified: '2026-05-17T14:15:04.409Z'
+      lastVerified: '2026-05-17T15:04:27.138Z'
     finalization:
       path: .aiox-core/development/tasks/blocks/finalization.md
       layer: L2
@@ -5775,7 +5777,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8414839ac579a6e25c8ad8cc3218bb5f216288ef30a0a995dde59d3d7dc9130e
-      lastVerified: '2026-05-17T14:15:04.409Z'
+      lastVerified: '2026-05-17T15:04:27.139Z'
   templates:
     activation-instructions-inline-greeting:
       path: .aiox-core/product/templates/activation-instructions-inline-greeting.yaml
@@ -5798,7 +5800,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d4d3dc2bf0c06c0094ab0e76029c0ad322222e3420240ac3abcac6c150a4ae01
-      lastVerified: '2026-05-17T14:15:04.413Z'
+      lastVerified: '2026-05-17T15:04:27.141Z'
     activation-instructions-template:
       path: .aiox-core/product/templates/activation-instructions-template.md
       layer: L2
@@ -5821,7 +5823,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b4df5343728e565d975c28cad8a1a9dac370d0cf827689ced1c553268dc265e7
-      lastVerified: '2026-05-17T14:15:04.414Z'
+      lastVerified: '2026-05-17T15:04:27.142Z'
     agent-template:
       path: .aiox-core/product/templates/agent-template.yaml
       layer: L2
@@ -5844,7 +5846,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:98676fcc493c0d5f09264dcc52fcc2cf1129f9a195824ecb4c2ec035c2515121
-      lastVerified: '2026-05-17T14:15:04.414Z'
+      lastVerified: '2026-05-17T15:04:27.142Z'
     aiox-ai-config:
       path: .aiox-core/product/templates/aiox-ai-config.yaml
       layer: L2
@@ -5866,7 +5868,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:14efe89e4be87326f621b1ff2a03c928806566ec134e74b191ff24156d5a0140
-      lastVerified: '2026-05-17T14:15:04.414Z'
+      lastVerified: '2026-05-17T15:04:27.142Z'
     architecture-tmpl:
       path: .aiox-core/product/templates/architecture-tmpl.yaml
       layer: L2
@@ -5887,7 +5889,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9483f38486932842e1bc1a73c35b3f90fa2cd9c703c7d5effabea7dc8f76350a
-      lastVerified: '2026-05-17T14:15:04.415Z'
+      lastVerified: '2026-05-17T15:04:27.143Z'
     brainstorming-output-tmpl:
       path: .aiox-core/product/templates/brainstorming-output-tmpl.yaml
       layer: L2
@@ -5908,7 +5910,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:acd98caed4a32328afdf3f3f42554a4f45e507cc527e95593fb7e63ccb8e66a1
-      lastVerified: '2026-05-17T14:15:04.415Z'
+      lastVerified: '2026-05-17T15:04:27.144Z'
     brownfield-architecture-tmpl:
       path: .aiox-core/product/templates/brownfield-architecture-tmpl.yaml
       layer: L2
@@ -5930,7 +5932,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5d399d93a42b674758515e5cf70ffb21cd77befc9f54a8fe0b9dba0773bbbf66
-      lastVerified: '2026-05-17T14:15:04.416Z'
+      lastVerified: '2026-05-17T15:04:27.144Z'
     brownfield-prd-tmpl:
       path: .aiox-core/product/templates/brownfield-prd-tmpl.yaml
       layer: L2
@@ -5952,7 +5954,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bc1852d15e3a383c7519e5976094de3055c494fdd467acd83137700c900c4c61
-      lastVerified: '2026-05-17T14:15:04.416Z'
+      lastVerified: '2026-05-17T15:04:27.145Z'
     brownfield-risk-report-tmpl:
       path: .aiox-core/product/templates/brownfield-risk-report-tmpl.yaml
       layer: L2
@@ -5975,7 +5977,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2aca2b93e48ea944bce3c933f7466b4e520e4c26ec486e23f0a82cccf6e0356b
-      lastVerified: '2026-05-17T14:15:04.416Z'
+      lastVerified: '2026-05-17T15:04:27.145Z'
     changelog-template:
       path: .aiox-core/product/templates/changelog-template.md
       layer: L2
@@ -5995,7 +5997,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:af44d857c9bf8808e89419d1d859557c3c827de143be3c0f36f2a053c9ee9197
-      lastVerified: '2026-05-17T14:15:04.417Z'
+      lastVerified: '2026-05-17T15:04:27.145Z'
     command-rationalization-matrix:
       path: .aiox-core/product/templates/command-rationalization-matrix.md
       layer: L2
@@ -6017,7 +6019,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:651157c5e6ad75323e24d5685660addb4f2cfe8bfa01e0c64a8e7e10c90f1d12
-      lastVerified: '2026-05-17T14:15:04.417Z'
+      lastVerified: '2026-05-17T15:04:27.145Z'
     competitor-analysis-tmpl:
       path: .aiox-core/product/templates/competitor-analysis-tmpl.yaml
       layer: L2
@@ -6039,12 +6041,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:690cde6406250883a765eddcbad415c737268525340cf2c8679c8f3074c9d507
-      lastVerified: '2026-05-17T14:15:04.417Z'
+      lastVerified: '2026-05-17T15:04:27.145Z'
     current-approach-tmpl:
       path: .aiox-core/product/templates/current-approach-tmpl.md
       layer: L2
       type: template
-      purpose: 'Current Approach: Subtask {{subtaskId}}'
+      purpose: Entity at .aiox-core/product/templates/current-approach-tmpl.md
       keywords:
         - current
         - approach
@@ -6062,7 +6064,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec258049a5cda587b24523faf6b26ed0242765f4e732af21c4f42e42cf326714
-      lastVerified: '2026-05-17T14:15:04.417Z'
+      lastVerified: '2026-05-17T15:04:27.146Z'
     design-story-tmpl:
       path: .aiox-core/product/templates/design-story-tmpl.yaml
       layer: L2
@@ -6089,12 +6091,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2bfefc11ae2bcfc679dbd924c58f8b764fa23538c14cb25344d6edef41968f29
-      lastVerified: '2026-05-17T14:15:04.418Z'
+      lastVerified: '2026-05-17T15:04:27.146Z'
     ds-artifact-analysis:
       path: .aiox-core/product/templates/ds-artifact-analysis.md
       layer: L2
       type: template
-      purpose: 'Artifact Analysis Report #{{ARTIFACT_ID}}'
+      purpose: Entity at .aiox-core/product/templates/ds-artifact-analysis.md
       keywords:
         - ds
         - artifact
@@ -6112,7 +6114,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2ef1866841e4dcd55f9510f7ca14fd1f754f1e9c8a66cdc74d37ebcee13ede5d
-      lastVerified: '2026-05-17T14:15:04.418Z'
+      lastVerified: '2026-05-17T15:04:27.146Z'
     front-end-architecture-tmpl:
       path: .aiox-core/product/templates/front-end-architecture-tmpl.yaml
       layer: L2
@@ -6135,7 +6137,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de0432b4f98236c3a1d6cc9975b90fbc57727653bdcf6132355c0bcf0b4dbb9c
-      lastVerified: '2026-05-17T14:15:04.418Z'
+      lastVerified: '2026-05-17T15:04:27.147Z'
     front-end-spec-tmpl:
       path: .aiox-core/product/templates/front-end-spec-tmpl.yaml
       layer: L2
@@ -6158,7 +6160,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9033c7cccbd0893c11545c680f29c6743de8e7ad8e761c6c2487e2985b0a4411
-      lastVerified: '2026-05-17T14:15:04.419Z'
+      lastVerified: '2026-05-17T15:04:27.147Z'
     fullstack-architecture-tmpl:
       path: .aiox-core/product/templates/fullstack-architecture-tmpl.yaml
       layer: L2
@@ -6180,7 +6182,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1ac74304138be53d87808b8e4afe6f870936a1f3a9e35e18c3321b3d42145215
-      lastVerified: '2026-05-17T14:15:04.420Z'
+      lastVerified: '2026-05-17T15:04:27.148Z'
     github-actions-cd:
       path: .aiox-core/product/templates/github-actions-cd.yml
       layer: L2
@@ -6202,7 +6204,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e6d6f2da3909a76d188137962076988f8e639a8f580e278ddb076b917a159a63
-      lastVerified: '2026-05-17T14:15:04.420Z'
+      lastVerified: '2026-05-17T15:04:27.148Z'
     github-actions-ci:
       path: .aiox-core/product/templates/github-actions-ci.yml
       layer: L2
@@ -6224,7 +6226,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5628f43737eb39ba06d9c127dc42c9d89dc1ac712560ea948dee4cc3707fb517
-      lastVerified: '2026-05-17T14:15:04.420Z'
+      lastVerified: '2026-05-17T15:04:27.148Z'
     github-pr-template:
       path: .aiox-core/product/templates/github-pr-template.md
       layer: L2
@@ -6247,7 +6249,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:472729ec721fbf37ece2027861bb44e0d7a8f5a5f12d6fddb5b4a58a1fc34dd6
-      lastVerified: '2026-05-17T14:15:04.420Z'
+      lastVerified: '2026-05-17T15:04:27.148Z'
     gordon-mcp:
       path: .aiox-core/product/templates/gordon-mcp.yaml
       layer: L2
@@ -6269,7 +6271,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:54d961455a216f968bcb8234c5bf6cda3676e683f43dfcad7a18abc92dc767ab
-      lastVerified: '2026-05-17T14:15:04.420Z'
+      lastVerified: '2026-05-17T15:04:27.148Z'
     index-strategy-tmpl:
       path: .aiox-core/product/templates/index-strategy-tmpl.yaml
       layer: L2
@@ -6290,7 +6292,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6db2b40f6eef47f4faa31ce513ee7b0d5f04d9a5e081a72e0cdbad402eb444ae
-      lastVerified: '2026-05-17T14:15:04.420Z'
+      lastVerified: '2026-05-17T15:04:27.149Z'
     market-research-tmpl:
       path: .aiox-core/product/templates/market-research-tmpl.yaml
       layer: L2
@@ -6312,7 +6314,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a908f070009aa0403f9db542585401912aabe7913726bd2fa26b7954f162b674
-      lastVerified: '2026-05-17T14:15:04.421Z'
+      lastVerified: '2026-05-17T15:04:27.149Z'
     migration-plan-tmpl:
       path: .aiox-core/product/templates/migration-plan-tmpl.yaml
       layer: L2
@@ -6333,12 +6335,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d0b8580cab768484a2730b7a7f1032e2bab9643940d29dd3c351b7ac930e8ea1
-      lastVerified: '2026-05-17T14:15:04.421Z'
+      lastVerified: '2026-05-17T15:04:27.150Z'
     migration-strategy-tmpl:
       path: .aiox-core/product/templates/migration-strategy-tmpl.md
       layer: L2
       type: template
-      purpose: 'Migration Strategy: {{PROJECT_NAME}}'
+      purpose: Entity at .aiox-core/product/templates/migration-strategy-tmpl.md
       keywords:
         - migration
         - strategy
@@ -6356,12 +6358,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:957ffccbe9eb1f1ea90a8951ef9eb187d22e50c2f95c2ff048580892d2f2e25b
-      lastVerified: '2026-05-17T14:15:04.422Z'
+      lastVerified: '2026-05-17T15:04:27.151Z'
     personalized-agent-template:
       path: .aiox-core/product/templates/personalized-agent-template.md
       layer: L2
       type: template
-      purpose: '{agent-id}'
+      purpose: Entity at .aiox-core/product/templates/personalized-agent-template.md
       keywords:
         - personalized
         - agent
@@ -6377,7 +6379,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:64062d7d4756859c3522e2a228b9079d1c7a5e22c8d1da69a7f0aa148f6181f2
-      lastVerified: '2026-05-17T14:15:04.422Z'
+      lastVerified: '2026-05-17T15:04:27.152Z'
     personalized-checklist-template:
       path: .aiox-core/product/templates/personalized-checklist-template.md
       layer: L2
@@ -6402,12 +6404,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:269ea02fb70b16e94f84ca1910e1911b1fe9fb190f6ed6e22ced869bde3a2e2d
-      lastVerified: '2026-05-17T14:15:04.422Z'
+      lastVerified: '2026-05-17T15:04:27.152Z'
     personalized-task-template-v2:
       path: .aiox-core/product/templates/personalized-task-template-v2.md
       layer: L2
       type: template
-      purpose: '{Brief description of what this task does and when to use it}'
+      purpose: Entity at .aiox-core/product/templates/personalized-task-template-v2.md
       keywords:
         - personalized
         - task
@@ -6425,12 +6427,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:50dae1fdfd967c1713c76e51a418bb0d00f5d9546cade796973da94faac978d3
-      lastVerified: '2026-05-17T14:15:04.424Z'
+      lastVerified: '2026-05-17T15:04:27.152Z'
     personalized-task-template:
       path: .aiox-core/product/templates/personalized-task-template.md
       layer: L2
       type: template
-      purpose: '{Brief description of what this task does and when to use it}'
+      purpose: Entity at .aiox-core/product/templates/personalized-task-template.md
       keywords:
         - personalized
         - task
@@ -6447,7 +6449,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7d47e5603d8c950afcfd64dc54820bb93681c35f040a842dfcf7f77ead16f53f
-      lastVerified: '2026-05-17T14:15:04.424Z'
+      lastVerified: '2026-05-17T15:04:27.153Z'
     personalized-template-file:
       path: .aiox-core/product/templates/personalized-template-file.yaml
       layer: L2
@@ -6470,7 +6472,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8de995f022e873f8230000c07b55510c52c1477f30c4cd868f1c6fc5ffa9fd9b
-      lastVerified: '2026-05-17T14:15:04.424Z'
+      lastVerified: '2026-05-17T15:04:27.153Z'
     personalized-workflow-template:
       path: .aiox-core/product/templates/personalized-workflow-template.yaml
       layer: L2
@@ -6493,7 +6495,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2e61ec76a8638046aad135b3a8538810f32b1c7abc6353e35af61766453f74ba
-      lastVerified: '2026-05-17T14:15:04.425Z'
+      lastVerified: '2026-05-17T15:04:27.153Z'
     prd-tmpl:
       path: .aiox-core/product/templates/prd-tmpl.yaml
       layer: L2
@@ -6514,7 +6516,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:25c239f40e05f24aee1986601a98865188dbe3ea00a705028efc3adad6d420f3
-      lastVerified: '2026-05-17T14:15:04.425Z'
+      lastVerified: '2026-05-17T15:04:27.154Z'
     project-brief-tmpl:
       path: .aiox-core/product/templates/project-brief-tmpl.yaml
       layer: L2
@@ -6536,7 +6538,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b8d388268c24dc5018f48a87036d591b11cb122fafe9b59c17809b06ea5d9d58
-      lastVerified: '2026-05-17T14:15:04.425Z'
+      lastVerified: '2026-05-17T15:04:27.154Z'
     qa-gate-tmpl:
       path: .aiox-core/product/templates/qa-gate-tmpl.yaml
       layer: L2
@@ -6557,12 +6559,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a0d3e4a37ee8f719aacb8a31949522bfa239982198d0f347ea7d3f44ad8003ca
-      lastVerified: '2026-05-17T14:15:04.425Z'
+      lastVerified: '2026-05-17T15:04:27.154Z'
     qa-report-tmpl:
       path: .aiox-core/product/templates/qa-report-tmpl.md
       layer: L2
       type: template
-      purpose: 'QA Report: {{storyId}}'
+      purpose: Entity at .aiox-core/product/templates/qa-report-tmpl.md
       keywords:
         - qa
         - report
@@ -6579,7 +6581,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b2b0059050648fad63bfad7fa128225990b2fa6a6fb914902b2a5baf707c1cc6
-      lastVerified: '2026-05-17T14:15:04.425Z'
+      lastVerified: '2026-05-17T15:04:27.154Z'
     rls-policies-tmpl:
       path: .aiox-core/product/templates/rls-policies-tmpl.yaml
       layer: L2
@@ -6600,7 +6602,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3c303ab5a5f95c89f0caf9c632296e8ca43e29a921484523016c1c5bc320428f
-      lastVerified: '2026-05-17T14:15:04.426Z'
+      lastVerified: '2026-05-17T15:04:27.155Z'
     schema-design-tmpl:
       path: .aiox-core/product/templates/schema-design-tmpl.yaml
       layer: L2
@@ -6621,12 +6623,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7c5b7dfc67e1332e1fbf39657169094e2b92cd4fd6c7b441c3586981c732af95
-      lastVerified: '2026-05-17T14:15:04.426Z'
+      lastVerified: '2026-05-17T15:04:27.155Z'
     spec-tmpl:
       path: .aiox-core/product/templates/spec-tmpl.md
       layer: L2
       type: template
-      purpose: 'Spec: {{story-title}}'
+      purpose: Entity at .aiox-core/product/templates/spec-tmpl.md
       keywords:
         - spec
         - tmpl
@@ -6642,7 +6644,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ff625ad82e4e0f07c137ab5cd0567caac7980ab985783d2f76443dc900bffa5
-      lastVerified: '2026-05-17T14:15:04.426Z'
+      lastVerified: '2026-05-17T15:04:27.156Z'
     state-persistence-tmpl:
       path: .aiox-core/product/templates/state-persistence-tmpl.yaml
       layer: L2
@@ -6666,7 +6668,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7ff9caabce83ccc14acb05e9d06eaf369a8ebd54c2ddf4988efcc942f6c51037
-      lastVerified: '2026-05-17T14:15:04.427Z'
+      lastVerified: '2026-05-17T15:04:27.156Z'
     story-tmpl:
       path: .aiox-core/product/templates/story-tmpl.yaml
       layer: L2
@@ -6697,7 +6699,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0b64b49e5332cbce7d36da1ff40495628cb6ce650855b752dc82372706d41e13
-      lastVerified: '2026-05-17T14:15:04.427Z'
+      lastVerified: '2026-05-17T15:04:27.156Z'
     task-execution-report:
       path: .aiox-core/product/templates/task-execution-report.md
       layer: L2
@@ -6718,12 +6720,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e0f08a3e199234f3d2207ba8f435786b7d8e1b36174f46cb82fc3666b9a9309e
-      lastVerified: '2026-05-17T14:15:04.427Z'
+      lastVerified: '2026-05-17T15:04:27.157Z'
     task-template:
       path: .aiox-core/product/templates/task-template.md
       layer: L2
       type: template
-      purpose: '{{TASK_TITLE}}'
+      purpose: Entity at .aiox-core/product/templates/task-template.md
       keywords:
         - task
         - template
@@ -6739,7 +6741,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:aeb3a2843c1ca70a094601573899a47bb5956f3b5cd7a8bbad9d624ae39cf1fe
-      lastVerified: '2026-05-17T14:15:04.427Z'
+      lastVerified: '2026-05-17T15:04:27.157Z'
     tokens-schema-tmpl:
       path: .aiox-core/product/templates/tokens-schema-tmpl.yaml
       layer: L2
@@ -6761,7 +6763,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:66a7c164278cbe8b41dcc8525e382bdf5c59673a6694930aa33b857f199b4c2b
-      lastVerified: '2026-05-17T14:15:04.428Z'
+      lastVerified: '2026-05-17T15:04:27.157Z'
     workflow-template:
       path: .aiox-core/product/templates/workflow-template.yaml
       layer: L2
@@ -6783,7 +6785,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7185fbc069702ef6c4444c2c0cbf3d95f692435406ab3cad811768de4b7d4a28
-      lastVerified: '2026-05-17T14:15:04.428Z'
+      lastVerified: '2026-05-17T15:04:27.157Z'
     antigravity-rules:
       path: .aiox-core/product/templates/ide-rules/antigravity-rules.md
       layer: L2
@@ -6812,7 +6814,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:150fd84d590c2d41f169afdc2368743cb5a90a94a29df2f217b5e5a8e9c3ee1b
-      lastVerified: '2026-05-17T14:15:04.428Z'
+      lastVerified: '2026-05-17T15:04:27.158Z'
     claude-rules:
       path: .aiox-core/product/templates/ide-rules/claude-rules.md
       layer: L2
@@ -6845,7 +6847,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d5723c0a6d77b7137e9b8699937841f7452302b60905cd35276a319e6ce01742
-      lastVerified: '2026-05-17T14:15:04.428Z'
+      lastVerified: '2026-05-17T15:04:27.158Z'
     codex-rules:
       path: .aiox-core/product/templates/ide-rules/codex-rules.md
       layer: L2
@@ -6880,7 +6882,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:18302f137bda51c687b7c7ad76a17f73d84a1e254801ab9e72837d577962b7c5
-      lastVerified: '2026-05-17T14:15:04.429Z'
+      lastVerified: '2026-05-17T15:04:27.158Z'
     copilot-rules:
       path: .aiox-core/product/templates/ide-rules/copilot-rules.md
       layer: L2
@@ -6903,7 +6905,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5f7ecf4f6dbac28bc49b3a61d0902dcc28023b2918082195aab721b0a24847be
-      lastVerified: '2026-05-17T14:15:04.429Z'
+      lastVerified: '2026-05-17T15:04:27.158Z'
     cursor-rules:
       path: .aiox-core/product/templates/ide-rules/cursor-rules.md
       layer: L2
@@ -6932,7 +6934,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ea607f2b6a089afccbcaaec3b1197b5396c4446e76a689a51867a78bceda09b2
-      lastVerified: '2026-05-17T14:15:04.429Z'
+      lastVerified: '2026-05-17T15:04:27.159Z'
     gemini-rules:
       path: .aiox-core/product/templates/ide-rules/gemini-rules.md
       layer: L2
@@ -6953,7 +6955,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:20f687384c4deb909e9171f8e83f40b962a9cc717755b62d88db285316b2188a
-      lastVerified: '2026-05-17T14:15:04.429Z'
+      lastVerified: '2026-05-17T15:04:27.159Z'
   scripts:
     activation-runtime:
       path: .aiox-core/development/scripts/activation-runtime.js
@@ -6975,7 +6977,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3750084310b5a88e2f8d345ad4b417a408f2633d10dab11f4d648e8e10caa90c
-      lastVerified: '2026-05-17T14:15:04.430Z'
+      lastVerified: '2026-05-17T15:04:27.160Z'
     agent-assignment-resolver:
       path: .aiox-core/development/scripts/agent-assignment-resolver.js
       layer: L2
@@ -6995,7 +6997,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ae8a89d038cd9af894d9ec45d8b97ed930f84f70e88f17dbf1a3c556e336c75e
-      lastVerified: '2026-05-17T14:15:04.431Z'
+      lastVerified: '2026-05-17T15:04:27.161Z'
     agent-config-loader:
       path: .aiox-core/development/scripts/agent-config-loader.js
       layer: L2
@@ -7020,7 +7022,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6935a5574f887d88101c44340a96f2a4f8d01b2bdeb433108b84253178a106c7
-      lastVerified: '2026-05-17T14:15:04.431Z'
+      lastVerified: '2026-05-17T15:04:27.161Z'
     agent-exit-hooks:
       path: .aiox-core/development/scripts/agent-exit-hooks.js
       layer: L2
@@ -7041,7 +7043,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7aee7f33cae1bc4192a5085898caaf57f4866ce68488637d0f90a6372b616ce8
-      lastVerified: '2026-05-17T14:15:04.432Z'
+      lastVerified: '2026-05-17T15:04:27.162Z'
     apply-inline-greeting-all-agents:
       path: .aiox-core/development/scripts/apply-inline-greeting-all-agents.js
       layer: L2
@@ -7063,7 +7065,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5de6a7ddcab1ae34043b8a030b664deb9ce79e187ca30d22656716240e76a030
-      lastVerified: '2026-05-17T14:15:04.432Z'
+      lastVerified: '2026-05-17T15:04:27.162Z'
     approval-workflow:
       path: .aiox-core/development/scripts/approval-workflow.js
       layer: L2
@@ -7082,7 +7084,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:06979905e62b61e6dde1d2e1714ce61b9a4538a31f31ae1e5f41365f36395b09
-      lastVerified: '2026-05-17T14:15:04.432Z'
+      lastVerified: '2026-05-17T15:04:27.162Z'
     audit-agent-config:
       path: .aiox-core/development/scripts/audit-agent-config.js
       layer: L2
@@ -7102,7 +7104,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d3908286737b3951a0140224aae604d63ab485d503d1f0fb83bc902112637db0
-      lastVerified: '2026-05-17T14:15:04.432Z'
+      lastVerified: '2026-05-17T15:04:27.162Z'
     backlog-manager:
       path: .aiox-core/development/scripts/backlog-manager.js
       layer: L2
@@ -7124,7 +7126,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7790e867301aed155dcad303feb8113ffd45abe99052e70749ceaae894e9620b
-      lastVerified: '2026-05-17T14:15:04.433Z'
+      lastVerified: '2026-05-17T15:04:27.163Z'
     backup-manager:
       path: .aiox-core/development/scripts/backup-manager.js
       layer: L2
@@ -7145,7 +7147,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:81c9fd6a4b8a8e7feb1f7a9d6ba790e597ad8113a9ca0723ae20eb111bfb3cee
-      lastVerified: '2026-05-17T14:15:04.433Z'
+      lastVerified: '2026-05-17T15:04:27.163Z'
     batch-update-agents-session-context:
       path: .aiox-core/development/scripts/batch-update-agents-session-context.js
       layer: L2
@@ -7167,7 +7169,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d6fa38b55d788f0832021a15492d6b19d8967b481c05b87ab67d33a90ff7269b
-      lastVerified: '2026-05-17T14:15:04.433Z'
+      lastVerified: '2026-05-17T15:04:27.163Z'
     branch-manager:
       path: .aiox-core/development/scripts/branch-manager.js
       layer: L2
@@ -7187,7 +7189,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5d292b329fea370ee9e0930c5d6e9cb5c69af78ec1435ee194ddba0c3d2232a1
-      lastVerified: '2026-05-17T14:15:04.433Z'
+      lastVerified: '2026-05-17T15:04:27.163Z'
     code-quality-improver:
       path: .aiox-core/development/scripts/code-quality-improver.js
       layer: L2
@@ -7207,7 +7209,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d0c844089e53dcd6c06755d4cb432a60fbebcedcf5a86ed635650573549a1941
-      lastVerified: '2026-05-17T14:15:04.434Z'
+      lastVerified: '2026-05-17T15:04:27.164Z'
     commit-message-generator:
       path: .aiox-core/development/scripts/commit-message-generator.js
       layer: L2
@@ -7229,7 +7231,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c5990a5a012a2994d9a4d29ded445fef21d51e0b8203292104fbbd76b3e23826
-      lastVerified: '2026-05-17T14:15:04.434Z'
+      lastVerified: '2026-05-17T15:04:27.165Z'
     conflict-resolver:
       path: .aiox-core/development/scripts/conflict-resolver.js
       layer: L2
@@ -7249,7 +7251,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8971b9aca2ab23a9478ac70e59710ec843f483fcbe088371444f4fc9b56c5278
-      lastVerified: '2026-05-17T14:15:04.435Z'
+      lastVerified: '2026-05-17T15:04:27.165Z'
     decision-context:
       path: .aiox-core/development/scripts/decision-context.js
       layer: L2
@@ -7269,7 +7271,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7deca4e738f078e2ccded6e8e26d2322697ea7b9fedf5a48fe8eec18e227c347
-      lastVerified: '2026-05-17T14:15:04.435Z'
+      lastVerified: '2026-05-17T15:04:27.165Z'
     decision-log-generator:
       path: .aiox-core/development/scripts/decision-log-generator.js
       layer: L2
@@ -7296,7 +7298,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:15f1c67d72d2572c68cf8738dfc549166c424475f6706502496f4e21596db504
-      lastVerified: '2026-05-17T14:15:04.435Z'
+      lastVerified: '2026-05-17T15:04:27.165Z'
     decision-log-indexer:
       path: .aiox-core/development/scripts/decision-log-indexer.js
       layer: L2
@@ -7317,7 +7319,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4525176b92aefc6ea7387fc350e325192af044769b4774fde5bf35d74f93fd56
-      lastVerified: '2026-05-17T14:15:04.435Z'
+      lastVerified: '2026-05-17T15:04:27.166Z'
     decision-recorder:
       path: .aiox-core/development/scripts/decision-recorder.js
       layer: L2
@@ -7340,7 +7342,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73a259407434e4c4653232e578d408ea6dbde5b809a8c16b7cb169933b941c1c
-      lastVerified: '2026-05-17T14:15:04.436Z'
+      lastVerified: '2026-05-17T15:04:27.166Z'
     dependency-analyzer:
       path: .aiox-core/development/scripts/dependency-analyzer.js
       layer: L2
@@ -7359,7 +7361,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0ab1a54c3df1cd81c8bc4b7f4d769f91c7b0bfa6ce38b8c7e1d7d5b223d2245f
-      lastVerified: '2026-05-17T14:15:04.436Z'
+      lastVerified: '2026-05-17T15:04:27.166Z'
     dev-context-loader:
       path: .aiox-core/development/scripts/dev-context-loader.js
       layer: L2
@@ -7379,7 +7381,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0db8d8c4ec863935b02263560d90a901462fb51a87e922baee26882c9d3b8f7c
-      lastVerified: '2026-05-17T14:15:04.436Z'
+      lastVerified: '2026-05-17T15:04:27.167Z'
     diff-generator:
       path: .aiox-core/development/scripts/diff-generator.js
       layer: L2
@@ -7398,7 +7400,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cad97b0096fc034fa6ed6cbd14a963abe32d880c1ce8034b6aa62af2e2239833
-      lastVerified: '2026-05-17T14:15:04.436Z'
+      lastVerified: '2026-05-17T15:04:27.167Z'
     elicitation-engine:
       path: .aiox-core/development/scripts/elicitation-engine.js
       layer: L2
@@ -7419,7 +7421,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ce7ea9b9c7e3600fcec27eee444a2860c15ec187ca449f3b63564f453d71c50
-      lastVerified: '2026-05-17T14:15:04.436Z'
+      lastVerified: '2026-05-17T15:04:27.167Z'
     elicitation-session-manager:
       path: .aiox-core/development/scripts/elicitation-session-manager.js
       layer: L2
@@ -7440,7 +7442,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0a7141f2cf61e8fa32f8c861633b50e87e75bc6023b650756c1b55ad947d314b
-      lastVerified: '2026-05-17T14:15:04.437Z'
+      lastVerified: '2026-05-17T15:04:27.168Z'
     generate-greeting:
       path: .aiox-core/development/scripts/generate-greeting.js
       layer: L2
@@ -7460,7 +7462,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:49b857fe36a0216a0df8395a6847f14608bd6a228817276201d22598a6862a4f
-      lastVerified: '2026-05-17T14:15:04.437Z'
+      lastVerified: '2026-05-17T15:04:27.168Z'
     git-wrapper:
       path: .aiox-core/development/scripts/git-wrapper.js
       layer: L2
@@ -7480,7 +7482,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ca880db21647162725bbc5bcd4a01613ad2cc4911aa829a9b9242a05bb62283a
-      lastVerified: '2026-05-17T14:15:04.437Z'
+      lastVerified: '2026-05-17T15:04:27.168Z'
     greeting-builder:
       path: .aiox-core/development/scripts/greeting-builder.js
       layer: L2
@@ -7511,7 +7513,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dd0c50dc690a44fdddd9cf8adde609ea0ef2aa6916a78b9fcc971195ddff5656
-      lastVerified: '2026-05-17T14:15:04.438Z'
+      lastVerified: '2026-05-17T15:04:27.170Z'
     greeting-config-cli:
       path: .aiox-core/development/scripts/greeting-config-cli.js
       layer: L2
@@ -7532,7 +7534,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c6e5c4dac08349b17cae64562311a5c2fab8d7c29bc96d86cbe2b43846312b3d
-      lastVerified: '2026-05-17T14:15:04.439Z'
+      lastVerified: '2026-05-17T15:04:27.170Z'
     greeting-preference-manager:
       path: .aiox-core/development/scripts/greeting-preference-manager.js
       layer: L2
@@ -7555,7 +7557,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f6e8034fb7eb27a05f0ef186351282073c3e9b7d5d1db67fb88814c9b72fc219
-      lastVerified: '2026-05-17T14:15:04.439Z'
+      lastVerified: '2026-05-17T15:04:27.170Z'
     issue-triage:
       path: .aiox-core/development/scripts/issue-triage.js
       layer: L2
@@ -7574,7 +7576,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a9f9741b1426732f19803bf9f292b15d8eed0fb875cf02df70735f48512f2310
-      lastVerified: '2026-05-17T14:15:04.439Z'
+      lastVerified: '2026-05-17T15:04:27.170Z'
     manifest-preview:
       path: .aiox-core/development/scripts/manifest-preview.js
       layer: L2
@@ -7595,7 +7597,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:93fff0b2f1993f1f03352a8d9162b93368a7f3b0caf1223ea23b228d092d2084
-      lastVerified: '2026-05-17T14:15:04.439Z'
+      lastVerified: '2026-05-17T15:04:27.171Z'
     metrics-tracker:
       path: .aiox-core/development/scripts/metrics-tracker.js
       layer: L2
@@ -7615,7 +7617,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ac90ed08276a66591c8170ef5b5501f46cb1ba9d276b383e20fc77a563083312
-      lastVerified: '2026-05-17T14:15:04.439Z'
+      lastVerified: '2026-05-17T15:04:27.171Z'
     migrate-task-to-v2:
       path: .aiox-core/development/scripts/migrate-task-to-v2.js
       layer: L2
@@ -7636,7 +7638,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6bfef70de9592d53657f10a4e5c4582ac0ff11868d29e78b86676db45816152d
-      lastVerified: '2026-05-17T14:15:04.440Z'
+      lastVerified: '2026-05-17T15:04:27.171Z'
     modification-validator:
       path: .aiox-core/development/scripts/modification-validator.js
       layer: L2
@@ -7658,7 +7660,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8bff78c5ce3a7c1add30f21f3b835aafd1b54b1752b7f24fc687a672026d7b13
-      lastVerified: '2026-05-17T14:15:04.440Z'
+      lastVerified: '2026-05-17T15:04:27.172Z'
     pattern-learner:
       path: .aiox-core/development/scripts/pattern-learner.js
       layer: L2
@@ -7678,7 +7680,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d562b095bd15dc12a4f474883a1ddb25fa4b7353729c1ff1eaa53675b964de52
-      lastVerified: '2026-05-17T14:15:04.440Z'
+      lastVerified: '2026-05-17T15:04:27.172Z'
     performance-analyzer:
       path: .aiox-core/development/scripts/performance-analyzer.js
       layer: L2
@@ -7697,7 +7699,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:52fc6c7dd22d7bdbbdfe51393c845075ee4fad75067fd91665682b9f0654e7c4
-      lastVerified: '2026-05-17T14:15:04.441Z'
+      lastVerified: '2026-05-17T15:04:27.172Z'
     populate-entity-registry:
       path: .aiox-core/development/scripts/populate-entity-registry.js
       layer: L2
@@ -7717,8 +7719,8 @@ entities:
         score: 0.7
         constraints: []
         extensionPoints: []
-      checksum: sha256:2bdf871a3435304f69044bd7463c94647316f7d43e5b891c80c5f181f0f01401
-      lastVerified: '2026-05-17T14:15:04.441Z'
+      checksum: sha256:65cc968e9fa82bb18390ee0ed7063082b5341a441b83a9778638f1ce4064ab23
+      lastVerified: '2026-05-17T15:04:27.172Z'
     refactoring-suggester:
       path: .aiox-core/development/scripts/refactoring-suggester.js
       layer: L2
@@ -7737,7 +7739,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d50ea6b609c9cf8385979386fee4b4385d11ebcde15460260f66d04c705f6cd9
-      lastVerified: '2026-05-17T14:15:04.441Z'
+      lastVerified: '2026-05-17T15:04:27.173Z'
     rollback-handler:
       path: .aiox-core/development/scripts/rollback-handler.js
       layer: L2
@@ -7758,7 +7760,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1017334a2fcc7c13cf46f12da127525435c0689e4d123d44156699431e941cd8
-      lastVerified: '2026-05-17T14:15:04.442Z'
+      lastVerified: '2026-05-17T15:04:27.173Z'
     security-checker:
       path: .aiox-core/development/scripts/security-checker.js
       layer: L2
@@ -7777,7 +7779,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e567af91b0b79e7ba51399cf6bfe4279417e632465f923bc8334c28f9405883c
-      lastVerified: '2026-05-17T14:15:04.442Z'
+      lastVerified: '2026-05-17T15:04:27.173Z'
     skill-validator:
       path: .aiox-core/development/scripts/skill-validator.js
       layer: L2
@@ -7796,7 +7798,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b6bab880896a6fdb16d288c11e1d8fe3fa9f57f144b213bcb6eca1560ec38af1
-      lastVerified: '2026-05-17T14:15:04.442Z'
+      lastVerified: '2026-05-17T15:04:27.174Z'
     story-index-generator:
       path: .aiox-core/development/scripts/story-index-generator.js
       layer: L2
@@ -7817,7 +7819,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c9ce1d2f89e76b9b2250aaa2b49a2881fc331dfbdec0bc0c5b7e1ec7767af140
-      lastVerified: '2026-05-17T14:15:04.442Z'
+      lastVerified: '2026-05-17T15:04:27.174Z'
     story-manager:
       path: .aiox-core/development/scripts/story-manager.js
       layer: L2
@@ -7843,7 +7845,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ba05c6dc3b29dad5ca57b0dafad8951d750bc30bdc04a9b083d4878c6f84f8f2
-      lastVerified: '2026-05-17T14:15:04.442Z'
+      lastVerified: '2026-05-17T15:04:27.175Z'
     story-update-hook:
       path: .aiox-core/development/scripts/story-update-hook.js
       layer: L2
@@ -7865,7 +7867,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:554a162e434717f86858ef04d8fdfe3ac40decf060cdc3d4d4987959fb2c51df
-      lastVerified: '2026-05-17T14:15:04.443Z'
+      lastVerified: '2026-05-17T15:04:27.175Z'
     task-identifier-resolver:
       path: .aiox-core/development/scripts/task-identifier-resolver.js
       layer: L2
@@ -7885,7 +7887,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ef63e5302a7393d4409e50fc437fdf33bd85f40b1907862ccfd507188f072d22
-      lastVerified: '2026-05-17T14:15:04.443Z'
+      lastVerified: '2026-05-17T15:04:27.177Z'
     template-engine:
       path: .aiox-core/development/scripts/template-engine.js
       layer: L2
@@ -7904,7 +7906,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b97d091cb9a09e64d8632ae106cd00b3fd8a25bfbdb60d8cda6e5591c7dfd67f
-      lastVerified: '2026-05-17T14:15:04.443Z'
+      lastVerified: '2026-05-17T15:04:27.178Z'
     template-validator:
       path: .aiox-core/development/scripts/template-validator.js
       layer: L2
@@ -7924,7 +7926,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fb87e8d076b57469d33034f2cae32fd01eae81900317a267d26ab18eebaacb17
-      lastVerified: '2026-05-17T14:15:04.443Z'
+      lastVerified: '2026-05-17T15:04:27.178Z'
     test-generator:
       path: .aiox-core/development/scripts/test-generator.js
       layer: L2
@@ -7943,7 +7945,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c49f0d828ba4e5d996f6dc4fedd540fe2a95091de5e45093018686181493d164
-      lastVerified: '2026-05-17T14:15:04.443Z'
+      lastVerified: '2026-05-17T15:04:27.179Z'
     test-greeting-system:
       path: .aiox-core/development/scripts/test-greeting-system.js
       layer: L2
@@ -7964,7 +7966,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:598f32f09db543e67c0e79da78aaa6e2c78eb54b8f91a5014a27c67468e663bb
-      lastVerified: '2026-05-17T14:15:04.444Z'
+      lastVerified: '2026-05-17T15:04:27.179Z'
     transaction-manager:
       path: .aiox-core/development/scripts/transaction-manager.js
       layer: L2
@@ -7984,7 +7986,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c1049e40ffa489206b48a8c95b0a55093ebf95fc2b2fb522e33b0fc8023d7d2a
-      lastVerified: '2026-05-17T14:15:04.444Z'
+      lastVerified: '2026-05-17T15:04:27.179Z'
     unified-activation-pipeline:
       path: .aiox-core/development/scripts/unified-activation-pipeline.js
       layer: L2
@@ -8016,7 +8018,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6910a7f6b0cef65a0886e0b29bbcb0ee401ca4fb444eb255a7a368cb67327aa7
-      lastVerified: '2026-05-17T14:15:04.445Z'
+      lastVerified: '2026-05-17T15:04:27.180Z'
     usage-tracker:
       path: .aiox-core/development/scripts/usage-tracker.js
       layer: L2
@@ -8036,7 +8038,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6057623755bf0ee1d9e0fb36740fc41914a5f8ca8ad994d40edec260e273744b
-      lastVerified: '2026-05-17T14:15:04.445Z'
+      lastVerified: '2026-05-17T15:04:27.181Z'
     validate-filenames:
       path: .aiox-core/development/scripts/validate-filenames.js
       layer: L2
@@ -8055,7 +8057,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0228b1538ff02dfe1f747038cbb5e86630683a3c950e27d6315bcd762b1a93fd
-      lastVerified: '2026-05-17T14:15:04.446Z'
+      lastVerified: '2026-05-17T15:04:27.181Z'
     validate-task-v2:
       path: .aiox-core/development/scripts/validate-task-v2.js
       layer: L2
@@ -8075,7 +8077,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4abe50b097c2d0f7a722b691ecd84021ea48b76a017ad76f4c49f748d002fe09
-      lastVerified: '2026-05-17T14:15:04.446Z'
+      lastVerified: '2026-05-17T15:04:27.181Z'
     verify-workflow-gaps:
       path: .aiox-core/development/scripts/verify-workflow-gaps.js
       layer: L2
@@ -8101,7 +8103,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a06a3fac2c4fdf995f18d6108d48855a1156b763ef906a3943b94dc9a709c167
-      lastVerified: '2026-05-17T14:15:04.446Z'
+      lastVerified: '2026-05-17T15:04:27.182Z'
     version-tracker:
       path: .aiox-core/development/scripts/version-tracker.js
       layer: L2
@@ -8120,7 +8122,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d11804b82497e2a9c6e83191095681f5d57ac956b69975294f3f9d2efd0a7bdd
-      lastVerified: '2026-05-17T14:15:04.447Z'
+      lastVerified: '2026-05-17T15:04:27.182Z'
     workflow-navigator:
       path: .aiox-core/development/scripts/workflow-navigator.js
       layer: L2
@@ -8142,7 +8144,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e9af315c4b6ed0f3a0ccc0956921b04f75865a019ada427bdb1d871a1a059bcb
-      lastVerified: '2026-05-17T14:15:04.447Z'
+      lastVerified: '2026-05-17T15:04:27.182Z'
     workflow-state-manager:
       path: .aiox-core/development/scripts/workflow-state-manager.js
       layer: L2
@@ -8165,7 +8167,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:34b249724bb9b4625b4c6e0c67f412d341927323278867367faf8999d09e741c
-      lastVerified: '2026-05-17T14:15:04.447Z'
+      lastVerified: '2026-05-17T15:04:27.182Z'
     workflow-validator:
       path: .aiox-core/development/scripts/workflow-validator.js
       layer: L2
@@ -8189,7 +8191,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:abb16e5cd34ec06bbca0a31af3fc500c3a5c98f66d0a72546e4a2827653abcd3
-      lastVerified: '2026-05-17T14:15:04.447Z'
+      lastVerified: '2026-05-17T15:04:27.183Z'
     yaml-validator:
       path: .aiox-core/development/scripts/yaml-validator.js
       layer: L2
@@ -8208,7 +8210,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:916864f9e56e1ccb7fc1596bd2da47400e4037f848a0d4e2bc46d0fa24cc544f
-      lastVerified: '2026-05-17T14:15:04.448Z'
+      lastVerified: '2026-05-17T15:04:27.183Z'
     index:
       path: .aiox-core/development/scripts/squad/index.js
       layer: L2
@@ -8234,7 +8236,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d9bab56298104c00cc55d5e68bcf8bf660bc0f2a3f8c7609dc2ed911d34a4492
-      lastVerified: '2026-05-17T14:15:04.448Z'
+      lastVerified: '2026-05-17T15:04:27.183Z'
     squad-analyzer:
       path: .aiox-core/development/scripts/squad/squad-analyzer.js
       layer: L2
@@ -8254,7 +8256,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3aa6fd5273ee0cc35331d4150ed98ef43e8ab678c7c7eaaf4b6ea4b40c657b0c
-      lastVerified: '2026-05-17T14:15:04.448Z'
+      lastVerified: '2026-05-17T15:04:27.184Z'
     squad-designer:
       path: .aiox-core/development/scripts/squad/squad-designer.js
       layer: L2
@@ -8277,7 +8279,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:101cbb7d6ded0d6f991b29ac63dfee2c7bb86cbc8c4fefef728b7d12c3352829
-      lastVerified: '2026-05-17T14:15:04.449Z'
+      lastVerified: '2026-05-17T15:04:27.184Z'
     squad-downloader:
       path: .aiox-core/development/scripts/squad/squad-downloader.js
       layer: L2
@@ -8299,12 +8301,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e171444c33222c3ee7b34a874ce2298de010ddf9f883d9741084621084564dc9
-      lastVerified: '2026-05-17T14:15:04.449Z'
+      lastVerified: '2026-05-17T15:04:27.184Z'
     squad-extender:
       path: .aiox-core/development/scripts/squad/squad-extender.js
       layer: L2
       type: script
-      purpose: ${context.componentName}
+      purpose: Entity at .aiox-core/development/scripts/squad/squad-extender.js
       keywords:
         - squad
         - extender
@@ -8320,12 +8322,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de3ee647aa5d1fb32a4216777f3bd4716022fec64f0566c0a004b0ea4d110cca
-      lastVerified: '2026-05-17T14:15:04.449Z'
+      lastVerified: '2026-05-17T15:04:27.185Z'
     squad-generator:
       path: .aiox-core/development/scripts/squad/squad-generator.js
       layer: L2
       type: script
-      purpose: '*${taskName.replace(/-/g, ''-'')}'
+      purpose: Entity at .aiox-core/development/scripts/squad/squad-generator.js
       keywords:
         - squad
         - generator
@@ -8344,7 +8346,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c8c75b71af915c95b781662ba5cdee5899fd6842966fd8b90019923e091be575
-      lastVerified: '2026-05-17T14:15:04.450Z'
+      lastVerified: '2026-05-17T15:04:27.185Z'
     squad-loader:
       path: .aiox-core/development/scripts/squad/squad-loader.js
       layer: L2
@@ -8370,7 +8372,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7093b9457c93da6845722bf7eac660164963d5007c459afae2149340a7979f1f
-      lastVerified: '2026-05-17T14:15:04.450Z'
+      lastVerified: '2026-05-17T15:04:27.186Z'
     squad-migrator:
       path: .aiox-core/development/scripts/squad/squad-migrator.js
       layer: L2
@@ -8391,7 +8393,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:38d7906b3718701130c79ed66f2916710f0f13fb2d445b13e8cdb1c199192a0d
-      lastVerified: '2026-05-17T14:15:04.450Z'
+      lastVerified: '2026-05-17T15:04:27.186Z'
     squad-publisher:
       path: .aiox-core/development/scripts/squad/squad-publisher.js
       layer: L2
@@ -8413,7 +8415,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:73b3adcf1b6edb16cd1679fe37852d1f2fde5c89cee4ea7b0ae8ca95f7ff85d2
-      lastVerified: '2026-05-17T14:15:04.451Z'
+      lastVerified: '2026-05-17T15:04:27.186Z'
     squad-validator:
       path: .aiox-core/development/scripts/squad/squad-validator.js
       layer: L2
@@ -8442,7 +8444,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bba0ca266653ca7d6162de011165256e6e49ebe34f2136ae16a4c3393901ab27
-      lastVerified: '2026-05-17T14:15:04.451Z'
+      lastVerified: '2026-05-17T15:04:27.187Z'
   modules:
     index.esm:
       path: .aiox-core/core/index.esm.js
@@ -8473,7 +8475,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:10586193db3efc151c4347d24786a657a01f611a0ffb55ce4008e62c6fe89e40
-      lastVerified: '2026-05-17T14:15:04.459Z'
+      lastVerified: '2026-05-17T15:04:27.191Z'
     index:
       path: .aiox-core/core/index.js
       layer: L1
@@ -8506,7 +8508,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b09d5546bdb1507c60ddc5dc9b48760b55e4e6a4ccc8fdcb63e168e8ea334b13
-      lastVerified: '2026-05-17T14:15:04.459Z'
+      lastVerified: '2026-05-17T15:04:27.191Z'
     code-intel-client:
       path: .aiox-core/core/code-intel/code-intel-client.js
       layer: L1
@@ -8529,7 +8531,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c9a08a37775acf90397aa079a4ad2c5edcc47f2cfd592b26ae9f3d154d1deb8
-      lastVerified: '2026-05-17T14:15:04.459Z'
+      lastVerified: '2026-05-17T15:04:27.192Z'
     code-intel-enricher:
       path: .aiox-core/core/code-intel/code-intel-enricher.js
       layer: L1
@@ -8550,7 +8552,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ee54acdce08258a5f52ee51b38e5c4ffe727e42c8682818120addf7f6863549f
-      lastVerified: '2026-05-17T14:15:04.460Z'
+      lastVerified: '2026-05-17T15:04:27.192Z'
     hook-runtime:
       path: .aiox-core/core/code-intel/hook-runtime.js
       layer: L1
@@ -8570,7 +8572,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4d812dc503650ef90249ad2993b3f713aea806138a27455a6a9757329d829c8e
-      lastVerified: '2026-05-17T14:15:04.460Z'
+      lastVerified: '2026-05-17T15:04:27.192Z'
     code-intel-index:
       path: .aiox-core/core/code-intel/index.js
       layer: L1
@@ -8596,7 +8598,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c8103fb966def9e8ed53dc1840e0e853b5fa4f13291a73a179cbae3545f38754
-      lastVerified: '2026-05-17T14:15:04.460Z'
+      lastVerified: '2026-05-17T15:04:27.193Z'
     registry-syncer:
       path: .aiox-core/core/code-intel/registry-syncer.js
       layer: L1
@@ -8618,7 +8620,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0fc20a7f90fc1ac2078878267db64517fd2ae75d8d2a81101d0cac77d1bf6458
-      lastVerified: '2026-05-17T14:15:04.461Z'
+      lastVerified: '2026-05-17T15:04:27.193Z'
     config-cache:
       path: .aiox-core/core/config/config-cache.js
       layer: L1
@@ -8637,7 +8639,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9f3c3f90f574d5f49dd94592ab28109465d025b3a740d8639ab781c2560c12ab
-      lastVerified: '2026-05-17T14:15:04.461Z'
+      lastVerified: '2026-05-17T15:04:27.194Z'
     config-loader:
       path: .aiox-core/core/config/config-loader.js
       layer: L1
@@ -8658,7 +8660,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:05c8cfa5fe8c0bd659ac65791e5b551767e581a465cad6bb42a9c0a31847e4b4
-      lastVerified: '2026-05-17T14:15:04.461Z'
+      lastVerified: '2026-05-17T15:04:27.194Z'
     config-resolver:
       path: .aiox-core/core/config/config-resolver.js
       layer: L1
@@ -8685,7 +8687,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3b29df6954cec440debef87cb4e4e7610c94dc74e562d32c74b8ec57d893213b
-      lastVerified: '2026-05-17T14:15:04.462Z'
+      lastVerified: '2026-05-17T15:04:27.195Z'
     env-interpolator:
       path: .aiox-core/core/config/env-interpolator.js
       layer: L1
@@ -8706,7 +8708,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d9d9782d1c685fc1734034f656903ff35ac71665c0bedb3fc479544c89d1ece1
-      lastVerified: '2026-05-17T14:15:04.462Z'
+      lastVerified: '2026-05-17T15:04:27.195Z'
     merge-utils:
       path: .aiox-core/core/config/merge-utils.js
       layer: L1
@@ -8728,7 +8730,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e25cb65f4c4e855cfeb4acced46d64a8c9cf7e55a97ac051ec3d985b8855c823
-      lastVerified: '2026-05-17T14:15:04.462Z'
+      lastVerified: '2026-05-17T15:04:27.196Z'
     migrate-config:
       path: .aiox-core/core/config/migrate-config.js
       layer: L1
@@ -8747,7 +8749,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5f46e718e0891d6bf5f46d0f9375960a8e12d010b9699cb287bd0fe71f252f41
-      lastVerified: '2026-05-17T14:15:04.462Z'
+      lastVerified: '2026-05-17T15:04:27.196Z'
     template-overrides:
       path: .aiox-core/core/config/template-overrides.js
       layer: L1
@@ -8766,7 +8768,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:202d141a292bc5a8dd0697e044d7627b260839ae8b7119fd40ae486b3a1b0825
-      lastVerified: '2026-05-17T14:15:04.462Z'
+      lastVerified: '2026-05-17T15:04:27.196Z'
     fix-handler:
       path: .aiox-core/core/doctor/fix-handler.js
       layer: L1
@@ -8788,7 +8790,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c8255536f08a622b2773819080bdbf5d65f8f3f43b77eb257d98064cd74903a3
-      lastVerified: '2026-05-17T14:15:04.463Z'
+      lastVerified: '2026-05-17T15:04:27.197Z'
     doctor-index:
       path: .aiox-core/core/doctor/index.js
       layer: L1
@@ -8810,7 +8812,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a6072bf0e5c198b6d83ecf3fb5425d63982ad3a201455ba9e3ae3bd51f690ad6
-      lastVerified: '2026-05-17T14:15:04.463Z'
+      lastVerified: '2026-05-17T15:04:27.197Z'
     agent-elicitation:
       path: .aiox-core/core/elicitation/agent-elicitation.js
       layer: L1
@@ -8831,7 +8833,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ef13ebff1375279e7b8f0f0bbd3699a0d201f9a67127efa64c4142159a26f417
-      lastVerified: '2026-05-17T14:15:04.463Z'
+      lastVerified: '2026-05-17T15:04:27.198Z'
     elicitation-engine:
       path: .aiox-core/core/elicitation/elicitation-engine.js
       layer: L1
@@ -8856,7 +8858,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:256f31ef3a5dd0ba085beb2a1556194e5f2e47d4d15cfeba6896b0022933400c
-      lastVerified: '2026-05-17T14:15:04.464Z'
+      lastVerified: '2026-05-17T15:04:27.198Z'
     session-manager:
       path: .aiox-core/core/elicitation/session-manager.js
       layer: L1
@@ -8878,7 +8880,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:79e410d808c4b15802d04c9c7f806796c048e846a69d1a69783c619954771f9b
-      lastVerified: '2026-05-17T14:15:04.464Z'
+      lastVerified: '2026-05-17T15:04:27.198Z'
     task-elicitation:
       path: .aiox-core/core/elicitation/task-elicitation.js
       layer: L1
@@ -8899,7 +8901,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cc44ad635e60cbdb67d18209b4b50d1fb2824de2234ec607a6639eb1754bfc75
-      lastVerified: '2026-05-17T14:15:04.464Z'
+      lastVerified: '2026-05-17T15:04:27.198Z'
     workflow-elicitation:
       path: .aiox-core/core/elicitation/workflow-elicitation.js
       layer: L1
@@ -8921,7 +8923,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:722d9b28d2485e3b5b89af6ea136e6d3907b805b9870f6e07e943d0264dc7fff
-      lastVerified: '2026-05-17T14:15:04.464Z'
+      lastVerified: '2026-05-17T15:04:27.199Z'
     aiox-error:
       path: .aiox-core/core/errors/aiox-error.js
       layer: L1
@@ -8945,7 +8947,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6734641df389f921f1d139c129ec007d15b3a08114a15fe9faf792ed1036d0c8
-      lastVerified: '2026-05-17T14:15:04.464Z'
+      lastVerified: '2026-05-17T15:04:27.199Z'
     constants:
       path: .aiox-core/core/errors/constants.js
       layer: L1
@@ -8967,7 +8969,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9f6fa0b1a9b8538d321674ac43628f42452ce2ac770d0433c1ab84b55b1e56dd
-      lastVerified: '2026-05-17T14:15:04.465Z'
+      lastVerified: '2026-05-17T15:04:27.199Z'
     error-registry:
       path: .aiox-core/core/errors/error-registry.js
       layer: L1
@@ -8990,7 +8992,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7ba8dffa725860a285618593b8ed47b05c4fa488fdedf1282c2e214881c370bc
-      lastVerified: '2026-05-17T14:15:04.465Z'
+      lastVerified: '2026-05-17T15:04:27.199Z'
     errors-index:
       path: .aiox-core/core/errors/index.js
       layer: L1
@@ -9015,7 +9017,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:462d0aed6f57f2e4b9d51bcb20467451473c927e0d182b5c3ad43f352f44122c
-      lastVerified: '2026-05-17T14:15:04.465Z'
+      lastVerified: '2026-05-17T15:04:27.200Z'
     serializer:
       path: .aiox-core/core/errors/serializer.js
       layer: L1
@@ -9037,7 +9039,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7144adaf3a245afd732aef16e2cdb61f08246badb6b90ac1a7f4b73705ff3ce8
-      lastVerified: '2026-05-17T14:15:04.465Z'
+      lastVerified: '2026-05-17T15:04:27.200Z'
     utils:
       path: .aiox-core/core/errors/utils.js
       layer: L1
@@ -9059,7 +9061,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:24b8ff80e98efc2b562843262490b7ac537ee77565715b644f212652192ced62
-      lastVerified: '2026-05-17T14:15:04.466Z'
+      lastVerified: '2026-05-17T15:04:27.200Z'
     dashboard-emitter:
       path: .aiox-core/core/events/dashboard-emitter.js
       layer: L1
@@ -9081,7 +9083,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c694e4fc5765d6c396b25617cc34e3447068af780fdbb202b060a31cd357549
-      lastVerified: '2026-05-17T14:15:04.466Z'
+      lastVerified: '2026-05-17T15:04:27.200Z'
     events-index:
       path: .aiox-core/core/events/index.js
       layer: L1
@@ -9102,7 +9104,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c5a3a1ba660f1a0d7963e4e8a29ee536a301621c941d962c00f67ade17ba7db3
-      lastVerified: '2026-05-17T14:15:04.466Z'
+      lastVerified: '2026-05-17T15:04:27.200Z'
     types:
       path: .aiox-core/core/events/types.js
       layer: L1
@@ -9122,7 +9124,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b9b69520fb8f51aaa9c768006282dfbf17846df9edc829ddc6557d7fa9930865
-      lastVerified: '2026-05-17T14:15:04.466Z'
+      lastVerified: '2026-05-17T15:04:27.200Z'
     autonomous-build-loop:
       path: .aiox-core/core/execution/autonomous-build-loop.js
       layer: L1
@@ -9148,7 +9150,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:22246474800340c7a97c8b865f5f9e3cb162efd45c5db1be2f9f729969a0b6d0
-      lastVerified: '2026-05-17T14:15:04.467Z'
+      lastVerified: '2026-05-17T15:04:27.201Z'
     build-orchestrator:
       path: .aiox-core/core/execution/build-orchestrator.js
       layer: L1
@@ -9173,7 +9175,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:51aec922a58d5d4121ef156bb961ac7b8f29db711679897fdade6ca71a1635e5
-      lastVerified: '2026-05-17T14:15:04.468Z'
+      lastVerified: '2026-05-17T15:04:27.202Z'
     build-state-manager:
       path: .aiox-core/core/execution/build-state-manager.js
       layer: L1
@@ -9199,7 +9201,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:02bafb4a29e7f769ae775fbc4e571ad34882569665f61ebc28eb87f7043eafc8
-      lastVerified: '2026-05-17T14:15:04.469Z'
+      lastVerified: '2026-05-17T15:04:27.203Z'
     context-injector:
       path: .aiox-core/core/execution/context-injector.js
       layer: L1
@@ -9220,7 +9222,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7654f6e6c3d555f3963369e71edf84b15c0fdec53bd161800b71782f78275244
-      lastVerified: '2026-05-17T14:15:04.469Z'
+      lastVerified: '2026-05-17T15:04:27.203Z'
     parallel-executor:
       path: .aiox-core/core/execution/parallel-executor.js
       layer: L1
@@ -9241,7 +9243,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:46870e5c8ff8db3ee0386e477d427cc98eeb008f630818b093a9524b410590ae
-      lastVerified: '2026-05-17T14:15:04.469Z'
+      lastVerified: '2026-05-17T15:04:27.203Z'
     parallel-monitor:
       path: .aiox-core/core/execution/parallel-monitor.js
       layer: L1
@@ -9260,7 +9262,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:58ecd92f5de9c688f28cf952ae6cc5ee07ddf14dc89fb0ea13b2f0a527e29fae
-      lastVerified: '2026-05-17T14:15:04.469Z'
+      lastVerified: '2026-05-17T15:04:27.204Z'
     rate-limit-manager:
       path: .aiox-core/core/execution/rate-limit-manager.js
       layer: L1
@@ -9281,7 +9283,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b6e2ca99cf59a9dfa5a4e48109d0a47f36262efcc73e69f11a1c0c727d48abb
-      lastVerified: '2026-05-17T14:15:04.469Z'
+      lastVerified: '2026-05-17T15:04:27.204Z'
     result-aggregator:
       path: .aiox-core/core/execution/result-aggregator.js
       layer: L1
@@ -9300,7 +9302,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bcd102ca46e74d61af151aa7877921807c9bf5aba45bfba73f9f5c8cf714d8e2
-      lastVerified: '2026-05-17T14:15:04.470Z'
+      lastVerified: '2026-05-17T15:04:27.204Z'
     semantic-merge-engine:
       path: .aiox-core/core/execution/semantic-merge-engine.js
       layer: L1
@@ -9321,7 +9323,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:26f2a057407cf114a0611944960a8e6d58d93c5e03abe905489e6b699cb98a75
-      lastVerified: '2026-05-17T14:15:04.470Z'
+      lastVerified: '2026-05-17T15:04:27.205Z'
     subagent-dispatcher:
       path: .aiox-core/core/execution/subagent-dispatcher.js
       layer: L1
@@ -9342,7 +9344,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa8ce6aa5fdd85f7a06c3c560a85d904222658076158c35031ddae19bb63efe1
-      lastVerified: '2026-05-17T14:15:04.471Z'
+      lastVerified: '2026-05-17T15:04:27.206Z'
     wave-executor:
       path: .aiox-core/core/execution/wave-executor.js
       layer: L1
@@ -9363,7 +9365,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4e2324edb37ae0729062b5ac029f2891e050e7efd3a48d0f4a1dc4f227a6716b
-      lastVerified: '2026-05-17T14:15:04.472Z'
+      lastVerified: '2026-05-17T15:04:27.206Z'
     delegate-cli:
       path: .aiox-core/core/external-executors/delegate-cli.js
       layer: L1
@@ -9383,7 +9385,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3f4bb7d4edd742ad13dc91ebdc7296b94ac762caa50ea6943429d93cd65c0ce1
-      lastVerified: '2026-05-17T14:15:04.472Z'
+      lastVerified: '2026-05-17T15:04:27.206Z'
     external-executors-index:
       path: .aiox-core/core/external-executors/index.js
       layer: L1
@@ -9403,7 +9405,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:db61bee165e4a7dba3627275d52d6b162e3b2cbf47d31d88beb38682cb8352db
-      lastVerified: '2026-05-17T14:15:04.472Z'
+      lastVerified: '2026-05-17T15:04:27.206Z'
     cli:
       path: .aiox-core/core/graph-dashboard/cli.js
       layer: L1
@@ -9432,7 +9434,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:29f273a06fecc77eb3e39162ba1aaf28e1cbadb2a000158f009817021a30b4d1
-      lastVerified: '2026-05-17T14:15:04.473Z'
+      lastVerified: '2026-05-17T15:04:27.214Z'
     graph-dashboard-index:
       path: .aiox-core/core/graph-dashboard/index.js
       layer: L1
@@ -9453,7 +9455,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d4e43c674dd7c119afd0afacc5b899c35de82890a61a3bcefc957819314f8cee
-      lastVerified: '2026-05-17T14:15:04.473Z'
+      lastVerified: '2026-05-17T15:04:27.215Z'
     base-check:
       path: .aiox-core/core/health-check/base-check.js
       layer: L1
@@ -9513,7 +9515,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4bdc81b92825c72ab185fa8f161aa0348d63071f2bc0d894317199e00c269f8d
-      lastVerified: '2026-05-17T14:15:04.473Z'
+      lastVerified: '2026-05-17T15:04:27.215Z'
     check-registry:
       path: .aiox-core/core/health-check/check-registry.js
       layer: L1
@@ -9539,7 +9541,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:131564effd0499f61a2420914be706b9134db955b4adf09bd03eee511c323867
-      lastVerified: '2026-05-17T14:15:04.474Z'
+      lastVerified: '2026-05-17T15:04:27.215Z'
     engine:
       path: .aiox-core/core/health-check/engine.js
       layer: L1
@@ -9559,7 +9561,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7a53405621243960ce482e8d3052a40caf8704d670a9f3388eca294056971497
-      lastVerified: '2026-05-17T14:15:04.474Z'
+      lastVerified: '2026-05-17T15:04:27.215Z'
     health-check-index:
       path: .aiox-core/core/health-check/index.js
       layer: L1
@@ -9583,7 +9585,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:738bec37c11cfb02e9df96e3631f74fa0652f5a531c7b0f1d8887e0141b1f72e
-      lastVerified: '2026-05-17T14:15:04.474Z'
+      lastVerified: '2026-05-17T15:04:27.216Z'
     ideation-engine:
       path: .aiox-core/core/ideation/ideation-engine.js
       layer: L1
@@ -9602,7 +9604,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c91f7bc999eca74394eeae9bc7400e63e134de4092d6bdc08b92bf423e423ec3
-      lastVerified: '2026-05-17T14:15:04.475Z'
+      lastVerified: '2026-05-17T15:04:27.216Z'
     circuit-breaker:
       path: .aiox-core/core/ids/circuit-breaker.js
       layer: L1
@@ -9623,7 +9625,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:63be126f2e0d320daa60cb5b68b21df93cad4c19d1f959e06a6ac776213f8eba
-      lastVerified: '2026-05-17T14:15:04.475Z'
+      lastVerified: '2026-05-17T15:04:27.217Z'
     framework-governor:
       path: .aiox-core/core/ids/framework-governor.js
       layer: L1
@@ -9646,7 +9648,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ef7a3b7444a51f2f122c114c662b1db544d1c9e7833dc6f77dce30ac3a2005a2
-      lastVerified: '2026-05-17T14:15:04.476Z'
+      lastVerified: '2026-05-17T15:04:27.217Z'
     incremental-decision-engine:
       path: .aiox-core/core/ids/incremental-decision-engine.js
       layer: L1
@@ -9668,7 +9670,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:257b1f67f6df8eb91fe0a95405563611b8bf2f836cbca2398a0a394e40d6c219
-      lastVerified: '2026-05-17T14:15:04.476Z'
+      lastVerified: '2026-05-17T15:04:27.217Z'
     ids-index:
       path: .aiox-core/core/ids/index.js
       layer: L1
@@ -9698,7 +9700,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:363ef37a0fcc18e9e2646650f74750a77c21a95e16de976f64f52825cc50a6a1
-      lastVerified: '2026-05-17T14:15:04.476Z'
+      lastVerified: '2026-05-17T15:04:27.218Z'
     layer-classifier:
       path: .aiox-core/core/ids/layer-classifier.js
       layer: L1
@@ -9718,7 +9720,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2a240b70ac3507e50a64b96d580c4d933bf2116125fb52c8237db2ed9ebf27b7
-      lastVerified: '2026-05-17T14:15:04.477Z'
+      lastVerified: '2026-05-17T15:04:27.218Z'
     registry-healer:
       path: .aiox-core/core/ids/registry-healer.js
       layer: L1
@@ -9739,7 +9741,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2b128ea4c1e8bc8f9324390ab55c1b3623c9ad3352522cbecec1acaefe472c5d
-      lastVerified: '2026-05-17T14:15:04.477Z'
+      lastVerified: '2026-05-17T15:04:27.219Z'
     registry-loader:
       path: .aiox-core/core/ids/registry-loader.js
       layer: L1
@@ -9764,7 +9766,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:88c67bace0a5ab6a14cb1d096e3f9cab9f5edc0dd8377788e27b692ccefbd487
-      lastVerified: '2026-05-17T14:15:04.477Z'
+      lastVerified: '2026-05-17T15:04:27.219Z'
     registry-updater:
       path: .aiox-core/core/ids/registry-updater.js
       layer: L1
@@ -9785,7 +9787,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:00ae2e78486a9e7b3c8bf8e9ca0e9e955211ee4ae795c630e7f2934840d5596d
-      lastVerified: '2026-05-17T14:15:04.478Z'
+      lastVerified: '2026-05-17T15:04:27.219Z'
     verification-gate:
       path: .aiox-core/core/ids/verification-gate.js
       layer: L1
@@ -9806,7 +9808,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:96050661c90fa52bfc755911d02c9194ec35c00e71fc6bbc92a13686dd53bb91
-      lastVerified: '2026-05-17T14:15:04.478Z'
+      lastVerified: '2026-05-17T15:04:27.219Z'
     manifest-generator:
       path: .aiox-core/core/manifest/manifest-generator.js
       layer: L1
@@ -9825,7 +9827,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:81b796990dd747bbb9785d205dbe5f6d5556754fc51745fb84b7ce4675acbdbf
-      lastVerified: '2026-05-17T14:15:04.478Z'
+      lastVerified: '2026-05-17T15:04:27.220Z'
     manifest-validator:
       path: .aiox-core/core/manifest/manifest-validator.js
       layer: L1
@@ -9844,7 +9846,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3558e7dbf653eac385222a299d0eddaaf77e119a70ec034f7a7291c401d7be2c
-      lastVerified: '2026-05-17T14:15:04.478Z'
+      lastVerified: '2026-05-17T15:04:27.220Z'
     config-migrator:
       path: .aiox-core/core/mcp/config-migrator.js
       layer: L1
@@ -9866,7 +9868,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0603a288d79e8526a2c757834bab5191bbc240b1b9dcb548b09d10cee97de322
-      lastVerified: '2026-05-17T14:15:04.479Z'
+      lastVerified: '2026-05-17T15:04:27.220Z'
     global-config-manager:
       path: .aiox-core/core/mcp/global-config-manager.js
       layer: L1
@@ -9889,7 +9891,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c010cfff03119c8369a3c4c3cc73ce31d79108dc15c5c66e67f63766a2a2c5d8
-      lastVerified: '2026-05-17T14:15:04.479Z'
+      lastVerified: '2026-05-17T15:04:27.220Z'
     mcp-index:
       path: .aiox-core/core/mcp/index.js
       layer: L1
@@ -9911,7 +9913,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4f9be6c05a2d6d305f6a3c0130e5e1eca18feb41de47245e51ebe1c9a32ffa7f
-      lastVerified: '2026-05-17T14:15:04.479Z'
+      lastVerified: '2026-05-17T15:04:27.221Z'
     os-detector:
       path: .aiox-core/core/mcp/os-detector.js
       layer: L1
@@ -9933,7 +9935,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7c5eb398bf1e53ddc5e31a9367d01709eba56bc53f653430ea7de07e32aa2a11
-      lastVerified: '2026-05-17T14:15:04.479Z'
+      lastVerified: '2026-05-17T15:04:27.221Z'
     symlink-manager:
       path: .aiox-core/core/mcp/symlink-manager.js
       layer: L1
@@ -9955,7 +9957,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b2c68e5664f7f8595b81cbfba69be16d7f37f8d21608c99ddd066808aa2653c1
-      lastVerified: '2026-05-17T14:15:04.479Z'
+      lastVerified: '2026-05-17T15:04:27.221Z'
     gotchas-memory:
       path: .aiox-core/core/memory/gotchas-memory.js
       layer: L1
@@ -9979,7 +9981,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:deeb90a6dff9ef284537a1dabf52566cec3f64244f31f4081432515985a94e25
-      lastVerified: '2026-05-17T14:15:04.480Z'
+      lastVerified: '2026-05-17T15:04:27.222Z'
     agent-invoker:
       path: .aiox-core/core/orchestration/agent-invoker.js
       layer: L1
@@ -10000,7 +10002,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5e1e3428163c35b0c91f694b76a5ca1e520249de1f7f65aae87e6723c01a45e7
-      lastVerified: '2026-05-17T14:15:04.480Z'
+      lastVerified: '2026-05-17T15:04:27.222Z'
     bob-orchestrator:
       path: .aiox-core/core/orchestration/bob-orchestrator.js
       layer: L1
@@ -10034,7 +10036,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:971a21ed77f09ab76dc2822030c4b36edd1fd9d8ec405b25b32f36f0cd606ec8
-      lastVerified: '2026-05-17T14:15:04.481Z'
+      lastVerified: '2026-05-17T15:04:27.223Z'
     bob-status-writer:
       path: .aiox-core/core/orchestration/bob-status-writer.js
       layer: L1
@@ -10056,7 +10058,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d0368d44b8b45549f503d737b0fdb21afb02db8d544b19f4d0289828501ac016
-      lastVerified: '2026-05-17T14:15:04.481Z'
+      lastVerified: '2026-05-17T15:04:27.223Z'
     brownfield-handler:
       path: .aiox-core/core/orchestration/brownfield-handler.js
       layer: L1
@@ -10080,7 +10082,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:153eed3dcad1b5f58e0abb9ec4fb0c7013f441efeb169ea4a0cfda23f75928fc
-      lastVerified: '2026-05-17T14:15:04.482Z'
+      lastVerified: '2026-05-17T15:04:27.224Z'
     checklist-runner:
       path: .aiox-core/core/orchestration/checklist-runner.js
       layer: L1
@@ -10101,7 +10103,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:40f17b74c2fe6746f45aa5750c0b85b5af22221e010951eb6e93f5796fb70a8f
-      lastVerified: '2026-05-17T14:15:04.482Z'
+      lastVerified: '2026-05-17T15:04:27.224Z'
     cli-commands:
       path: .aiox-core/core/orchestration/cli-commands.js
       layer: L1
@@ -10122,7 +10124,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cedd09f6938b3e1e0e19c06f4763de00281ddb31529d16ab9e4f74d194a3bd3b
-      lastVerified: '2026-05-17T14:15:04.482Z'
+      lastVerified: '2026-05-17T15:04:27.224Z'
     condition-evaluator:
       path: .aiox-core/core/orchestration/condition-evaluator.js
       layer: L1
@@ -10143,7 +10145,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:daa6755c76359bb99a2e687c9c56f74b52b7151b0b0677a771b8fff24538d2ad
-      lastVerified: '2026-05-17T14:15:04.483Z'
+      lastVerified: '2026-05-17T15:04:27.225Z'
     context-manager:
       path: .aiox-core/core/orchestration/context-manager.js
       layer: L1
@@ -10165,7 +10167,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b6ed0e4eb069558998f95ab0c68fa040b1b8c2aab74ab44e26ab682fe9e247b4
-      lastVerified: '2026-05-17T14:15:04.483Z'
+      lastVerified: '2026-05-17T15:04:27.227Z'
     dashboard-integration:
       path: .aiox-core/core/orchestration/dashboard-integration.js
       layer: L1
@@ -10187,7 +10189,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8f2dd7d3885a9eaf58957505d312923e149f2771ae3ca0cda879631683f826c9
-      lastVerified: '2026-05-17T14:15:04.484Z'
+      lastVerified: '2026-05-17T15:04:27.228Z'
     data-lifecycle-manager:
       path: .aiox-core/core/orchestration/data-lifecycle-manager.js
       layer: L1
@@ -10211,7 +10213,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7fe6c9d9a278a1d7714e7fdba8710fafbc221520b096639be46f2ce1549a5c2a
-      lastVerified: '2026-05-17T14:15:04.484Z'
+      lastVerified: '2026-05-17T15:04:27.233Z'
     epic-context-accumulator:
       path: .aiox-core/core/orchestration/epic-context-accumulator.js
       layer: L1
@@ -10232,7 +10234,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4f342f7fc05f404de2b899358f86143106737b56d6c486c98e988a67d420078b
-      lastVerified: '2026-05-17T14:15:04.484Z'
+      lastVerified: '2026-05-17T15:04:27.237Z'
     execution-profile-resolver:
       path: .aiox-core/core/orchestration/execution-profile-resolver.js
       layer: L1
@@ -10254,7 +10256,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bb35f1c16c47c9306128c5f3e6c90df3ed91f9358576ea97a59007b74f5e9927
-      lastVerified: '2026-05-17T14:15:04.484Z'
+      lastVerified: '2026-05-17T15:04:27.238Z'
     executor-assignment:
       path: .aiox-core/core/orchestration/executor-assignment.js
       layer: L1
@@ -10277,7 +10279,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c046e3e837dbbb82d3877985192d3438d49f369274ac709789b913c502ada617
-      lastVerified: '2026-05-17T14:15:04.484Z'
+      lastVerified: '2026-05-17T15:04:27.238Z'
     fast-path-gate:
       path: .aiox-core/core/orchestration/fast-path-gate.js
       layer: L1
@@ -10298,7 +10300,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ecd04d15600bcbf1c717cfe5f1ac3ce38bdde30275fd38f7f48f96cf0757b249
-      lastVerified: '2026-05-17T14:15:04.485Z'
+      lastVerified: '2026-05-17T15:04:27.241Z'
     gate-evaluator:
       path: .aiox-core/core/orchestration/gate-evaluator.js
       layer: L1
@@ -10319,7 +10321,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4e9e78745f937ee78b13704f3acdb45b19d4aab9bc0f17a5adaf5eecfc58e653
-      lastVerified: '2026-05-17T14:15:04.485Z'
+      lastVerified: '2026-05-17T15:04:27.241Z'
     gemini-model-selector:
       path: .aiox-core/core/orchestration/gemini-model-selector.js
       layer: L1
@@ -10340,7 +10342,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2fe54c401ae60c0b5dc07f74c7a464992a0558b10c0b61f183c06943441d0d57
-      lastVerified: '2026-05-17T14:15:04.485Z'
+      lastVerified: '2026-05-17T15:04:27.244Z'
     greenfield-handler:
       path: .aiox-core/core/orchestration/greenfield-handler.js
       layer: L1
@@ -10365,7 +10367,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:949c80c9c0430d4ddb1fa6e721661bad479ab476a4fb529aad8bf8dafa6e57fd
-      lastVerified: '2026-05-17T14:15:04.486Z'
+      lastVerified: '2026-05-17T15:04:27.252Z'
     orchestration-index:
       path: .aiox-core/core/orchestration/index.js
       layer: L1
@@ -10413,7 +10415,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:eaebc2df86ad8fdd91082c4b1f007f967b2de89eb1ac4e5902e3b46b2eb5b169
-      lastVerified: '2026-05-17T14:15:04.487Z'
+      lastVerified: '2026-05-17T15:04:27.260Z'
     lock-manager:
       path: .aiox-core/core/orchestration/lock-manager.js
       layer: L1
@@ -10435,7 +10437,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:30af501b40da2a7bcfd591c62e367c5667eefd40af91d265c986521c93e7d1f2
-      lastVerified: '2026-05-17T14:15:04.487Z'
+      lastVerified: '2026-05-17T15:04:27.263Z'
     master-orchestrator:
       path: .aiox-core/core/orchestration/master-orchestrator.js
       layer: L1
@@ -10462,7 +10464,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:88238a9e0ef7d058efe0ca2fe7a9d0e34202bff7e409fd1a97886b0a8ccdce97
-      lastVerified: '2026-05-17T14:15:04.488Z'
+      lastVerified: '2026-05-17T15:04:27.270Z'
     message-formatter:
       path: .aiox-core/core/orchestration/message-formatter.js
       layer: L1
@@ -10483,7 +10485,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b7413c04fa22db1c5fc2f5c2aa47bb8ca0374e079894a44df21b733da6c258ae
-      lastVerified: '2026-05-17T14:15:04.488Z'
+      lastVerified: '2026-05-17T15:04:27.272Z'
     orchestration-parallel-executor:
       path: .aiox-core/core/orchestration/parallel-executor.js
       layer: L1
@@ -10502,7 +10504,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:17b9669337d080509cb270eb8564a0f5684b2abbad1056f81b6947bb0b2b594f
-      lastVerified: '2026-05-17T14:15:04.489Z'
+      lastVerified: '2026-05-17T15:04:27.277Z'
     recovery-handler:
       path: .aiox-core/core/orchestration/recovery-handler.js
       layer: L1
@@ -10526,7 +10528,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3224718aa40bbdd08e117b27ac71f4ec66252d9874acaf9bb3addfe8ca4d0c06
-      lastVerified: '2026-05-17T14:15:04.489Z'
+      lastVerified: '2026-05-17T15:04:27.280Z'
     session-state:
       path: .aiox-core/core/orchestration/session-state.js
       layer: L1
@@ -10554,7 +10556,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:70d511bf6a03e8cacefcec0065a4727cfb380471c89762bb291840968f55b44b
-      lastVerified: '2026-05-17T14:15:04.490Z'
+      lastVerified: '2026-05-17T15:04:27.281Z'
     skill-dispatcher:
       path: .aiox-core/core/orchestration/skill-dispatcher.js
       layer: L1
@@ -10575,7 +10577,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ebee66973a1df5d9dfed195ac6d83765a92023ba504e1814674345094fb8117
-      lastVerified: '2026-05-17T14:15:04.490Z'
+      lastVerified: '2026-05-17T15:04:27.283Z'
     subagent-prompt-builder:
       path: .aiox-core/core/orchestration/subagent-prompt-builder.js
       layer: L1
@@ -10597,7 +10599,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c014eaae229e6c84742273701a6ef21a19343e34ef8be38d5d6a9bc59ecd8b02
-      lastVerified: '2026-05-17T14:15:04.490Z'
+      lastVerified: '2026-05-17T15:04:27.283Z'
     surface-checker:
       path: .aiox-core/core/orchestration/surface-checker.js
       layer: L1
@@ -10621,7 +10623,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:92e9d5bea78c3db4940c39f79e537821b36451cd524d69e6b738272aa63c08b6
-      lastVerified: '2026-05-17T14:15:04.490Z'
+      lastVerified: '2026-05-17T15:04:27.283Z'
     task-complexity-classifier:
       path: .aiox-core/core/orchestration/task-complexity-classifier.js
       layer: L1
@@ -10642,7 +10644,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:33b3b7c349352d607c156e0018c508f0869a1c7d233d107bed194a51bc608c93
-      lastVerified: '2026-05-17T14:15:04.490Z'
+      lastVerified: '2026-05-17T15:04:27.283Z'
     tech-stack-detector:
       path: .aiox-core/core/orchestration/tech-stack-detector.js
       layer: L1
@@ -10665,7 +10667,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:074c52757e181cc1e344b26ae191ac67488d18e9da2b06b5def23abb6c64c056
-      lastVerified: '2026-05-17T14:15:04.491Z'
+      lastVerified: '2026-05-17T15:04:27.284Z'
     terminal-spawner:
       path: .aiox-core/core/orchestration/terminal-spawner.js
       layer: L1
@@ -10687,7 +10689,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a6453c6acf0ff007444adeaa5e4620890fff38f0b31b058a2da04d790fb098ab
-      lastVerified: '2026-05-17T14:15:04.491Z'
+      lastVerified: '2026-05-17T15:04:27.284Z'
     workflow-executor:
       path: .aiox-core/core/orchestration/workflow-executor.js
       layer: L1
@@ -10714,7 +10716,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:49372791e5729fd7987c80efe1400168e8d59eac000a009b88d9fde6735cf4db
-      lastVerified: '2026-05-17T14:15:04.492Z'
+      lastVerified: '2026-05-17T15:04:27.285Z'
     workflow-orchestrator:
       path: .aiox-core/core/orchestration/workflow-orchestrator.js
       layer: L1
@@ -10742,7 +10744,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:82816bd5e6fecc9bbb77292444e53254c72bf93e5c04260784743354c6a58627
-      lastVerified: '2026-05-17T14:15:04.492Z'
+      lastVerified: '2026-05-17T15:04:27.286Z'
     permissions-index:
       path: .aiox-core/core/permissions/index.js
       layer: L1
@@ -10765,7 +10767,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5748821f5b7fcc2c54e74956ddd9e05326fa96520a753a506feb9910042f562b
-      lastVerified: '2026-05-17T14:15:04.493Z'
+      lastVerified: '2026-05-17T15:04:27.286Z'
     operation-guard:
       path: .aiox-core/core/permissions/operation-guard.js
       layer: L1
@@ -10787,7 +10789,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f9b1b1bd547145c0d8a0f47534af0678ee852df6236acd05c53e479cb0e3f0bd
-      lastVerified: '2026-05-17T14:15:04.493Z'
+      lastVerified: '2026-05-17T15:04:27.286Z'
     permission-mode:
       path: .aiox-core/core/permissions/permission-mode.js
       layer: L1
@@ -10809,7 +10811,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:84f09067c7154d97cb2252b9a7def00562acf569cfc3b035d6d4e39fb40d4033
-      lastVerified: '2026-05-17T14:15:04.493Z'
+      lastVerified: '2026-05-17T15:04:27.287Z'
     pro-updater:
       path: .aiox-core/core/pro/pro-updater.js
       layer: L1
@@ -10828,7 +10830,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:30ea78b8ab088e695936ae662057697410856751f463eeb649e00b67dcc31531
-      lastVerified: '2026-05-17T14:15:04.493Z'
+      lastVerified: '2026-05-17T15:04:27.287Z'
     base-layer:
       path: .aiox-core/core/quality-gates/base-layer.js
       layer: L1
@@ -10850,7 +10852,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a9a3921da08176b0bd44f338a59abc1f5107f3b1ee56571e840bf4e8ed233f4
-      lastVerified: '2026-05-17T14:15:04.494Z'
+      lastVerified: '2026-05-17T15:04:27.287Z'
     checklist-generator:
       path: .aiox-core/core/quality-gates/checklist-generator.js
       layer: L1
@@ -10870,7 +10872,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7f2800f6e2465a846c9bef8a73403e7b91bf18d1d1425804d31244bd883ec55a
-      lastVerified: '2026-05-17T14:15:04.494Z'
+      lastVerified: '2026-05-17T15:04:27.288Z'
     focus-area-recommender:
       path: .aiox-core/core/quality-gates/focus-area-recommender.js
       layer: L1
@@ -10891,7 +10893,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f6364e2d444d19a8a3d0fb59d5264ae55137d48e008f5a3efe57f92465c4b53e
-      lastVerified: '2026-05-17T14:15:04.494Z'
+      lastVerified: '2026-05-17T15:04:27.288Z'
     human-review-orchestrator:
       path: .aiox-core/core/quality-gates/human-review-orchestrator.js
       layer: L1
@@ -10914,7 +10916,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3462b577d1bfa561156e72483241cb3bd0a6756448bd17acb3f4d92ead144781
-      lastVerified: '2026-05-17T14:15:04.494Z'
+      lastVerified: '2026-05-17T15:04:27.288Z'
     layer1-precommit:
       path: .aiox-core/core/quality-gates/layer1-precommit.js
       layer: L1
@@ -10935,7 +10937,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:250b62740b473383e41b371bb59edddabd8a312f5f48a5a8e883e6196a48b8f3
-      lastVerified: '2026-05-17T14:15:04.495Z'
+      lastVerified: '2026-05-17T15:04:27.288Z'
     layer2-pr-automation:
       path: .aiox-core/core/quality-gates/layer2-pr-automation.js
       layer: L1
@@ -10957,7 +10959,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:af31e7ac60b74b52ee983d0fcff7457042eea553b6127538cab41eb94eaee8e0
-      lastVerified: '2026-05-17T14:15:04.495Z'
+      lastVerified: '2026-05-17T15:04:27.289Z'
     layer3-human-review:
       path: .aiox-core/core/quality-gates/layer3-human-review.js
       layer: L1
@@ -10980,7 +10982,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9bf79d5adfddae55d7dddfda777cd2775aa76f82204ddd0f660f6edbd093b16b
-      lastVerified: '2026-05-17T14:15:04.495Z'
+      lastVerified: '2026-05-17T15:04:27.289Z'
     notification-manager:
       path: .aiox-core/core/quality-gates/notification-manager.js
       layer: L1
@@ -11001,7 +11003,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:89466b448383f8021075f43b870036b2e1d0277e543bd4357dd4988dc7c31b14
-      lastVerified: '2026-05-17T14:15:04.495Z'
+      lastVerified: '2026-05-17T15:04:27.289Z'
     quality-gate-manager:
       path: .aiox-core/core/quality-gates/quality-gate-manager.js
       layer: L1
@@ -11026,7 +11028,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b0d5ce2653218eae63121e892d886c3234a87bf98536369c75b537163e07fb26
-      lastVerified: '2026-05-17T14:15:04.496Z'
+      lastVerified: '2026-05-17T15:04:27.290Z'
     build-registry:
       path: .aiox-core/core/registry/build-registry.js
       layer: L1
@@ -11045,7 +11047,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e23f7e4f2d378de42204698eb0a818f6f8a4868a97341c8fbb92158c3e7d4767
-      lastVerified: '2026-05-17T14:15:04.496Z'
+      lastVerified: '2026-05-17T15:04:27.290Z'
     registry-registry-loader:
       path: .aiox-core/core/registry/registry-loader.js
       layer: L1
@@ -11064,7 +11066,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0cf9fa2ca39f7c4ca20043f3c4d7742e40dec7e94f81b706cf9318ebee199975
-      lastVerified: '2026-05-17T14:15:04.497Z'
+      lastVerified: '2026-05-17T15:04:27.290Z'
     validate-registry:
       path: .aiox-core/core/registry/validate-registry.js
       layer: L1
@@ -11083,7 +11085,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d9805ce445661a3a2d9e6c73bf35cbd1bc2403419825442cd7b8f01cc1409cb3
-      lastVerified: '2026-05-17T14:15:04.497Z'
+      lastVerified: '2026-05-17T15:04:27.291Z'
     agent-immortality:
       path: .aiox-core/core/resilience/agent-immortality.js
       layer: L1
@@ -11103,7 +11105,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d1612c672e91a802924c4a61d8beade66d5740487ca0a244950a2c8249a70962
-      lastVerified: '2026-05-17T14:15:04.497Z'
+      lastVerified: '2026-05-17T15:04:27.293Z'
     resilience-index:
       path: .aiox-core/core/resilience/index.js
       layer: L1
@@ -11123,7 +11125,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5acbb55fbbf25fc052c0ee2eac5f35d30228144e9f426083b89aabc9e54d084f
-      lastVerified: '2026-05-17T14:15:04.497Z'
+      lastVerified: '2026-05-17T15:04:27.294Z'
     context-detector:
       path: .aiox-core/core/session/context-detector.js
       layer: L1
@@ -11149,7 +11151,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5537563d5dfc613e16fd610c9e1407e7811c4f19745a78a4fc81c34af20000f4
-      lastVerified: '2026-05-17T14:15:04.498Z'
+      lastVerified: '2026-05-17T15:04:27.294Z'
     context-loader:
       path: .aiox-core/core/session/context-loader.js
       layer: L1
@@ -11173,7 +11175,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e810e119059dce081d1143b16e4e6bb7aa65684169b4ebc36f55ecbaf109bd63
-      lastVerified: '2026-05-17T14:15:04.498Z'
+      lastVerified: '2026-05-17T15:04:27.295Z'
     synapse-engine:
       path: .aiox-core/core/synapse/engine.js
       layer: L1
@@ -11196,7 +11198,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b65523b2fec6a44ab380298c4d98f0569209dec8b50be3922479ffcd6548df0
-      lastVerified: '2026-05-17T14:15:04.498Z'
+      lastVerified: '2026-05-17T15:04:27.295Z'
     ui-index:
       path: .aiox-core/core/ui/index.js
       layer: L1
@@ -11217,7 +11219,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:49f683bbedad4f161006e7317c409ec12af2aa9f7ba0750c4d1d15ac3df05350
-      lastVerified: '2026-05-17T14:15:04.498Z'
+      lastVerified: '2026-05-17T15:04:27.295Z'
     observability-panel:
       path: .aiox-core/core/ui/observability-panel.js
       layer: L1
@@ -11239,7 +11241,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f73bb7b80e60d8158c5044b13bb4dd4945270d3d44b8ac3e2c30635e5040f0f8
-      lastVerified: '2026-05-17T14:15:04.499Z'
+      lastVerified: '2026-05-17T15:04:27.296Z'
     panel-renderer:
       path: .aiox-core/core/ui/panel-renderer.js
       layer: L1
@@ -11260,7 +11262,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d51a8a9d1dd76ce6bc08d38eaf53f4f7df948cc4edc8e7f56d68c39522f64dc6
-      lastVerified: '2026-05-17T14:15:04.499Z'
+      lastVerified: '2026-05-17T15:04:27.296Z'
     output-formatter:
       path: .aiox-core/core/utils/output-formatter.js
       layer: L1
@@ -11279,7 +11281,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6fdfee469b7c108ec24a045b9b2719d836a242052abd285957a9ac732c6fc594
-      lastVerified: '2026-05-17T14:15:04.499Z'
+      lastVerified: '2026-05-17T15:04:27.296Z'
     security-utils:
       path: .aiox-core/core/utils/security-utils.js
       layer: L1
@@ -11298,7 +11300,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:00c938eda0e142b8c204b50afdd662864b5209b60a32a0e6e847e4e4cbceee09
-      lastVerified: '2026-05-17T14:15:04.499Z'
+      lastVerified: '2026-05-17T15:04:27.296Z'
     yaml-validator:
       path: .aiox-core/core/utils/yaml-validator.js
       layer: L1
@@ -11317,7 +11319,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:05084596198634dd2a670a752d5c451edfe268e16e3bae511db52184f895366f
-      lastVerified: '2026-05-17T14:15:04.499Z'
+      lastVerified: '2026-05-17T15:04:27.296Z'
     creation-helper:
       path: .aiox-core/core/code-intel/helpers/creation-helper.js
       layer: L1
@@ -11337,7 +11339,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e674fdbe6979dbe961853f080d5971ba264dee23ab70abafcc21ee99356206e7
-      lastVerified: '2026-05-17T14:15:04.499Z'
+      lastVerified: '2026-05-17T15:04:27.297Z'
     dev-helper:
       path: .aiox-core/core/code-intel/helpers/dev-helper.js
       layer: L1
@@ -11358,7 +11360,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7e7f9bb92725ca1d85b0a7151668bc5bcdd6fc9b73fed5b2b2c28217d14535ab
-      lastVerified: '2026-05-17T14:15:04.500Z'
+      lastVerified: '2026-05-17T15:04:27.297Z'
     devops-helper:
       path: .aiox-core/core/code-intel/helpers/devops-helper.js
       layer: L1
@@ -11380,7 +11382,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e72f95de2f3737b6e12094526eabfb4974a8339ce6d25f2e323f734fe567c155
-      lastVerified: '2026-05-17T14:15:04.500Z'
+      lastVerified: '2026-05-17T15:04:27.297Z'
     planning-helper:
       path: .aiox-core/core/code-intel/helpers/planning-helper.js
       layer: L1
@@ -11405,7 +11407,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9ca5b57b74b5729685369662659e15a91e35ec3a33691973be000ecd85974f3d
-      lastVerified: '2026-05-17T14:15:04.500Z'
+      lastVerified: '2026-05-17T15:04:27.297Z'
     qa-helper:
       path: .aiox-core/core/code-intel/helpers/qa-helper.js
       layer: L1
@@ -11425,7 +11427,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9dbb84c1c4ed1aa57385ad2a6c74520f2020e6f8883012dd57c51486172ee528
-      lastVerified: '2026-05-17T14:15:04.500Z'
+      lastVerified: '2026-05-17T15:04:27.298Z'
     story-helper:
       path: .aiox-core/core/code-intel/helpers/story-helper.js
       layer: L1
@@ -11445,7 +11447,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:778466253ac66103ebc3b1caf71f44b06a0d5fb3d39fe8d3d473dd4bc73fefc6
-      lastVerified: '2026-05-17T14:15:04.501Z'
+      lastVerified: '2026-05-17T15:04:27.298Z'
     code-graph-provider:
       path: .aiox-core/core/code-intel/providers/code-graph-provider.js
       layer: L1
@@ -11468,7 +11470,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:83251871bc2d65864a4e148e3921408e74662a2739bfbd12395a2daaa4bde9a0
-      lastVerified: '2026-05-17T14:15:04.501Z'
+      lastVerified: '2026-05-17T15:04:27.298Z'
     provider-interface:
       path: .aiox-core/core/code-intel/providers/provider-interface.js
       layer: L1
@@ -11490,7 +11492,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:74df278e31f240ee4499f10989c4b6f8c7c7cba6e8f317cb433a23fd6693c487
-      lastVerified: '2026-05-17T14:15:04.501Z'
+      lastVerified: '2026-05-17T15:04:27.298Z'
     registry-provider:
       path: .aiox-core/core/code-intel/providers/registry-provider.js
       layer: L1
@@ -11513,7 +11515,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d7173384a1c0ff33326d1f45ee3fba0a6cbf7d7fe0476c1a60fda5442f5486e3
-      lastVerified: '2026-05-17T14:15:04.501Z'
+      lastVerified: '2026-05-17T15:04:27.299Z'
     agent-memory:
       path: .aiox-core/core/doctor/checks/agent-memory.js
       layer: L1
@@ -11534,7 +11536,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:08d5d685e4fdaaedf081020229844f4a58c9fd00244e4c37eb5b3fd78f4feb61
-      lastVerified: '2026-05-17T14:15:04.501Z'
+      lastVerified: '2026-05-17T15:04:27.299Z'
     claude-md:
       path: .aiox-core/core/doctor/checks/claude-md.js
       layer: L1
@@ -11554,7 +11556,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:88162c90d0b671c1a924fd6e18aeeb0fb229d19fb4204c12551feafbdef5d01d
-      lastVerified: '2026-05-17T14:15:04.501Z'
+      lastVerified: '2026-05-17T15:04:27.299Z'
     code-intel:
       path: .aiox-core/core/doctor/checks/code-intel.js
       layer: L1
@@ -11582,7 +11584,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5ed69815b54a686ef1076964f1eb667059712d35487fc2f1785a9897f59436fb
-      lastVerified: '2026-05-17T14:15:04.502Z'
+      lastVerified: '2026-05-17T15:04:27.299Z'
     commands-count:
       path: .aiox-core/core/doctor/checks/commands-count.js
       layer: L1
@@ -11602,7 +11604,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:eb3be16a561337ed64883ba578df1cb74790fcb6edee47bfd309d2480e66fbee
-      lastVerified: '2026-05-17T14:15:04.502Z'
+      lastVerified: '2026-05-17T15:04:27.299Z'
     core-config:
       path: .aiox-core/core/doctor/checks/core-config.js
       layer: L1
@@ -11622,7 +11624,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:53ddc48091f64805c100d08fb8cac5d1b4d74e844c8cfcde122f881a428b650b
-      lastVerified: '2026-05-17T14:15:04.502Z'
+      lastVerified: '2026-05-17T15:04:27.299Z'
     entity-registry:
       path: .aiox-core/core/doctor/checks/entity-registry.js
       layer: L1
@@ -11641,7 +11643,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bed5f0881102fecf77e7a4f990a1363b840422701f736e806c1c69908acae0aa
-      lastVerified: '2026-05-17T14:15:04.502Z'
+      lastVerified: '2026-05-17T15:04:27.300Z'
     git-hooks:
       path: .aiox-core/core/doctor/checks/git-hooks.js
       layer: L1
@@ -11661,7 +11663,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3fe9411a64265c581952f40044b70cc21b324773f54e4b902e4ce390c976fa2f
-      lastVerified: '2026-05-17T14:15:04.502Z'
+      lastVerified: '2026-05-17T15:04:27.300Z'
     graph-dashboard:
       path: .aiox-core/core/doctor/checks/graph-dashboard.js
       layer: L1
@@ -11681,7 +11683,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c4a16ab33117169aac7e4e29d841eec4f28a076f6d93fb9d872749831a14a17
-      lastVerified: '2026-05-17T14:15:04.502Z'
+      lastVerified: '2026-05-17T15:04:27.300Z'
     hooks-claude-count:
       path: .aiox-core/core/doctor/checks/hooks-claude-count.js
       layer: L1
@@ -11702,7 +11704,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:026ddf0248819b89b1147e0876a2934e38e0113d3c6380d68a752d432060e7ec
-      lastVerified: '2026-05-17T14:15:04.502Z'
+      lastVerified: '2026-05-17T15:04:27.300Z'
     ide-sync:
       path: .aiox-core/core/doctor/checks/ide-sync.js
       layer: L1
@@ -11722,7 +11724,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4ddd037b4ad18c4201ca1428a1044efd313e9d2721cd399aebd3c5043fd4e2d1
-      lastVerified: '2026-05-17T14:15:04.503Z'
+      lastVerified: '2026-05-17T15:04:27.300Z'
     doctor-checks-index:
       path: .aiox-core/core/doctor/checks/index.js
       layer: L1
@@ -11756,7 +11758,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c4034f86b66895c1ab9a8be4148577d5b886c21f31e05d32cbf8e4970e88f204
-      lastVerified: '2026-05-17T14:15:04.503Z'
+      lastVerified: '2026-05-17T15:04:27.301Z'
     node-version:
       path: .aiox-core/core/doctor/checks/node-version.js
       layer: L1
@@ -11777,7 +11779,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9e8bd100affa46131ac495c1e60ce87c88bbe879d459601a502589824d1aeac1
-      lastVerified: '2026-05-17T14:15:04.503Z'
+      lastVerified: '2026-05-17T15:04:27.301Z'
     npm-packages:
       path: .aiox-core/core/doctor/checks/npm-packages.js
       layer: L1
@@ -11797,7 +11799,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c54cb15dc3492ec50b4edc4733ecc5c41d5a00536aed87a5a5d815f472ee9f7
-      lastVerified: '2026-05-17T14:15:04.503Z'
+      lastVerified: '2026-05-17T15:04:27.301Z'
     rules-files:
       path: .aiox-core/core/doctor/checks/rules-files.js
       layer: L1
@@ -11818,7 +11820,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec58342215cede634f50c5b3164155c4f27fd8070af176ec0e02e6deec6fb218
-      lastVerified: '2026-05-17T14:15:04.503Z'
+      lastVerified: '2026-05-17T15:04:27.301Z'
     settings-json:
       path: .aiox-core/core/doctor/checks/settings-json.js
       layer: L1
@@ -11838,7 +11840,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bd26841b966fcfa003eca6f85416d4f877b9dcfea0e4017df9f2a97c14c33fbb
-      lastVerified: '2026-05-17T14:15:04.503Z'
+      lastVerified: '2026-05-17T15:04:27.301Z'
     skills-count:
       path: .aiox-core/core/doctor/checks/skills-count.js
       layer: L1
@@ -11858,7 +11860,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:811d904bde6d2ba4940f19cbe6a29cc12c5df6908ac95cb37bcb7add687fe4cc
-      lastVerified: '2026-05-17T14:15:04.504Z'
+      lastVerified: '2026-05-17T15:04:27.302Z'
     json:
       path: .aiox-core/core/doctor/formatters/json.js
       layer: L1
@@ -11878,7 +11880,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ea3f28f168f48ca3002661210932846f0e82c3dd9261d5e9115036f67e5a1ea4
-      lastVerified: '2026-05-17T14:15:04.504Z'
+      lastVerified: '2026-05-17T15:04:27.302Z'
     text:
       path: .aiox-core/core/doctor/formatters/text.js
       layer: L1
@@ -11897,7 +11899,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bd582b33c2d915516798627351c46d6d8edb56f655bb91037dfdbac159de77eb
-      lastVerified: '2026-05-17T14:15:04.504Z'
+      lastVerified: '2026-05-17T15:04:27.302Z'
     code-intel-source:
       path: .aiox-core/core/graph-dashboard/data-sources/code-intel-source.js
       layer: L1
@@ -11921,7 +11923,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2b0534f57a8f6ca2ff5942e42faf147f1be84773b3af33c9e506ee8f318b558c
-      lastVerified: '2026-05-17T14:15:04.504Z'
+      lastVerified: '2026-05-17T15:04:27.302Z'
     metrics-source:
       path: .aiox-core/core/graph-dashboard/data-sources/metrics-source.js
       layer: L1
@@ -11942,7 +11944,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b1e4027f82350760b67ea8f58e04a5e739f87f010838487043e29dab7301ae9e
-      lastVerified: '2026-05-17T14:15:04.504Z'
+      lastVerified: '2026-05-17T15:04:27.302Z'
     registry-source:
       path: .aiox-core/core/graph-dashboard/data-sources/registry-source.js
       layer: L1
@@ -11963,7 +11965,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:32d2a4bd5b102823d5933e5f9a648ae7e647cb1918092063161fed80d32b844b
-      lastVerified: '2026-05-17T14:15:04.504Z'
+      lastVerified: '2026-05-17T15:04:27.302Z'
     dot-formatter:
       path: .aiox-core/core/graph-dashboard/formatters/dot-formatter.js
       layer: L1
@@ -11983,7 +11985,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c369343f2b617a730951eb137d5ba74087bfd9f5dddbbf439e1fc2f87117d7a
-      lastVerified: '2026-05-17T14:15:04.504Z'
+      lastVerified: '2026-05-17T15:04:27.303Z'
     html-formatter:
       path: .aiox-core/core/graph-dashboard/formatters/html-formatter.js
       layer: L1
@@ -12003,7 +12005,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:81bfd3d61234cf17a0d7e25fbcdb86ddddc3f911e25a95f21604f7fe1d8d6a84
-      lastVerified: '2026-05-17T14:15:04.505Z'
+      lastVerified: '2026-05-17T15:04:27.303Z'
     json-formatter:
       path: .aiox-core/core/graph-dashboard/formatters/json-formatter.js
       layer: L1
@@ -12023,7 +12025,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0544ec384f716130a5141edc7ad6733dccd82b86e37fc1606f1120b0037c3f8d
-      lastVerified: '2026-05-17T14:15:04.505Z'
+      lastVerified: '2026-05-17T15:04:27.303Z'
     mermaid-formatter:
       path: .aiox-core/core/graph-dashboard/formatters/mermaid-formatter.js
       layer: L1
@@ -12043,7 +12045,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a6a5361cb7cdce2632d348ad32c659a3c383471fd338e76d578cc83c0888b2d7
-      lastVerified: '2026-05-17T14:15:04.505Z'
+      lastVerified: '2026-05-17T15:04:27.304Z'
     stats-renderer:
       path: .aiox-core/core/graph-dashboard/renderers/stats-renderer.js
       layer: L1
@@ -12063,7 +12065,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:375f904e8592a546f594f63b2c717db03db500e7070372db6de5524ac74ba474
-      lastVerified: '2026-05-17T14:15:04.505Z'
+      lastVerified: '2026-05-17T15:04:27.304Z'
     status-renderer:
       path: .aiox-core/core/graph-dashboard/renderers/status-renderer.js
       layer: L1
@@ -12083,7 +12085,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8e971ae267a570fac96782ee2d1ddb7787cc1efde9e17a2f23c9261ae0286acb
-      lastVerified: '2026-05-17T14:15:04.505Z'
+      lastVerified: '2026-05-17T15:04:27.304Z'
     tree-renderer:
       path: .aiox-core/core/graph-dashboard/renderers/tree-renderer.js
       layer: L1
@@ -12104,7 +12106,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:067bb5aefdfff0442a6132b89cec9ac61e84c9a9295097209a71c839978cef10
-      lastVerified: '2026-05-17T14:15:04.506Z'
+      lastVerified: '2026-05-17T15:04:27.304Z'
     health-check-checks-index:
       path: .aiox-core/core/health-check/checks/index.js
       layer: L1
@@ -12127,7 +12129,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d0713cca1b852d1b5a93d0c8e7d3c0fd3f3f05dde858ba1d5e5f9e053f41ae13
-      lastVerified: '2026-05-17T14:15:04.506Z'
+      lastVerified: '2026-05-17T15:04:27.304Z'
     backup-manager:
       path: .aiox-core/core/health-check/healers/backup-manager.js
       layer: L1
@@ -12146,7 +12148,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2827c219b84ef9a133a057c7b15b752a7681807711de47c0807b87b16973ffb1
-      lastVerified: '2026-05-17T14:15:04.506Z'
+      lastVerified: '2026-05-17T15:04:27.305Z'
     health-check-healers-index:
       path: .aiox-core/core/health-check/healers/index.js
       layer: L1
@@ -12167,7 +12169,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:09bb735207abb8ed6edbaa82247567d47f77fe3f09920e6b64c719338a9dd9e8
-      lastVerified: '2026-05-17T14:15:04.506Z'
+      lastVerified: '2026-05-17T15:04:27.305Z'
     console:
       path: .aiox-core/core/health-check/reporters/console.js
       layer: L1
@@ -12187,7 +12189,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:573f28a6c9c2a4087ccd349398f47351aa9a752c92a1f2e4a3c3f396682d5516
-      lastVerified: '2026-05-17T14:15:04.507Z'
+      lastVerified: '2026-05-17T15:04:27.306Z'
     health-check-reporters-index:
       path: .aiox-core/core/health-check/reporters/index.js
       layer: L1
@@ -12209,7 +12211,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5e32e3e0fa9e152bf2ffbcdbc80cbd046722eff75745ef571b21d55de760f9a2
-      lastVerified: '2026-05-17T14:15:04.507Z'
+      lastVerified: '2026-05-17T15:04:27.306Z'
     health-check-reporters-json:
       path: .aiox-core/core/health-check/reporters/json.js
       layer: L1
@@ -12228,7 +12230,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:56b97bb379b7f9e35cd0796ae51c17d990429b0b17f4a34f4350c65333b40b12
-      lastVerified: '2026-05-17T14:15:04.507Z'
+      lastVerified: '2026-05-17T15:04:27.306Z'
     markdown:
       path: .aiox-core/core/health-check/reporters/markdown.js
       layer: L1
@@ -12248,7 +12250,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9bc17bd3bc540f60bd3ea102586cd1e04b8b7ae10e8980fad75f185eec29ad51
-      lastVerified: '2026-05-17T14:15:04.507Z'
+      lastVerified: '2026-05-17T15:04:27.307Z'
     g1-epic-creation:
       path: .aiox-core/core/ids/gates/g1-epic-creation.js
       layer: L1
@@ -12269,7 +12271,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ba7c342b176f38f2c80cb141fe820b9a963a1966e33fef3a4ec568363b011c5f
-      lastVerified: '2026-05-17T14:15:04.507Z'
+      lastVerified: '2026-05-17T15:04:27.307Z'
     g2-story-creation:
       path: .aiox-core/core/ids/gates/g2-story-creation.js
       layer: L1
@@ -12290,7 +12292,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cb6312358a3d1c92a0094d25861e0747d0c1d63ffb08c82d8ed0a115a73ca1c5
-      lastVerified: '2026-05-17T14:15:04.508Z'
+      lastVerified: '2026-05-17T15:04:27.307Z'
     g3-story-validation:
       path: .aiox-core/core/ids/gates/g3-story-validation.js
       layer: L1
@@ -12311,7 +12313,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7b24912d9e80c5ca52d11950b133df6782b1c0c0914127ccef0dc8384026b4ae
-      lastVerified: '2026-05-17T14:15:04.508Z'
+      lastVerified: '2026-05-17T15:04:27.307Z'
     g4-dev-context:
       path: .aiox-core/core/ids/gates/g4-dev-context.js
       layer: L1
@@ -12332,7 +12334,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a0fdd59eb0c3a8a59862397b1af5af84971ce051929ae9d32361b7ca99a444fb
-      lastVerified: '2026-05-17T14:15:04.508Z'
+      lastVerified: '2026-05-17T15:04:27.307Z'
     g5-semantic-handshake:
       path: .aiox-core/core/ids/gates/g5-semantic-handshake.js
       layer: L1
@@ -12353,7 +12355,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a008c60a4afc98f03dc41219989f7306884254d802b0958282a29462c9fd0f72
-      lastVerified: '2026-05-17T14:15:04.508Z'
+      lastVerified: '2026-05-17T15:04:27.308Z'
     active-modules.verify:
       path: .aiox-core/core/memory/__tests__/active-modules.verify.js
       layer: L1
@@ -12375,7 +12377,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:895ec75f6a303edf4cffa0ab7adbb8a4876f62626cc0d7178420efd5758f21a9
-      lastVerified: '2026-05-17T14:15:04.522Z'
+      lastVerified: '2026-05-17T15:04:27.308Z'
     epic-3-executor:
       path: .aiox-core/core/orchestration/executors/epic-3-executor.js
       layer: L1
@@ -12396,12 +12398,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1cadb0544660cead45f940839a0bec51f6a8ef143b7ab1dc006b89c4abb0c1c0
-      lastVerified: '2026-05-17T14:15:04.525Z'
+      lastVerified: '2026-05-17T15:04:27.308Z'
     epic-4-executor:
       path: .aiox-core/core/orchestration/executors/epic-4-executor.js
       layer: L1
       type: module
-      purpose: 'Generated: ${new Date().toISOString()}'
+      purpose: Entity at .aiox-core/core/orchestration/executors/epic-4-executor.js
       keywords:
         - epic
         - executor
@@ -12422,7 +12424,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b2f8944114839f9b02a0b46d037fa64e2d1584d3aab6ff74537e32a16b6a793d
-      lastVerified: '2026-05-17T14:15:04.536Z'
+      lastVerified: '2026-05-17T15:04:27.309Z'
     epic-5-executor:
       path: .aiox-core/core/orchestration/executors/epic-5-executor.js
       layer: L1
@@ -12445,7 +12447,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d334dc728dec74fdb744f14d83f9fd2b7dabc46bcaa0d2dfae482cc131e0107b
-      lastVerified: '2026-05-17T14:15:04.536Z'
+      lastVerified: '2026-05-17T15:04:27.309Z'
     epic-6-executor:
       path: .aiox-core/core/orchestration/executors/epic-6-executor.js
       layer: L1
@@ -12467,7 +12469,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1bbc14e8236f87c074db46833345a724ee5056a28b97fbb2528d4eedd350ab12
-      lastVerified: '2026-05-17T14:15:04.545Z'
+      lastVerified: '2026-05-17T15:04:27.309Z'
     epic-executor:
       path: .aiox-core/core/orchestration/executors/epic-executor.js
       layer: L1
@@ -12491,7 +12493,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f2b20cd8cc4f3473bfcc7afdc0bc20e21665bab92274433ede58eabc4691a6b9
-      lastVerified: '2026-05-17T14:15:04.547Z'
+      lastVerified: '2026-05-17T15:04:27.309Z'
     orchestration-executors-index:
       path: .aiox-core/core/orchestration/executors/index.js
       layer: L1
@@ -12515,7 +12517,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:21f66b6d59c67079bfd6f30dcb675bab60d8a3b6283c24246497d641beed1f57
-      lastVerified: '2026-05-17T14:15:04.548Z'
+      lastVerified: '2026-05-17T15:04:27.310Z'
     permission-mode.test:
       path: .aiox-core/core/permissions/__tests__/permission-mode.test.js
       layer: L1
@@ -12537,7 +12539,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8c8a48c75933a7bf3cf4588f8e4af3911cbb6b67fb07fa526a79bada8949ce2c
-      lastVerified: '2026-05-17T14:15:04.550Z'
+      lastVerified: '2026-05-17T15:04:27.310Z'
     context-builder:
       path: .aiox-core/core/synapse/context/context-builder.js
       layer: L1
@@ -12557,7 +12559,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:121cd0a1df8a44098831cd4335536e8facf4e65b8aec48f4ce9c2d432dc6252a
-      lastVerified: '2026-05-17T14:15:04.550Z'
+      lastVerified: '2026-05-17T15:04:27.310Z'
     context-tracker:
       path: .aiox-core/core/synapse/context/context-tracker.js
       layer: L1
@@ -12578,7 +12580,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5a54a15fbbbd4b6095e7e78297cb87e4a123a7c1d714a7c7916272ef6fd680f1
-      lastVerified: '2026-05-17T14:15:04.552Z'
+      lastVerified: '2026-05-17T15:04:27.310Z'
     hierarchical-context-manager:
       path: .aiox-core/core/synapse/context/hierarchical-context-manager.js
       layer: L1
@@ -12599,7 +12601,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:34f5b9e64c46880138ad684d64e7006f63c16211a219afa81a2c1b6236748af5
-      lastVerified: '2026-05-17T14:15:04.552Z'
+      lastVerified: '2026-05-17T15:04:27.311Z'
     synapse-context-index:
       path: .aiox-core/core/synapse/context/index.js
       layer: L1
@@ -12617,7 +12619,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6475a5730451d8754cc6c7ab4c1ef4decca98e093c69045661eae17da5897e07
-      lastVerified: '2026-05-17T14:15:04.552Z'
+      lastVerified: '2026-05-17T15:04:27.311Z'
     semantic-handshake-engine:
       path: .aiox-core/core/synapse/context/semantic-handshake-engine.js
       layer: L1
@@ -12637,7 +12639,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:be5f2f7300902a2916f6758b46636b96f083c11e1b831f5835bf97859a4b80a6
-      lastVerified: '2026-05-17T14:15:04.553Z'
+      lastVerified: '2026-05-17T15:04:27.311Z'
     report-formatter:
       path: .aiox-core/core/synapse/diagnostics/report-formatter.js
       layer: L1
@@ -12657,7 +12659,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e6d26c1cd9910d8311306111cc3fef3a4bb1c4bd6b1ef0e4bb8f407da9baf7f1
-      lastVerified: '2026-05-17T14:15:04.553Z'
+      lastVerified: '2026-05-17T15:04:27.312Z'
     synapse-diagnostics:
       path: .aiox-core/core/synapse/diagnostics/synapse-diagnostics.js
       layer: L1
@@ -12683,7 +12685,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de9dffce0e380637027cbd64b062d3eeffc37e42a84a337e5758fbef39fe3a00
-      lastVerified: '2026-05-17T14:15:04.554Z'
+      lastVerified: '2026-05-17T15:04:27.312Z'
     domain-loader:
       path: .aiox-core/core/synapse/domain/domain-loader.js
       layer: L1
@@ -12711,7 +12713,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:af788f9da956b89eef1e5eb4ef4efdf05ca758c8969a2c375f568119495ebc05
-      lastVerified: '2026-05-17T14:15:04.554Z'
+      lastVerified: '2026-05-17T15:04:27.312Z'
     l0-constitution:
       path: .aiox-core/core/synapse/layers/l0-constitution.js
       layer: L1
@@ -12732,7 +12734,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2123a6a44915aaac2a6bbd26c67c285c9d1e12b50fe42a8ada668306b07d1c4a
-      lastVerified: '2026-05-17T14:15:04.554Z'
+      lastVerified: '2026-05-17T15:04:27.312Z'
     l1-global:
       path: .aiox-core/core/synapse/layers/l1-global.js
       layer: L1
@@ -12753,7 +12755,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:21f6969e6d64e9a85c876be6799db4ca7d090f0009057f4a06ead8da12392d45
-      lastVerified: '2026-05-17T14:15:04.555Z'
+      lastVerified: '2026-05-17T15:04:27.313Z'
     l2-agent:
       path: .aiox-core/core/synapse/layers/l2-agent.js
       layer: L1
@@ -12774,7 +12776,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a8677dc58ae7927c5292a4b52883bbc905c8112573b8b8631f0b8bc01ea2b6e6
-      lastVerified: '2026-05-17T14:15:04.555Z'
+      lastVerified: '2026-05-17T15:04:27.313Z'
     l3-workflow:
       path: .aiox-core/core/synapse/layers/l3-workflow.js
       layer: L1
@@ -12795,7 +12797,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:496cbd71d7dac9c1daa534ffac45c622d0c032f334fedf493e9322a565b2b181
-      lastVerified: '2026-05-17T14:15:04.555Z'
+      lastVerified: '2026-05-17T15:04:27.313Z'
     l4-task:
       path: .aiox-core/core/synapse/layers/l4-task.js
       layer: L1
@@ -12815,7 +12817,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:30df70c04b16e3aff95899211ef6ae3d9f0a8097ebdc7de92599fc6cb792e5f0
-      lastVerified: '2026-05-17T14:15:04.555Z'
+      lastVerified: '2026-05-17T15:04:27.313Z'
     l5-squad:
       path: .aiox-core/core/synapse/layers/l5-squad.js
       layer: L1
@@ -12836,7 +12838,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fabc2bcb01543ef7d249631da02297d67e42f4d0fcf9e159b79564793ce8f7bb
-      lastVerified: '2026-05-17T14:15:04.555Z'
+      lastVerified: '2026-05-17T15:04:27.313Z'
     l6-keyword:
       path: .aiox-core/core/synapse/layers/l6-keyword.js
       layer: L1
@@ -12857,7 +12859,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8e5405999a2ce2f3ca4e62e863cf702ba27448914241f5eb8f02760bc7477523
-      lastVerified: '2026-05-17T14:15:04.556Z'
+      lastVerified: '2026-05-17T15:04:27.313Z'
     l7-star-command:
       path: .aiox-core/core/synapse/layers/l7-star-command.js
       layer: L1
@@ -12879,7 +12881,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3b8372ac1c51830c1ef560b1012b112a3559651b0750e42f2037f7fe9e6787d6
-      lastVerified: '2026-05-17T14:15:04.556Z'
+      lastVerified: '2026-05-17T15:04:27.314Z'
     layer-processor:
       path: .aiox-core/core/synapse/layers/layer-processor.js
       layer: L1
@@ -12906,7 +12908,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9cdb5efb2e95780373dd0ce8dcb64791dd1471128fc6914d274c6744036842a3
-      lastVerified: '2026-05-17T14:15:04.556Z'
+      lastVerified: '2026-05-17T15:04:27.314Z'
     memory-bridge:
       path: .aiox-core/core/synapse/memory/memory-bridge.js
       layer: L1
@@ -12928,7 +12930,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:820875f97ceea80fc6402c0dab1706cfe58de527897b22dea68db40b0d6ec368
-      lastVerified: '2026-05-17T14:15:04.557Z'
+      lastVerified: '2026-05-17T15:04:27.314Z'
     synapse-memory-provider:
       path: .aiox-core/core/synapse/memory/synapse-memory-provider.js
       layer: L1
@@ -12951,7 +12953,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5d613d1fac7ee82c49a3f03b38735fd3cabfe87dd868494672ddfef300ea3145
-      lastVerified: '2026-05-17T14:15:04.557Z'
+      lastVerified: '2026-05-17T15:04:27.314Z'
     formatter:
       path: .aiox-core/core/synapse/output/formatter.js
       layer: L1
@@ -12971,7 +12973,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fe4f6c2f6091defb6af66dad71db0640f919b983111087f8cc5821e3d44ca864
-      lastVerified: '2026-05-17T14:15:04.557Z'
+      lastVerified: '2026-05-17T15:04:27.314Z'
     synapse-runtime-hook-runtime:
       path: .aiox-core/core/synapse/runtime/hook-runtime.js
       layer: L1
@@ -12990,7 +12992,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c8a31f8cfcc760de06c65abd3c5d23d9ffd8490f7f0ae4a674efaba73e10dd44
-      lastVerified: '2026-05-17T14:15:04.557Z'
+      lastVerified: '2026-05-17T15:04:27.316Z'
     generate-constitution:
       path: .aiox-core/core/synapse/scripts/generate-constitution.js
       layer: L1
@@ -13009,7 +13011,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9010d6b34667c96602b76baa1857f0629c797d911b7c42dc11414b007e5e2b91
-      lastVerified: '2026-05-17T14:15:04.557Z'
+      lastVerified: '2026-05-17T15:04:27.319Z'
     synapse-session-session-manager:
       path: .aiox-core/core/synapse/session/session-manager.js
       layer: L1
@@ -13029,7 +13031,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:98e8c8fa15b074b6102bcd51c6f91f101743338e8cde6de9c31d6b6eea5d6580
-      lastVerified: '2026-05-17T14:15:04.558Z'
+      lastVerified: '2026-05-17T15:04:27.319Z'
     atomic-write:
       path: .aiox-core/core/synapse/utils/atomic-write.js
       layer: L1
@@ -13051,7 +13053,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:efeef0fbcebb184df5b79f4ba4b4b7fe274c3ba7d1c705ce1af92628e920bd8b
-      lastVerified: '2026-05-17T14:15:04.558Z'
+      lastVerified: '2026-05-17T15:04:27.319Z'
     paths:
       path: .aiox-core/core/synapse/utils/paths.js
       layer: L1
@@ -13069,7 +13071,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bf8cf93c1a16295e7de055bee292e2778a152b6e7d6c648dbc054a4b04dffc10
-      lastVerified: '2026-05-17T14:15:04.558Z'
+      lastVerified: '2026-05-17T15:04:27.319Z'
     tokens:
       path: .aiox-core/core/synapse/utils/tokens.js
       layer: L1
@@ -13091,7 +13093,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3b927daec51d0a791f3fe4ef9aafc362773450e7cf50eb4b6d8ae9011d70df9a
-      lastVerified: '2026-05-17T14:15:04.558Z'
+      lastVerified: '2026-05-17T15:04:27.320Z'
     build-config:
       path: .aiox-core/core/health-check/checks/deployment/build-config.js
       layer: L1
@@ -13112,7 +13114,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2be009177bf26ca7e1ac2f1f6bc973e409ba1feac83906c96cab0b70e60c1af7
-      lastVerified: '2026-05-17T14:15:04.558Z'
+      lastVerified: '2026-05-17T15:04:27.320Z'
     ci-config:
       path: .aiox-core/core/health-check/checks/deployment/ci-config.js
       layer: L1
@@ -13133,7 +13135,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ad8399d53c01cb989cc17e60a3547aec2a0c31ba62d2664ef47482ccd0c6b144
-      lastVerified: '2026-05-17T14:15:04.558Z'
+      lastVerified: '2026-05-17T15:04:27.320Z'
     deployment-readiness:
       path: .aiox-core/core/health-check/checks/deployment/deployment-readiness.js
       layer: L1
@@ -13154,7 +13156,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7c4706e829968ddae47f9f372140c36fd96e3148eec5dade3e1d5b7c3b276d38
-      lastVerified: '2026-05-17T14:15:04.558Z'
+      lastVerified: '2026-05-17T15:04:27.320Z'
     docker-config:
       path: .aiox-core/core/health-check/checks/deployment/docker-config.js
       layer: L1
@@ -13175,7 +13177,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a4558144220078fcc203ae662756df4f0715ffe56d94853996f01a7100a8b11a
-      lastVerified: '2026-05-17T14:15:04.559Z'
+      lastVerified: '2026-05-17T15:04:27.320Z'
     env-file:
       path: .aiox-core/core/health-check/checks/deployment/env-file.js
       layer: L1
@@ -13196,7 +13198,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2864d9210c0fcf58ac11016077ac24c23edd1dbb570ace46c1762de5f0d4ebae
-      lastVerified: '2026-05-17T14:15:04.559Z'
+      lastVerified: '2026-05-17T15:04:27.321Z'
     health-check-checks-deployment-index:
       path: .aiox-core/core/health-check/checks/deployment/index.js
       layer: L1
@@ -13221,7 +13223,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ac2b152a971650ecac4c84d92a7769b0aa6ec761c06b11e420bd62f0b8066eef
-      lastVerified: '2026-05-17T14:15:04.559Z'
+      lastVerified: '2026-05-17T15:04:27.321Z'
     disk-space:
       path: .aiox-core/core/health-check/checks/local/disk-space.js
       layer: L1
@@ -13242,7 +13244,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fa400f15c9bc1a61233472639bb44b6a5f4785fbe10690f8254e54edffb7dead
-      lastVerified: '2026-05-17T14:15:04.559Z'
+      lastVerified: '2026-05-17T15:04:27.321Z'
     environment-vars:
       path: .aiox-core/core/health-check/checks/local/environment-vars.js
       layer: L1
@@ -13263,7 +13265,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4da9aefdf717e267d5a0e60408b866f49ca5f49cde0e6b1fb14050046a9458d0
-      lastVerified: '2026-05-17T14:15:04.559Z'
+      lastVerified: '2026-05-17T15:04:27.321Z'
     git-install:
       path: .aiox-core/core/health-check/checks/local/git-install.js
       layer: L1
@@ -13284,7 +13286,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f17dd15a5696de04b6530f6eb99d1c29d2a19486c7220be42f87712cb0858df2
-      lastVerified: '2026-05-17T14:15:04.559Z'
+      lastVerified: '2026-05-17T15:04:27.321Z'
     ide-detection:
       path: .aiox-core/core/health-check/checks/local/ide-detection.js
       layer: L1
@@ -13305,7 +13307,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:632ccbc44b3cd4306ba2391e6cea8e91e20ccedd62bb421f46ca33cd7daa7230
-      lastVerified: '2026-05-17T14:15:04.560Z'
+      lastVerified: '2026-05-17T15:04:27.322Z'
     health-check-checks-local-index:
       path: .aiox-core/core/health-check/checks/local/index.js
       layer: L1
@@ -13333,7 +13335,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9f98eecb00f844f22448489f993f84c045847e3ef579c8bcf7f15a7bd56b167b
-      lastVerified: '2026-05-17T14:15:04.560Z'
+      lastVerified: '2026-05-17T15:04:27.322Z'
     memory:
       path: .aiox-core/core/health-check/checks/local/memory.js
       layer: L1
@@ -13354,7 +13356,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e959adc1f7f41ab5054bb8786967722d0364700b8e5139f94f5181a0d3dfc819
-      lastVerified: '2026-05-17T14:15:04.560Z'
+      lastVerified: '2026-05-17T15:04:27.322Z'
     network:
       path: .aiox-core/core/health-check/checks/local/network.js
       layer: L1
@@ -13374,7 +13376,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:77915bfd3f27b8f02c3eb8bb4d8c37f1e34541766633dde3b0d509b223435c98
-      lastVerified: '2026-05-17T14:15:04.560Z'
+      lastVerified: '2026-05-17T15:04:27.322Z'
     npm-install:
       path: .aiox-core/core/health-check/checks/local/npm-install.js
       layer: L1
@@ -13395,7 +13397,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:592a7ed7468d4f5dc28c5261a363035545b84d4b32c2601bd52075e02f0cbdc2
-      lastVerified: '2026-05-17T14:15:04.561Z'
+      lastVerified: '2026-05-17T15:04:27.322Z'
     shell-environment:
       path: .aiox-core/core/health-check/checks/local/shell-environment.js
       layer: L1
@@ -13416,7 +13418,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c98b9d4f3636d8c229c8031ed5126fc0fe35b6b740af320e21e05aaf1b5c402
-      lastVerified: '2026-05-17T14:15:04.561Z'
+      lastVerified: '2026-05-17T15:04:27.323Z'
     agent-config:
       path: .aiox-core/core/health-check/checks/project/agent-config.js
       layer: L1
@@ -13437,7 +13439,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0195e2b95c94fcea2c7fae5636664e24657e182a0b3d8e95ce4ccf7b15809de2
-      lastVerified: '2026-05-17T14:15:04.561Z'
+      lastVerified: '2026-05-17T15:04:27.323Z'
     aiox-directory:
       path: .aiox-core/core/health-check/checks/project/aiox-directory.js
       layer: L1
@@ -13458,7 +13460,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:332d298d2ac7eb89ca6f3471f3a0970175f80c9a8735582af2ad5eb3331a8523
-      lastVerified: '2026-05-17T14:15:04.561Z'
+      lastVerified: '2026-05-17T15:04:27.323Z'
     dependencies:
       path: .aiox-core/core/health-check/checks/project/dependencies.js
       layer: L1
@@ -13478,7 +13480,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:70feccca72c7eacd5740ec9b194a80d24f997f5300487633eba9a272cbf749df
-      lastVerified: '2026-05-17T14:15:04.561Z'
+      lastVerified: '2026-05-17T15:04:27.324Z'
     framework-config:
       path: .aiox-core/core/health-check/checks/project/framework-config.js
       layer: L1
@@ -13499,7 +13501,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6ca4088a1b5399d47bc6bd04a4867b807b7003e7a91e35ddafcfcc3996f171fc
-      lastVerified: '2026-05-17T14:15:04.561Z'
+      lastVerified: '2026-05-17T15:04:27.324Z'
     health-check-checks-project-index:
       path: .aiox-core/core/health-check/checks/project/index.js
       layer: L1
@@ -13527,7 +13529,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:69a081967556f8325572c25615f19e30abf18d7c0c73a195953587dff34e8dfa
-      lastVerified: '2026-05-17T14:15:04.561Z'
+      lastVerified: '2026-05-17T15:04:27.324Z'
     health-check-checks-project-node-version:
       path: .aiox-core/core/health-check/checks/project/node-version.js
       layer: L1
@@ -13547,7 +13549,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9bcebbd153d89b3f04d58850f48f2c2bcd9648286db656832197b429b7fc3391
-      lastVerified: '2026-05-17T14:15:04.562Z'
+      lastVerified: '2026-05-17T15:04:27.325Z'
     package-json:
       path: .aiox-core/core/health-check/checks/project/package-json.js
       layer: L1
@@ -13568,7 +13570,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ba15da8cc0aaec18e7320db8c4942e04d3c159beb8605fa58a5939d6b77debe3
-      lastVerified: '2026-05-17T14:15:04.562Z'
+      lastVerified: '2026-05-17T15:04:27.325Z'
     task-definitions:
       path: .aiox-core/core/health-check/checks/project/task-definitions.js
       layer: L1
@@ -13589,7 +13591,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:87c6edf9210856e065cd8c491a14b8a016aad429dbae7b0f814ac8b9b3989770
-      lastVerified: '2026-05-17T14:15:04.562Z'
+      lastVerified: '2026-05-17T15:04:27.325Z'
     workflow-dependencies:
       path: .aiox-core/core/health-check/checks/project/workflow-dependencies.js
       layer: L1
@@ -13610,7 +13612,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0eb04100b5c5a56b44b09ab7ca03426e01513c4eb109cc989603484329bc49d9
-      lastVerified: '2026-05-17T14:15:04.562Z'
+      lastVerified: '2026-05-17T15:04:27.325Z'
     branch-protection:
       path: .aiox-core/core/health-check/checks/repository/branch-protection.js
       layer: L1
@@ -13631,7 +13633,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4ee18e46c088005e2f39399dbd80a4fc3e8251baf1c9cbff698d7a941af8416f
-      lastVerified: '2026-05-17T14:15:04.562Z'
+      lastVerified: '2026-05-17T15:04:27.325Z'
     commit-history:
       path: .aiox-core/core/health-check/checks/repository/commit-history.js
       layer: L1
@@ -13652,7 +13654,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ae9d221803f518b0167d71a1c9c2ea5f2392c83d6279e87fbfb3dea95f5845ba
-      lastVerified: '2026-05-17T14:15:04.562Z'
+      lastVerified: '2026-05-17T15:04:27.326Z'
     conflicts:
       path: .aiox-core/core/health-check/checks/repository/conflicts.js
       layer: L1
@@ -13672,7 +13674,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6e9eb41c2a560a8cdc9154475be65ab1a110017d28c15a991af9dca5ebf9515e
-      lastVerified: '2026-05-17T14:15:04.563Z'
+      lastVerified: '2026-05-17T15:04:27.326Z'
     git-repo:
       path: .aiox-core/core/health-check/checks/repository/git-repo.js
       layer: L1
@@ -13693,7 +13695,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:80e1a09561f744772c40575f3f4c0d3a1847fbdf9825fbf616631c5edc67a833
-      lastVerified: '2026-05-17T14:15:04.563Z'
+      lastVerified: '2026-05-17T15:04:27.326Z'
     git-status:
       path: .aiox-core/core/health-check/checks/repository/git-status.js
       layer: L1
@@ -13714,7 +13716,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:aad6379855e89558b43584e8812f04e6a2f771331bbebee116a451f9f4b177d1
-      lastVerified: '2026-05-17T14:15:04.563Z'
+      lastVerified: '2026-05-17T15:04:27.326Z'
     gitignore:
       path: .aiox-core/core/health-check/checks/repository/gitignore.js
       layer: L1
@@ -13734,7 +13736,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bec3b6a29ed336920a55d21f888ce29a4589a421d8a6695d40954ddd49eb4106
-      lastVerified: '2026-05-17T14:15:04.563Z'
+      lastVerified: '2026-05-17T15:04:27.326Z'
     health-check-checks-repository-index:
       path: .aiox-core/core/health-check/checks/repository/index.js
       layer: L1
@@ -13762,7 +13764,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f34fdabfde45775c0906fffd02ac1bed1ac03fe6deec119883ca681c2daff85c
-      lastVerified: '2026-05-17T14:15:04.563Z'
+      lastVerified: '2026-05-17T15:04:27.327Z'
     large-files:
       path: .aiox-core/core/health-check/checks/repository/large-files.js
       layer: L1
@@ -13783,7 +13785,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8b1405280dd929c3ba5a47cf0a52bc7fd1f7efbc1ba3e8e4fdcbbcd56fe2a76e
-      lastVerified: '2026-05-17T14:15:04.563Z'
+      lastVerified: '2026-05-17T15:04:27.327Z'
     lockfile-integrity:
       path: .aiox-core/core/health-check/checks/repository/lockfile-integrity.js
       layer: L1
@@ -13804,7 +13806,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6b2d42f1d228f64079929c4d6cdeb9f5ed7217bb390ecfe2e00727c6f59527e0
-      lastVerified: '2026-05-17T14:15:04.564Z'
+      lastVerified: '2026-05-17T15:04:27.327Z'
     api-endpoints:
       path: .aiox-core/core/health-check/checks/services/api-endpoints.js
       layer: L1
@@ -13825,7 +13827,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2233d5af1610d5553353e21e720c9cb0ecfbb968ab605d14896705458ae7ca55
-      lastVerified: '2026-05-17T14:15:04.564Z'
+      lastVerified: '2026-05-17T15:04:27.327Z'
     claude-code:
       path: .aiox-core/core/health-check/checks/services/claude-code.js
       layer: L1
@@ -13845,7 +13847,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:69af55e5ad7e941e5e6d0a9e3aab7a4e6c2aaec491aa5955fd6c23be432b5ab7
-      lastVerified: '2026-05-17T14:15:04.564Z'
+      lastVerified: '2026-05-17T15:04:27.327Z'
     gemini-cli:
       path: .aiox-core/core/health-check/checks/services/gemini-cli.js
       layer: L1
@@ -13866,7 +13868,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1c37af5d3cd598c44bce4d37c9d90b3c72167841882d6ea3563cc55e2bfa147e
-      lastVerified: '2026-05-17T14:15:04.564Z'
+      lastVerified: '2026-05-17T15:04:27.328Z'
     github-cli:
       path: .aiox-core/core/health-check/checks/services/github-cli.js
       layer: L1
@@ -13886,7 +13888,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b94fa0d8917a8506ce80620d390e9344935a700f87bf8034c3c24d12256cd85a
-      lastVerified: '2026-05-17T14:15:04.564Z'
+      lastVerified: '2026-05-17T15:04:27.328Z'
     health-check-checks-services-index:
       path: .aiox-core/core/health-check/checks/services/index.js
       layer: L1
@@ -13911,7 +13913,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:979198ad95353636e18153b3f7e7ed1e49e2bf04af653d95b3058b9735332667
-      lastVerified: '2026-05-17T14:15:04.564Z'
+      lastVerified: '2026-05-17T15:04:27.328Z'
     mcp-integration:
       path: .aiox-core/core/health-check/checks/services/mcp-integration.js
       layer: L1
@@ -13932,7 +13934,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:139b29b91e4f2d0abf50b08a272a688036132abba8f71adca9b26c3fb8eb671e
-      lastVerified: '2026-05-17T14:15:04.565Z'
+      lastVerified: '2026-05-17T15:04:27.329Z'
     consistency-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/consistency-collector.js
       layer: L1
@@ -13952,7 +13954,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:65f4255f87c9900400649dc8b9aedaac4851b5939d93e127778bd93cee99db12
-      lastVerified: '2026-05-17T14:15:04.565Z'
+      lastVerified: '2026-05-17T15:04:27.329Z'
     hook-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/hook-collector.js
       layer: L1
@@ -13972,7 +13974,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c2cfa1b760bcb05decf5ad05f9159140cbe0cdc6b0f91581790e44d83dc6b660
-      lastVerified: '2026-05-17T14:15:04.565Z'
+      lastVerified: '2026-05-17T15:04:27.330Z'
     manifest-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/manifest-collector.js
       layer: L1
@@ -13993,7 +13995,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3dc895eb94485320ecbaca3a1d29e3776cfb691dd7dcc71cf44b34af30e8ebb6
-      lastVerified: '2026-05-17T14:15:04.565Z'
+      lastVerified: '2026-05-17T15:04:27.331Z'
     output-analyzer:
       path: .aiox-core/core/synapse/diagnostics/collectors/output-analyzer.js
       layer: L1
@@ -14013,7 +14015,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e6846b1aba0a6cba17c297a871861d4f8199d7500220bff296a6a3291e32493e
-      lastVerified: '2026-05-17T14:15:04.565Z'
+      lastVerified: '2026-05-17T15:04:27.331Z'
     pipeline-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/pipeline-collector.js
       layer: L1
@@ -14034,7 +14036,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8655b6240e2f54b70def1a8c2fae00d40e2615cb95fd7ca0d64c2e0a6dfe3b73
-      lastVerified: '2026-05-17T14:15:04.565Z'
+      lastVerified: '2026-05-17T15:04:27.331Z'
     quality-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/quality-collector.js
       layer: L1
@@ -14054,7 +14056,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:30ae299eab6d569d09afe3530a5b2f1ff35ef75366a1ab56a9e2a57d39d3611c
-      lastVerified: '2026-05-17T14:15:04.566Z'
+      lastVerified: '2026-05-17T15:04:27.332Z'
     relevance-matrix:
       path: .aiox-core/core/synapse/diagnostics/collectors/relevance-matrix.js
       layer: L1
@@ -14074,7 +14076,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f92c4f7061dc82eed4310a27b69eade33d3015f9beb1bed688601a2dccbad22e
-      lastVerified: '2026-05-17T14:15:04.566Z'
+      lastVerified: '2026-05-17T15:04:27.332Z'
     safe-read-json:
       path: .aiox-core/core/synapse/diagnostics/collectors/safe-read-json.js
       layer: L1
@@ -14099,7 +14101,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dc7bcd13779207ad67b1c3929b7e1e0ccfa3563f3458c20cad28cb1922e9a74c
-      lastVerified: '2026-05-17T14:15:04.566Z'
+      lastVerified: '2026-05-17T15:04:27.332Z'
     session-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/session-collector.js
       layer: L1
@@ -14119,7 +14121,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a116d884d6947ddc8e5f3def012d93696576c584c4fde1639b8d895924fc09ea
-      lastVerified: '2026-05-17T14:15:04.566Z'
+      lastVerified: '2026-05-17T15:04:27.332Z'
     timing-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/timing-collector.js
       layer: L1
@@ -14139,7 +14141,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2523ce93f863a28f798d992c4f2fab041c91a09413b3186fd290e6035b391587
-      lastVerified: '2026-05-17T14:15:04.566Z'
+      lastVerified: '2026-05-17T15:04:27.332Z'
     uap-collector:
       path: .aiox-core/core/synapse/diagnostics/collectors/uap-collector.js
       layer: L1
@@ -14159,7 +14161,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dd025894f8f0d3bd22a147dbc0debef8b83e96f3c59483653404b3cd5a01d5aa
-      lastVerified: '2026-05-17T14:15:04.567Z'
+      lastVerified: '2026-05-17T15:04:27.333Z'
   agents:
     aiox-master:
       path: .aiox-core/development/agents/aiox-master.md
@@ -14238,7 +14240,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:66175a22e6982e5c0f4123f84af8388eb0cfc81124b8e9ec8f44d502c4ca6cf8
-      lastVerified: '2026-05-17T14:15:04.573Z'
+      lastVerified: '2026-05-17T15:04:27.339Z'
     analyst:
       path: .aiox-core/development/agents/analyst.md
       layer: L2
@@ -14290,7 +14292,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:35150d764c6dc74bc02b61a4d613c9278e87ffb209403db23991339fdda4f8e2
-      lastVerified: '2026-05-17T14:15:04.575Z'
+      lastVerified: '2026-05-17T15:04:27.340Z'
     architect:
       path: .aiox-core/development/agents/architect.md
       layer: L2
@@ -14364,7 +14366,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b89e95048df940056570ecb6589f18a9a6114b96ca1b9fde130fb7bdb2ded8f
-      lastVerified: '2026-05-17T14:15:04.577Z'
+      lastVerified: '2026-05-17T15:04:27.343Z'
     data-engineer:
       path: .aiox-core/development/agents/data-engineer.md
       layer: L2
@@ -14431,7 +14433,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:41c791fbdf43f700f2e78418c8af18197d1135741bc7845d03013f726b125f6f
-      lastVerified: '2026-05-17T14:15:04.579Z'
+      lastVerified: '2026-05-17T15:04:27.344Z'
     dev:
       path: .aiox-core/development/agents/dev.md
       layer: L2
@@ -14545,7 +14547,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:eaaec824273f02b9ccbe6768d9e9147a5ad0d7faa9483b9730b1f02a71ef2769
-      lastVerified: '2026-05-17T14:15:04.581Z'
+      lastVerified: '2026-05-17T15:04:27.347Z'
     devops:
       path: .aiox-core/development/agents/devops.md
       layer: L2
@@ -14639,7 +14641,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5c52cc74f923ac381fa92fb969607b80a35f34b958c02d2d1edd1115f7690d35
-      lastVerified: '2026-05-17T14:15:04.583Z'
+      lastVerified: '2026-05-17T15:04:27.350Z'
     pm:
       path: .aiox-core/development/agents/pm.md
       layer: L2
@@ -14699,7 +14701,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8c81fd9b6df9b98fa3d3654062464498396ddb4eaf0b6dc3a644ae4227982f4b
-      lastVerified: '2026-05-17T14:15:04.585Z'
+      lastVerified: '2026-05-17T15:04:27.352Z'
     po:
       path: .aiox-core/development/agents/po.md
       layer: L2
@@ -14762,7 +14764,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f0090329fd2c2871d3b46d0b2ea1bb9ff3fe48c589fc25ed3d90cf2032621cfd
-      lastVerified: '2026-05-17T14:15:04.586Z'
+      lastVerified: '2026-05-17T15:04:27.353Z'
     qa:
       path: .aiox-core/development/agents/qa.md
       layer: L2
@@ -14848,7 +14850,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cf4a8f473067a9d2909072215bce7b13917c779442e6f858681bd8b9f0b0c3c0
-      lastVerified: '2026-05-17T14:15:04.587Z'
+      lastVerified: '2026-05-17T15:04:27.355Z'
     sm:
       path: .aiox-core/development/agents/sm.md
       layer: L2
@@ -14891,7 +14893,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b09334044d3ba581f5403d5d15e0d35c25e580634e712f24bb5a1bc73c9d1cf3
-      lastVerified: '2026-05-17T14:15:04.588Z'
+      lastVerified: '2026-05-17T15:04:27.356Z'
     squad-creator:
       path: .aiox-core/development/agents/squad-creator.md
       layer: L2
@@ -14930,7 +14932,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9ae479d628a74fdf8372da4e5a306fdc93235bce8f4957b44ad9adc76643f8e1
-      lastVerified: '2026-05-17T14:15:04.589Z'
+      lastVerified: '2026-05-17T15:04:27.356Z'
     ux-design-expert:
       path: .aiox-core/development/agents/ux-design-expert.md
       layer: L2
@@ -15001,7 +15003,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b6a552405cf1a1eab76e307a505e8b431bffa30ab9681a16169b1427373b8a99
-      lastVerified: '2026-05-17T14:15:04.590Z'
+      lastVerified: '2026-05-17T15:04:27.358Z'
     MEMORY:
       path: .aiox-core/development/agents/analyst/MEMORY.md
       layer: L3
@@ -15022,7 +15024,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b8b52820ba1929ba12403fc437868dd9e8a9c2532abe99296ad05864618693b0
-      lastVerified: '2026-05-17T14:15:04.590Z'
+      lastVerified: '2026-05-17T15:04:27.358Z'
     architect-MEMORY:
       path: .aiox-core/development/agents/architect/MEMORY.md
       layer: L3
@@ -15043,7 +15045,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ee99a68876311e0dc67e0b77ff11f8fa2154f0803f27f4aa89db36df50753d3b
-      lastVerified: '2026-05-17T14:15:04.591Z'
+      lastVerified: '2026-05-17T15:04:27.358Z'
     data-engineer-MEMORY:
       path: .aiox-core/development/agents/data-engineer/MEMORY.md
       layer: L3
@@ -15065,7 +15067,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:20024028651bf2078bf4e58e38aaa84191521ef9b5c11b044eb152a026ec8412
-      lastVerified: '2026-05-17T14:15:04.591Z'
+      lastVerified: '2026-05-17T15:04:27.358Z'
     dev-MEMORY:
       path: .aiox-core/development/agents/dev/MEMORY.md
       layer: L3
@@ -15086,7 +15088,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7c6197418798fa00617f63f93ea6e87dbbbc1bebdb1fb92276433cb7990fd7c0
-      lastVerified: '2026-05-17T14:15:04.591Z'
+      lastVerified: '2026-05-17T15:04:27.358Z'
     devops-MEMORY:
       path: .aiox-core/development/agents/devops/MEMORY.md
       layer: L3
@@ -15107,7 +15109,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:eb2ee887047c94db3441126cd0198cac44cec779026d7842a3a1c7eba936027f
-      lastVerified: '2026-05-17T14:15:04.591Z'
+      lastVerified: '2026-05-17T15:04:27.359Z'
     pm-MEMORY:
       path: .aiox-core/development/agents/pm/MEMORY.md
       layer: L3
@@ -15127,7 +15129,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6a8a5661a32cdf440a21531004ad64767da700b70ff8483faddfb7bcde937f2b
-      lastVerified: '2026-05-17T14:15:04.591Z'
+      lastVerified: '2026-05-17T15:04:27.359Z'
     po-MEMORY:
       path: .aiox-core/development/agents/po/MEMORY.md
       layer: L3
@@ -15147,7 +15149,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4295cbf549671ec6a267bef05871d66fffeb6b898ada166ab1663f7d03632354
-      lastVerified: '2026-05-17T14:15:04.591Z'
+      lastVerified: '2026-05-17T15:04:27.359Z'
     qa-MEMORY:
       path: .aiox-core/development/agents/qa/MEMORY.md
       layer: L3
@@ -15167,7 +15169,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:eec482f057d09635940e9a46bdd6cbb677af12dc4deed64bf71196d551b93abf
-      lastVerified: '2026-05-17T14:15:04.591Z'
+      lastVerified: '2026-05-17T15:04:27.359Z'
     sm-MEMORY:
       path: .aiox-core/development/agents/sm/MEMORY.md
       layer: L3
@@ -15189,7 +15191,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4abaa92d85f4574a79a308f098e9ae719c28f72101e746f2a574ad92e120dcf4
-      lastVerified: '2026-05-17T14:15:04.592Z'
+      lastVerified: '2026-05-17T15:04:27.361Z'
     ux-MEMORY:
       path: .aiox-core/development/agents/ux/MEMORY.md
       layer: L3
@@ -15211,7 +15213,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:39e36c9af4aa959fb547152bed812954c33a4c6c8d1a5aababd49052f229fde6
-      lastVerified: '2026-05-17T14:15:04.592Z'
+      lastVerified: '2026-05-17T15:04:27.363Z'
   checklists:
     agent-quality-gate:
       path: .aiox-core/development/checklists/agent-quality-gate.md
@@ -15233,7 +15235,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:46395b5c10794ca98321e4baaaaa1737485bec3f6bc3a616cf948478c0a1c644
-      lastVerified: '2026-05-17T14:15:04.593Z'
+      lastVerified: '2026-05-17T15:04:27.364Z'
     brownfield-compatibility-checklist:
       path: .aiox-core/development/checklists/brownfield-compatibility-checklist.md
       layer: L2
@@ -15255,7 +15257,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c5ff5d7cd45395e8766bf5c941ece8b0d5557758ecead7bef3ac3e08abee899
-      lastVerified: '2026-05-17T14:15:04.593Z'
+      lastVerified: '2026-05-17T15:04:27.364Z'
     issue-triage-checklist:
       path: .aiox-core/development/checklists/issue-triage-checklist.md
       layer: L2
@@ -15275,7 +15277,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c6dbaae38c0e3030dbffebcbcf95e5e766e0294a7a678531531cbd7ad6e54e2b
-      lastVerified: '2026-05-17T14:15:04.593Z'
+      lastVerified: '2026-05-17T15:04:27.364Z'
     memory-audit-checklist:
       path: .aiox-core/development/checklists/memory-audit-checklist.md
       layer: L2
@@ -15297,7 +15299,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bb3ca4ea56d0294a7acc1e9f5bd690ee70c676c28950b8a7c3c25bef8e428f7e
-      lastVerified: '2026-05-17T14:15:04.593Z'
+      lastVerified: '2026-05-17T15:04:27.365Z'
     self-critique-checklist:
       path: .aiox-core/development/checklists/self-critique-checklist.md
       layer: L2
@@ -15320,7 +15322,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:158f21a6be7a7cbc90de0302678490887c2f88b1d79d925f77a8a2209d2ae003
-      lastVerified: '2026-05-17T14:15:04.593Z'
+      lastVerified: '2026-05-17T15:04:27.365Z'
   data:
     agent-config-requirements:
       path: .aiox-core/data/agent-config-requirements.yaml
@@ -15341,7 +15343,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:68e87b5777d1872c4fed6644dd3c7e3c3e8fd590df7d2b58c36d541cf8e38dd3
-      lastVerified: '2026-05-17T14:15:04.594Z'
+      lastVerified: '2026-05-17T15:04:27.366Z'
     aiox-kb:
       path: .aiox-core/data/aiox-kb.md
       layer: L3
@@ -15364,7 +15366,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7ceaab838b4586a5314f0edea431f09fbc4dd82eb386f89db4442d1212add352
-      lastVerified: '2026-05-17T14:15:04.595Z'
+      lastVerified: '2026-05-17T15:04:27.367Z'
     entity-registry:
       path: .aiox-core/data/entity-registry.yaml
       layer: L3
@@ -15385,7 +15387,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:<self-reference>
-      lastVerified: '2026-05-17T14:15:04.693Z'
+      lastVerified: '2026-05-17T15:04:27.495Z'
     learned-patterns:
       path: .aiox-core/data/learned-patterns.yaml
       layer: L3
@@ -15404,7 +15406,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
-      lastVerified: '2026-05-17T14:15:04.598Z'
+      lastVerified: '2026-05-17T15:04:27.370Z'
     mcp-tool-examples:
       path: .aiox-core/data/mcp-tool-examples.yaml
       layer: L3
@@ -15425,7 +15427,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8a38e4171d7434d79f83032d9c37f2f604d9411dbec6c3c0334d6661481745fd
-      lastVerified: '2026-05-17T14:15:04.599Z'
+      lastVerified: '2026-05-17T15:04:27.370Z'
     technical-preferences:
       path: .aiox-core/data/technical-preferences.md
       layer: L3
@@ -15447,7 +15449,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:abb9327d3ce96a3cd49e73a555da4078e81ea0c4dbfe7154420c3ec7ac1c93b7
-      lastVerified: '2026-05-17T14:15:04.599Z'
+      lastVerified: '2026-05-17T15:04:27.371Z'
     tool-registry:
       path: .aiox-core/data/tool-registry.yaml
       layer: L3
@@ -15467,7 +15469,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:64e867d0eb36c7f7ac86f4f73f1b2ff89f43f37f28a6de34389be74b9346860c
-      lastVerified: '2026-05-17T14:15:04.599Z'
+      lastVerified: '2026-05-17T15:04:27.371Z'
     workflow-chains:
       path: .aiox-core/data/workflow-chains.yaml
       layer: L3
@@ -15489,7 +15491,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1fbf1625e267eedc315cf1e08e5827c250ddc6785fb2cb139e7702def9b66268
-      lastVerified: '2026-05-17T14:15:04.599Z'
+      lastVerified: '2026-05-17T15:04:27.371Z'
     workflow-patterns:
       path: .aiox-core/data/workflow-patterns.yaml
       layer: L3
@@ -15509,7 +15511,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0e90d71ce0cc218d8710c1f195f74a24d3aa7513f5728f5e65da9220612c3617
-      lastVerified: '2026-05-17T14:15:04.600Z'
+      lastVerified: '2026-05-17T15:04:27.372Z'
     workflow-state-schema:
       path: .aiox-core/data/workflow-state-schema.yaml
       layer: L3
@@ -15529,7 +15531,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d80a645a9c48b8ab8168ddbe36279662d72de4fb5cd8953a6685e5d1bd9968db
-      lastVerified: '2026-05-17T14:15:04.600Z'
+      lastVerified: '2026-05-17T15:04:27.372Z'
     _template:
       path: .aiox-core/data/tech-presets/_template.md
       layer: L3
@@ -15549,7 +15551,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:68b26930b728908b6097fc91956c8c446e5cc0dbe627e3b737495ebcd7e9569b
-      lastVerified: '2026-05-17T14:15:04.600Z'
+      lastVerified: '2026-05-17T15:04:27.372Z'
     angular-nestjs:
       path: .aiox-core/data/tech-presets/angular-nestjs.md
       layer: L3
@@ -15573,7 +15575,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d7b41b5076fc8a2c4312398f41414b8515cc0563ed727e4fe354548bdd80fb77
-      lastVerified: '2026-05-17T14:15:04.601Z'
+      lastVerified: '2026-05-17T15:04:27.372Z'
     csharp:
       path: .aiox-core/data/tech-presets/csharp.md
       layer: L3
@@ -15593,7 +15595,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4667d33407c59fd6c7b4558370893a14df6d461645fc840b2df2fb7508bd6fcf
-      lastVerified: '2026-05-17T14:15:04.601Z'
+      lastVerified: '2026-05-17T15:04:27.373Z'
     go:
       path: .aiox-core/data/tech-presets/go.md
       layer: L3
@@ -15613,7 +15615,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e0851caecbdc2cea6531359fe640427685cd6ed664dbf991ccb135917c4d1ec2
-      lastVerified: '2026-05-17T14:15:04.601Z'
+      lastVerified: '2026-05-17T15:04:27.373Z'
     java:
       path: .aiox-core/data/tech-presets/java.md
       layer: L3
@@ -15633,7 +15635,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b912e04412f63b59439f7cca119802bed95a6cb756221e3ba7aee45c3d2890fd
-      lastVerified: '2026-05-17T14:15:04.601Z'
+      lastVerified: '2026-05-17T15:04:27.373Z'
     nextjs-react:
       path: .aiox-core/data/tech-presets/nextjs-react.md
       layer: L3
@@ -15658,7 +15660,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:558ce0abd112ca39853fc5150bd850862e5fcfac74c8def80c3876b60c9f5d33
-      lastVerified: '2026-05-17T14:15:04.601Z'
+      lastVerified: '2026-05-17T15:04:27.373Z'
     php:
       path: .aiox-core/data/tech-presets/php.md
       layer: L3
@@ -15678,7 +15680,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:847dde754e7a98c4d11328768483358d2be7d2f10e43b6703403237987620077
-      lastVerified: '2026-05-17T14:15:04.602Z'
+      lastVerified: '2026-05-17T15:04:27.374Z'
     rust:
       path: .aiox-core/data/tech-presets/rust.md
       layer: L3
@@ -15698,7 +15700,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:58422e884e46660216d5389878ae2f0ab619da7d34f34ed1dff917dfd8fed7db
-      lastVerified: '2026-05-17T14:15:04.602Z'
+      lastVerified: '2026-05-17T15:04:27.374Z'
   workflows:
     auto-worktree:
       path: .aiox-core/development/workflows/auto-worktree.yaml
@@ -15721,7 +15723,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:74b0dff78c2b91eda03b9914a73cc99807645c8e0b174e576d22e0b3f5b75be3
-      lastVerified: '2026-05-17T14:15:04.604Z'
+      lastVerified: '2026-05-17T15:04:27.376Z'
     brownfield-discovery:
       path: .aiox-core/development/workflows/brownfield-discovery.yaml
       layer: L2
@@ -15746,7 +15748,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a52662b683781546d4585d456aad1cb7d41343a8c934d9a6d6441f8d3dec5385
-      lastVerified: '2026-05-17T14:15:04.605Z'
+      lastVerified: '2026-05-17T15:04:27.384Z'
     brownfield-fullstack:
       path: .aiox-core/development/workflows/brownfield-fullstack.yaml
       layer: L2
@@ -15772,7 +15774,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5200308dfa759d6ce37270f63853a6c1424d47ec552142d9ada6174aaf5c22ff
-      lastVerified: '2026-05-17T14:15:04.606Z'
+      lastVerified: '2026-05-17T15:04:27.385Z'
     brownfield-service:
       path: .aiox-core/development/workflows/brownfield-service.yaml
       layer: L2
@@ -15797,7 +15799,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6ef271e25edd0dfe4235ea5aab14dbf89509250d8471580418ce58d50a1748e8
-      lastVerified: '2026-05-17T14:15:04.607Z'
+      lastVerified: '2026-05-17T15:04:27.386Z'
     brownfield-ui:
       path: .aiox-core/development/workflows/brownfield-ui.yaml
       layer: L2
@@ -15823,7 +15825,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:553a05def42e2a884d59fdeaa1aaf07566e469e3ae30daf43543e8a934c1c67f
-      lastVerified: '2026-05-17T14:15:04.608Z'
+      lastVerified: '2026-05-17T15:04:27.386Z'
     design-system-build-quality:
       path: .aiox-core/development/workflows/design-system-build-quality.yaml
       layer: L2
@@ -15845,7 +15847,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e9aa8f3e1ae22aa0799627326a3548e78eee805e5652c12a15e84dbdbcd5ffe2
-      lastVerified: '2026-05-17T14:15:04.608Z'
+      lastVerified: '2026-05-17T15:04:27.387Z'
     development-cycle:
       path: .aiox-core/development/workflows/development-cycle.yaml
       layer: L2
@@ -15871,7 +15873,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c22f2700d6c3dcd227efec711ab206b4fa9e268768a15be86eea0405e2c82c4d
-      lastVerified: '2026-05-17T14:15:04.610Z'
+      lastVerified: '2026-05-17T15:04:27.389Z'
     epic-orchestration:
       path: .aiox-core/development/workflows/epic-orchestration.yaml
       layer: L2
@@ -15891,7 +15893,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4bb9d91027036d089ab880e46e4b256290761c4dbf17d716abe61b541161fe05
-      lastVerified: '2026-05-17T14:15:04.611Z'
+      lastVerified: '2026-05-17T15:04:27.390Z'
     greenfield-fullstack:
       path: .aiox-core/development/workflows/greenfield-fullstack.yaml
       layer: L2
@@ -15920,7 +15922,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:106b47c4205ac395118a49f5d5fb194125f5c17819780f9a598ef434352013ef
-      lastVerified: '2026-05-17T14:15:04.612Z'
+      lastVerified: '2026-05-17T15:04:27.392Z'
     greenfield-service:
       path: .aiox-core/development/workflows/greenfield-service.yaml
       layer: L2
@@ -15946,7 +15948,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b22d2ea83d2079878632f50351a21d7f2a9a8035283abd6fea701033774f9bb
-      lastVerified: '2026-05-17T14:15:04.613Z'
+      lastVerified: '2026-05-17T15:04:27.393Z'
     greenfield-ui:
       path: .aiox-core/development/workflows/greenfield-ui.yaml
       layer: L2
@@ -15973,7 +15975,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e7818aa9f7c8db4efd6d7fd631fb8ff6f1aac4202c3f6253dfd6d50dd708fc30
-      lastVerified: '2026-05-17T14:15:04.613Z'
+      lastVerified: '2026-05-17T15:04:27.394Z'
     qa-loop:
       path: .aiox-core/development/workflows/qa-loop.yaml
       layer: L2
@@ -15998,7 +16000,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:585d5e5dd2cf4d5682e8db2a816caa588ecf5ae3b332f4a5ceec9f406b5f0f09
-      lastVerified: '2026-05-17T14:15:04.615Z'
+      lastVerified: '2026-05-17T15:04:27.395Z'
     spec-pipeline:
       path: .aiox-core/development/workflows/spec-pipeline.yaml
       layer: L2
@@ -16026,7 +16028,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4604ff3e2e945fbbb45006e32d8de81c73cb38782526ca3c87924549ccc29ccf
-      lastVerified: '2026-05-17T14:15:04.616Z'
+      lastVerified: '2026-05-17T15:04:27.397Z'
     story-development-cycle:
       path: .aiox-core/development/workflows/story-development-cycle.yaml
       layer: L2
@@ -16050,7 +16052,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6125a3545e9a8550582d7d6ea640bbd5b0e4747b80e7c67ebf60ce284591220e
-      lastVerified: '2026-05-17T14:15:04.617Z'
+      lastVerified: '2026-05-17T15:04:27.397Z'
   utils:
     output-formatter:
       path: .aiox-core/core/utils/output-formatter.js
@@ -16070,7 +16072,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6fdfee469b7c108ec24a045b9b2719d836a242052abd285957a9ac732c6fc594
-      lastVerified: '2026-05-17T14:15:04.618Z'
+      lastVerified: '2026-05-17T15:04:27.398Z'
     security-utils:
       path: .aiox-core/core/utils/security-utils.js
       layer: L1
@@ -16089,7 +16091,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:00c938eda0e142b8c204b50afdd662864b5209b60a32a0e6e847e4e4cbceee09
-      lastVerified: '2026-05-17T14:15:04.618Z'
+      lastVerified: '2026-05-17T15:04:27.398Z'
     yaml-validator:
       path: .aiox-core/core/utils/yaml-validator.js
       layer: L1
@@ -16108,7 +16110,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:05084596198634dd2a670a752d5c451edfe268e16e3bae511db52184f895366f
-      lastVerified: '2026-05-17T14:15:04.618Z'
+      lastVerified: '2026-05-17T15:04:27.398Z'
   tools: {}
   infra-scripts:
     aiox-validator:
@@ -16129,7 +16131,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5a91cc8b54ccd58955dbbb5925f878d9e507dc2a9358f642c62f7ee84a6156a0
-      lastVerified: '2026-05-17T14:15:04.622Z'
+      lastVerified: '2026-05-17T15:04:27.400Z'
     approach-manager:
       path: .aiox-core/infrastructure/scripts/approach-manager.js
       layer: L2
@@ -16149,7 +16151,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:22ee604ca42094f5b7939ec129c52cb1fc362ae70688cc1ef7a921c956ab38d2
-      lastVerified: '2026-05-17T14:15:04.622Z'
+      lastVerified: '2026-05-17T15:04:27.401Z'
     approval-workflow:
       path: .aiox-core/infrastructure/scripts/approval-workflow.js
       layer: L2
@@ -16169,7 +16171,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4d744a8d08cadf09bf368a1457c1bd3bc68ccef0885c324b2527222da816544b
-      lastVerified: '2026-05-17T14:15:04.623Z'
+      lastVerified: '2026-05-17T15:04:27.401Z'
     asset-inventory:
       path: .aiox-core/infrastructure/scripts/asset-inventory.js
       layer: L2
@@ -16189,7 +16191,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:25ad926a05af465389b6fb92f7c9c79c453c54047b4ebe9629ee1c153a6b3373
-      lastVerified: '2026-05-17T14:15:04.623Z'
+      lastVerified: '2026-05-17T15:04:27.402Z'
     atomic-layer-classifier:
       path: .aiox-core/infrastructure/scripts/atomic-layer-classifier.js
       layer: L2
@@ -16209,7 +16211,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ecdb368d80a69c8da7cc507aff0b18bd2e58d8bd94b9fb0ba1e074595a19e884
-      lastVerified: '2026-05-17T14:15:04.623Z'
+      lastVerified: '2026-05-17T15:04:27.402Z'
     backup-manager:
       path: .aiox-core/infrastructure/scripts/backup-manager.js
       layer: L2
@@ -16230,7 +16232,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e7d0173f107c0576f443a7f4bc83387cdbb625518ce5749ca9059ffbf3070f44
-      lastVerified: '2026-05-17T14:15:04.624Z'
+      lastVerified: '2026-05-17T15:04:27.404Z'
     batch-creator:
       path: .aiox-core/infrastructure/scripts/batch-creator.js
       layer: L2
@@ -16253,7 +16255,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b91ca0e5d8af3d47658bc5bd754e72e654e68446c17c5e50e45ebd581535fe7d
-      lastVerified: '2026-05-17T14:15:04.624Z'
+      lastVerified: '2026-05-17T15:04:27.405Z'
     branch-manager:
       path: .aiox-core/infrastructure/scripts/branch-manager.js
       layer: L2
@@ -16273,7 +16275,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:49f3a7a7aa36347c3e3dbc998847913c829216c71a1c659bf7a55d67a940d1c3
-      lastVerified: '2026-05-17T14:15:04.624Z'
+      lastVerified: '2026-05-17T15:04:27.406Z'
     capability-analyzer:
       path: .aiox-core/infrastructure/scripts/capability-analyzer.js
       layer: L2
@@ -16294,7 +16296,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:92f55a27e60fd6aba2a0203f1c28aa12d6f70200097ec44d849db2653f758a17
-      lastVerified: '2026-05-17T14:15:04.625Z'
+      lastVerified: '2026-05-17T15:04:27.406Z'
     changelog-generator:
       path: .aiox-core/infrastructure/scripts/changelog-generator.js
       layer: L2
@@ -16313,7 +16315,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c2d6b203d39fe2ef8d6b7108beb59a03da0986f9331c22ce539d9857c7cc3612
-      lastVerified: '2026-05-17T14:15:04.625Z'
+      lastVerified: '2026-05-17T15:04:27.406Z'
     cicd-discovery:
       path: .aiox-core/infrastructure/scripts/cicd-discovery.js
       layer: L2
@@ -16332,7 +16334,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:04b5efa659f9d3baa998ca4b09f7fc6ec4800d0b165ecf118a8f10df93642228
-      lastVerified: '2026-05-17T14:15:04.625Z'
+      lastVerified: '2026-05-17T15:04:27.407Z'
     clickup-helpers:
       path: .aiox-core/infrastructure/scripts/clickup-helpers.js
       layer: L2
@@ -16354,7 +16356,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:043ceb5b712903e6b78be83c997575e8de64d5815dccef88355c20d8153af9a6
-      lastVerified: '2026-05-17T14:15:04.626Z'
+      lastVerified: '2026-05-17T15:04:27.407Z'
     code-quality-improver:
       path: .aiox-core/infrastructure/scripts/code-quality-improver.js
       layer: L2
@@ -16375,7 +16377,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:765dd10a367656b330a659b2245ef2eb9a947905fee71555198837743fc1483f
-      lastVerified: '2026-05-17T14:15:04.626Z'
+      lastVerified: '2026-05-17T15:04:27.408Z'
     codebase-mapper:
       path: .aiox-core/infrastructure/scripts/codebase-mapper.js
       layer: L2
@@ -16395,7 +16397,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:1b72ae317c81c01ed1d6d518d64cf18fdecb9d408ab45dba6ad45cb39c6e3a1d
-      lastVerified: '2026-05-17T14:15:04.627Z'
+      lastVerified: '2026-05-17T15:04:27.408Z'
     collect-tool-usage:
       path: .aiox-core/infrastructure/scripts/collect-tool-usage.js
       layer: L2
@@ -16415,7 +16417,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8a739b79182dc41e28b7e02aeb9ec1dde5ec49f3ca534399acc59711b3b92bbf
-      lastVerified: '2026-05-17T14:15:04.627Z'
+      lastVerified: '2026-05-17T15:04:27.408Z'
     commit-message-generator:
       path: .aiox-core/infrastructure/scripts/commit-message-generator.js
       layer: L2
@@ -16437,7 +16439,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:611b0f27acd02e49aff7a2d91b48823dc4a2d788440fff2f32bf500a1bc84132
-      lastVerified: '2026-05-17T14:15:04.628Z'
+      lastVerified: '2026-05-17T15:04:27.409Z'
     component-generator:
       path: .aiox-core/infrastructure/scripts/component-generator.js
       layer: L2
@@ -16479,7 +16481,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c74da9a766aeca878568a0e70f78141e7a772322d428f99e90fcd7b9a5fd7edc
-      lastVerified: '2026-05-17T14:15:04.628Z'
+      lastVerified: '2026-05-17T15:04:27.409Z'
     component-metadata:
       path: .aiox-core/infrastructure/scripts/component-metadata.js
       layer: L2
@@ -16501,7 +16503,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0ad8034533561b13187072eaa611510117463bacbaff12f9ae48008128560000
-      lastVerified: '2026-05-17T14:15:04.629Z'
+      lastVerified: '2026-05-17T15:04:27.410Z'
     component-search:
       path: .aiox-core/infrastructure/scripts/component-search.js
       layer: L2
@@ -16522,7 +16524,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:08feb4672de885f140527e460614cbc90d90544753581f36afeec71ee8614703
-      lastVerified: '2026-05-17T14:15:04.629Z'
+      lastVerified: '2026-05-17T15:04:27.410Z'
     config-cache:
       path: .aiox-core/infrastructure/scripts/config-cache.js
       layer: L2
@@ -16545,7 +16547,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:363383dbf90df90d69b8ba769db4f9749b0ae91b4fe95ee15be633941906f8a2
-      lastVerified: '2026-05-17T14:15:04.629Z'
+      lastVerified: '2026-05-17T15:04:27.410Z'
     config-loader:
       path: .aiox-core/infrastructure/scripts/config-loader.js
       layer: L2
@@ -16567,7 +16569,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8f9489f7c57e775bfbb750761d9714505d5df3938b664cbbdf6701f9e18e240b
-      lastVerified: '2026-05-17T14:15:04.630Z'
+      lastVerified: '2026-05-17T15:04:27.411Z'
     conflict-resolver:
       path: .aiox-core/infrastructure/scripts/conflict-resolver.js
       layer: L2
@@ -16587,7 +16589,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3d2794a66f16fcea95b096386dc9c2dcd31e5938d862030e7ac1f38c00a2c0bd
-      lastVerified: '2026-05-17T14:15:04.630Z'
+      lastVerified: '2026-05-17T15:04:27.411Z'
     coverage-analyzer:
       path: .aiox-core/infrastructure/scripts/coverage-analyzer.js
       layer: L2
@@ -16607,7 +16609,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:95e70563eadf720ce4c6aa6349ace311cf34c63bc5044f71565f328a2dc9a706
-      lastVerified: '2026-05-17T14:15:04.631Z'
+      lastVerified: '2026-05-17T15:04:27.411Z'
     dashboard-status-writer:
       path: .aiox-core/infrastructure/scripts/dashboard-status-writer.js
       layer: L2
@@ -16627,7 +16629,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a01bc8e74ce40206bbb49453af46896388754f412961b6f6585927a382338f01
-      lastVerified: '2026-05-17T14:15:04.631Z'
+      lastVerified: '2026-05-17T15:04:27.412Z'
     dependency-analyzer:
       path: .aiox-core/infrastructure/scripts/dependency-analyzer.js
       layer: L2
@@ -16648,7 +16650,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:af326d5d70a097cc255171d8f30b1d99a302b07d96d94528cfaad3f97bdea479
-      lastVerified: '2026-05-17T14:15:04.631Z'
+      lastVerified: '2026-05-17T15:04:27.412Z'
     dependency-impact-analyzer:
       path: .aiox-core/infrastructure/scripts/dependency-impact-analyzer.js
       layer: L2
@@ -16671,7 +16673,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3c9d87250845f7def63a2230d4af43ed2d6ae84cfba6b6d72a5b9e285a66f5ed
-      lastVerified: '2026-05-17T14:15:04.632Z'
+      lastVerified: '2026-05-17T15:04:27.413Z'
     diff-generator:
       path: .aiox-core/infrastructure/scripts/diff-generator.js
       layer: L2
@@ -16692,7 +16694,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:569387c1dd8ee00d0ebc34b9f463438150ed9c96af2e5728fde83c36626211cf
-      lastVerified: '2026-05-17T14:15:04.632Z'
+      lastVerified: '2026-05-17T15:04:27.413Z'
     documentation-synchronizer:
       path: .aiox-core/infrastructure/scripts/documentation-synchronizer.js
       layer: L2
@@ -16712,7 +16714,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:94fc482ef0182608a3433824d02cb24fe0d7ab4aaa256853b9b79e603bf28e9e
-      lastVerified: '2026-05-17T14:15:04.633Z'
+      lastVerified: '2026-05-17T15:04:27.413Z'
     framework-analyzer:
       path: .aiox-core/infrastructure/scripts/framework-analyzer.js
       layer: L2
@@ -16734,7 +16736,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8bd86d50f5a3f050191a49e22e8348bbefa72e3df396313064239a2f1a4a9856
-      lastVerified: '2026-05-17T14:15:04.633Z'
+      lastVerified: '2026-05-17T15:04:27.414Z'
     generate-optimization-report:
       path: .aiox-core/infrastructure/scripts/generate-optimization-report.js
       layer: L2
@@ -16754,7 +16756,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b57357bc4120529381b811fd7c1aab901d3b67dd765d043eefc61bb22f5b8df1
-      lastVerified: '2026-05-17T14:15:04.633Z'
+      lastVerified: '2026-05-17T15:04:27.414Z'
     generate-settings-json:
       path: .aiox-core/infrastructure/scripts/generate-settings-json.js
       layer: L2
@@ -16774,7 +16776,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:dc5b8803825ed749080925d7c17ece39b33a7faf3b02d08a445e8cc7408048a1
-      lastVerified: '2026-05-17T14:15:04.634Z'
+      lastVerified: '2026-05-17T15:04:27.414Z'
     git-config-detector:
       path: .aiox-core/infrastructure/scripts/git-config-detector.js
       layer: L2
@@ -16796,7 +16798,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:52ed96d98fc6f9e83671d7d27f78dcff4f2475f3b8e339dc31922f6b2814ad78
-      lastVerified: '2026-05-17T14:15:04.634Z'
+      lastVerified: '2026-05-17T15:04:27.415Z'
     git-wrapper:
       path: .aiox-core/infrastructure/scripts/git-wrapper.js
       layer: L2
@@ -16817,7 +16819,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7130442ca72ba89e397be77000b44e2431b92a8af44d1fac63c869807641e587
-      lastVerified: '2026-05-17T14:15:04.634Z'
+      lastVerified: '2026-05-17T15:04:27.415Z'
     gotchas-documenter:
       path: .aiox-core/infrastructure/scripts/gotchas-documenter.js
       layer: L2
@@ -16837,7 +16839,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ef42171b57775622977a9221db8a7d994a33f3acaa0a72c2908d13943d45d796
-      lastVerified: '2026-05-17T14:15:04.635Z'
+      lastVerified: '2026-05-17T15:04:27.415Z'
     improvement-engine:
       path: .aiox-core/infrastructure/scripts/improvement-engine.js
       layer: L2
@@ -16857,7 +16859,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4fed61115f4148eb6b8c42ebd9d5b05732695ab1b4343e2466383baf4883d58d
-      lastVerified: '2026-05-17T14:15:04.635Z'
+      lastVerified: '2026-05-17T15:04:27.415Z'
     improvement-validator:
       path: .aiox-core/infrastructure/scripts/improvement-validator.js
       layer: L2
@@ -16879,7 +16881,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b63362e7ac1c4dbf17655be6609cab666f9f1970821da79609890f76a906c02b
-      lastVerified: '2026-05-17T14:15:04.635Z'
+      lastVerified: '2026-05-17T15:04:27.416Z'
     migrate-agent:
       path: .aiox-core/infrastructure/scripts/migrate-agent.js
       layer: L2
@@ -16899,7 +16901,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0b7330c4a7dccfe028aea2d99e4d3c2f3acface55b79c32bd51ab3bc00e33a86
-      lastVerified: '2026-05-17T14:15:04.636Z'
+      lastVerified: '2026-05-17T15:04:27.416Z'
     modification-risk-assessment:
       path: .aiox-core/infrastructure/scripts/modification-risk-assessment.js
       layer: L2
@@ -16920,7 +16922,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:974dfb83d3bfbb56f4a02385d8edb735c0acab62acb8a1a4e7c69f5ecf10c810
-      lastVerified: '2026-05-17T14:15:04.636Z'
+      lastVerified: '2026-05-17T15:04:27.417Z'
     modification-validator:
       path: .aiox-core/infrastructure/scripts/modification-validator.js
       layer: L2
@@ -16944,7 +16946,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0853fbe9e628510a0e6f8b95ac3c467d49df5cd7b15637f374928c1d3f9e2b87
-      lastVerified: '2026-05-17T14:15:04.637Z'
+      lastVerified: '2026-05-17T15:04:27.417Z'
     output-formatter:
       path: .aiox-core/infrastructure/scripts/output-formatter.js
       layer: L2
@@ -16966,7 +16968,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6f28092d0dabf3b0b486ef06a1836d47c3247a3c331ed6cfbcd597d45496ddb6
-      lastVerified: '2026-05-17T14:15:04.637Z'
+      lastVerified: '2026-05-17T15:04:27.417Z'
     path-analyzer:
       path: .aiox-core/infrastructure/scripts/path-analyzer.js
       layer: L2
@@ -16986,7 +16988,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:47250c416f8090278b4a81de7be4a3f2592f4a20b6afc9c9e30c9cafd292e166
-      lastVerified: '2026-05-17T14:15:04.637Z'
+      lastVerified: '2026-05-17T15:04:27.417Z'
     pattern-extractor:
       path: .aiox-core/infrastructure/scripts/pattern-extractor.js
       layer: L2
@@ -17007,7 +17009,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9edc6aabdb32431466c5c8db9da883bc0a5f4457cfc74ccc6c10ed687f8e1e52
-      lastVerified: '2026-05-17T14:15:04.638Z'
+      lastVerified: '2026-05-17T15:04:27.418Z'
     performance-analyzer:
       path: .aiox-core/infrastructure/scripts/performance-analyzer.js
       layer: L2
@@ -17027,7 +17029,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6d925acfbaf3cedae2b17ec262f8436c2d38d7eacd4513acfa0a6b3ebb600337
-      lastVerified: '2026-05-17T14:15:04.638Z'
+      lastVerified: '2026-05-17T15:04:27.418Z'
     performance-and-error-resolver:
       path: .aiox-core/infrastructure/scripts/performance-and-error-resolver.js
       layer: L2
@@ -17048,7 +17050,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de4246a4f01f6da08c8de8a3595505ad8837524db39458f4e6c163cb671b6097
-      lastVerified: '2026-05-17T14:15:04.638Z'
+      lastVerified: '2026-05-17T15:04:27.419Z'
     performance-optimizer:
       path: .aiox-core/infrastructure/scripts/performance-optimizer.js
       layer: L2
@@ -17068,7 +17070,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:80be8b0599b24f3f21f27ac5e53a4f3ecbb69c7b928ba101c6d1912fb19f7156
-      lastVerified: '2026-05-17T14:15:04.639Z'
+      lastVerified: '2026-05-17T15:04:27.420Z'
     performance-tracker:
       path: .aiox-core/infrastructure/scripts/performance-tracker.js
       layer: L2
@@ -17088,7 +17090,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3c98129cc1597bb637634f566f3440a47c31820e66580a65ebebca5d5771ee6f
-      lastVerified: '2026-05-17T14:15:04.639Z'
+      lastVerified: '2026-05-17T15:04:27.420Z'
     plan-tracker:
       path: .aiox-core/infrastructure/scripts/plan-tracker.js
       layer: L2
@@ -17110,7 +17112,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:12bdcdb1b05e1d36686c7ae3cd4c080e592fe41b0807d64ee08ed089d4e257da
-      lastVerified: '2026-05-17T14:15:04.640Z'
+      lastVerified: '2026-05-17T15:04:27.420Z'
     pm-adapter-factory:
       path: .aiox-core/infrastructure/scripts/pm-adapter-factory.js
       layer: L2
@@ -17137,7 +17139,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:72ceafb9cf559d619951f95d62a7fd645c95258eca27248985fbb2afb20aa257
-      lastVerified: '2026-05-17T14:15:04.640Z'
+      lastVerified: '2026-05-17T15:04:27.421Z'
     pm-adapter:
       path: .aiox-core/infrastructure/scripts/pm-adapter.js
       layer: L2
@@ -17156,7 +17158,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d8383516f70e1641be210dd4b033541fb6bfafd39fd5976361b8e322cdcb1058
-      lastVerified: '2026-05-17T14:15:04.640Z'
+      lastVerified: '2026-05-17T15:04:27.421Z'
     pr-review-ai:
       path: .aiox-core/infrastructure/scripts/pr-review-ai.js
       layer: L2
@@ -17176,7 +17178,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8872f4ddc23184ea3305cae682741a6a02c1efc170afaa20793c3a9951b374fc
-      lastVerified: '2026-05-17T14:15:04.641Z'
+      lastVerified: '2026-05-17T15:04:27.421Z'
     project-status-loader:
       path: .aiox-core/infrastructure/scripts/project-status-loader.js
       layer: L2
@@ -17200,7 +17202,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:33d753efad0658a702b08f9422406423a9aceac4c88479622fc660c8e0c8eccb
-      lastVerified: '2026-05-17T14:15:04.641Z'
+      lastVerified: '2026-05-17T15:04:27.422Z'
     qa-loop-orchestrator:
       path: .aiox-core/infrastructure/scripts/qa-loop-orchestrator.js
       layer: L2
@@ -17221,7 +17223,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cadd573d7667f6aecd77940ec48c9c8af5e09685877002625faa14a68f5568c2
-      lastVerified: '2026-05-17T14:15:04.642Z'
+      lastVerified: '2026-05-17T15:04:27.422Z'
     qa-report-generator:
       path: .aiox-core/infrastructure/scripts/qa-report-generator.js
       layer: L2
@@ -17241,7 +17243,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:23756fafc80bc0b6a6926a7436cf6653df02be1d28a68cf6628f203f778ce201
-      lastVerified: '2026-05-17T14:15:04.643Z'
+      lastVerified: '2026-05-17T15:04:27.423Z'
     recovery-tracker:
       path: .aiox-core/infrastructure/scripts/recovery-tracker.js
       layer: L2
@@ -17264,7 +17266,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:09eb60cdd5b6a42a93b5f7450448899bf83e704ecec7d56ea27b560f063e2d1a
-      lastVerified: '2026-05-17T14:15:04.643Z'
+      lastVerified: '2026-05-17T15:04:27.423Z'
     refactoring-suggester:
       path: .aiox-core/infrastructure/scripts/refactoring-suggester.js
       layer: L2
@@ -17284,7 +17286,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:118d4cdbc64cf3238065f2fb98958305ae81e1384bc68f5a6c7b768f1232cd1e
-      lastVerified: '2026-05-17T14:15:04.644Z'
+      lastVerified: '2026-05-17T15:04:27.424Z'
     repair-agent-references:
       path: .aiox-core/infrastructure/scripts/repair-agent-references.js
       layer: L2
@@ -17307,7 +17309,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:63b5f580b783d5098c3ab3d8da11af9871306b3a1fc0f986f25c813eb4c4dd75
-      lastVerified: '2026-05-17T14:15:04.644Z'
+      lastVerified: '2026-05-17T15:04:27.429Z'
     repository-detector:
       path: .aiox-core/infrastructure/scripts/repository-detector.js
       layer: L2
@@ -17329,7 +17331,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:10ffca7f57d24d3729c71a9104a154500a3c72328d67884e26e38d22199af332
-      lastVerified: '2026-05-17T14:15:04.644Z'
+      lastVerified: '2026-05-17T15:04:27.429Z'
     rollback-manager:
       path: .aiox-core/infrastructure/scripts/rollback-manager.js
       layer: L2
@@ -17351,7 +17353,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fe14a4c0b55f35c30f76daf12712fb97308171683bf81d2566e0d01838d57a6e
-      lastVerified: '2026-05-17T14:15:04.644Z'
+      lastVerified: '2026-05-17T15:04:27.430Z'
     sandbox-tester:
       path: .aiox-core/infrastructure/scripts/sandbox-tester.js
       layer: L2
@@ -17371,7 +17373,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:019af2e23de70d7dacb49faf031ba0c1f5553ecebe52f361bab74bfca73ba609
-      lastVerified: '2026-05-17T14:15:04.645Z'
+      lastVerified: '2026-05-17T15:04:27.430Z'
     security-checker:
       path: .aiox-core/infrastructure/scripts/security-checker.js
       layer: L2
@@ -17395,7 +17397,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d14d9376e3044e61eba40c03931a05dc518f7b8a10618d4f8c9c8a4b300e71fc
-      lastVerified: '2026-05-17T14:15:04.645Z'
+      lastVerified: '2026-05-17T15:04:27.430Z'
     spot-check-validator:
       path: .aiox-core/infrastructure/scripts/spot-check-validator.js
       layer: L2
@@ -17415,7 +17417,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4bf2d20ded322312aef98291d2a23913da565e1622bc97366c476793c6792c81
-      lastVerified: '2026-05-17T14:15:04.645Z'
+      lastVerified: '2026-05-17T15:04:27.430Z'
     status-mapper:
       path: .aiox-core/infrastructure/scripts/status-mapper.js
       layer: L2
@@ -17435,7 +17437,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6ce6d7324350997b3e1b112aabfbbd0612ebde753ca9ed03e494869b3bb57b1f
-      lastVerified: '2026-05-17T14:15:04.645Z'
+      lastVerified: '2026-05-17T15:04:27.431Z'
     story-worktree-hooks:
       path: .aiox-core/infrastructure/scripts/story-worktree-hooks.js
       layer: L2
@@ -17456,7 +17458,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:3e719f61633200d116260931d93925197c7d2d5d857492f87974c6aae160e1a4
-      lastVerified: '2026-05-17T14:15:04.646Z'
+      lastVerified: '2026-05-17T15:04:27.431Z'
     stuck-detector:
       path: .aiox-core/infrastructure/scripts/stuck-detector.js
       layer: L2
@@ -17479,7 +17481,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d1afb4d6d17c06075d43e2327d4f84fce1a4e57a46374b0250a3028c211b1c66
-      lastVerified: '2026-05-17T14:15:04.646Z'
+      lastVerified: '2026-05-17T15:04:27.431Z'
     subtask-verifier:
       path: .aiox-core/infrastructure/scripts/subtask-verifier.js
       layer: L2
@@ -17499,7 +17501,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ceb0450fa12fa48f0255bb4565858eb1a97b28c30b98d36cb61d52d72e08b054
-      lastVerified: '2026-05-17T14:15:04.646Z'
+      lastVerified: '2026-05-17T15:04:27.432Z'
     template-engine:
       path: .aiox-core/infrastructure/scripts/template-engine.js
       layer: L2
@@ -17520,7 +17522,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec62a12ff9ad140d32fcbdfc9b5eef636101b75f0835469f1193fee8db0a7d55
-      lastVerified: '2026-05-17T14:15:04.646Z'
+      lastVerified: '2026-05-17T15:04:27.432Z'
     template-validator:
       path: .aiox-core/infrastructure/scripts/template-validator.js
       layer: L2
@@ -17541,7 +17543,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:de989116d2f895b58e10355b8853e7b96af6fde151d2612616f18842b9cc56c4
-      lastVerified: '2026-05-17T14:15:04.647Z'
+      lastVerified: '2026-05-17T15:04:27.432Z'
     test-discovery:
       path: .aiox-core/infrastructure/scripts/test-discovery.js
       layer: L2
@@ -17560,7 +17562,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:04038aa49ae515697084fcdacaf0ef8bc36029fc114f5a1206065d7928870449
-      lastVerified: '2026-05-17T14:15:04.647Z'
+      lastVerified: '2026-05-17T15:04:27.433Z'
     test-generator:
       path: .aiox-core/infrastructure/scripts/test-generator.js
       layer: L2
@@ -17580,7 +17582,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f3146896fbcbc99563cc015b828f097167642e24c919c7c9bf6bbfee9ea87cc1
-      lastVerified: '2026-05-17T14:15:04.647Z'
+      lastVerified: '2026-05-17T15:04:27.433Z'
     test-quality-assessment:
       path: .aiox-core/infrastructure/scripts/test-quality-assessment.js
       layer: L2
@@ -17601,7 +17603,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:08c49331641c0fb1873e37fd14a41d88cec7b40f4b16267ae26b4cadc4d292b6
-      lastVerified: '2026-05-17T14:15:04.648Z'
+      lastVerified: '2026-05-17T15:04:27.433Z'
     test-utilities-fast:
       path: .aiox-core/infrastructure/scripts/test-utilities-fast.js
       layer: L2
@@ -17621,7 +17623,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:70d87a74dac153c65d622afa4d62816e41d8d81eee6d42e1c0e498999bec7c40
-      lastVerified: '2026-05-17T14:15:04.648Z'
+      lastVerified: '2026-05-17T15:04:27.434Z'
     test-utilities:
       path: .aiox-core/infrastructure/scripts/test-utilities.js
       layer: L2
@@ -17640,7 +17642,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2df35a1706b1389809226fde3c4e0bc72e4d5cebacab3cb98beaa70768049061
-      lastVerified: '2026-05-17T14:15:04.649Z'
+      lastVerified: '2026-05-17T15:04:27.434Z'
     tool-resolver:
       path: .aiox-core/infrastructure/scripts/tool-resolver.js
       layer: L2
@@ -17662,7 +17664,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2fa44e4a940d4c33570fd9b4495b5c39792c52ca91b98c4be2fb55cb974ad095
-      lastVerified: '2026-05-17T14:15:04.649Z'
+      lastVerified: '2026-05-17T15:04:27.434Z'
     transaction-manager:
       path: .aiox-core/infrastructure/scripts/transaction-manager.js
       layer: L2
@@ -17685,7 +17687,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bed375a4d72928ecfa670626c3e504194c4bf4439eab399fc5b31c919e873e86
-      lastVerified: '2026-05-17T14:15:04.649Z'
+      lastVerified: '2026-05-17T15:04:27.434Z'
     usage-analytics:
       path: .aiox-core/infrastructure/scripts/usage-analytics.js
       layer: L2
@@ -17705,7 +17707,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5328370f603d7601e7e69b2c19646fad8557394068955fc029b9bc4f70d66bfe
-      lastVerified: '2026-05-17T14:15:04.649Z'
+      lastVerified: '2026-05-17T15:04:27.435Z'
     validate-agents:
       path: .aiox-core/infrastructure/scripts/validate-agents.js
       layer: L2
@@ -17725,7 +17727,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5f5f89a1fcf02ba340772ed30ade56fc346114d7a4d43e6d69af40858c64b180
-      lastVerified: '2026-05-17T14:15:04.650Z'
+      lastVerified: '2026-05-17T15:04:27.435Z'
     validate-claude-integration:
       path: .aiox-core/infrastructure/scripts/validate-claude-integration.js
       layer: L2
@@ -17746,7 +17748,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0174d5e5e38eb8aa5aaa0a44d87f0f8dda623a24f318855c1e50e9d04f7596d6
-      lastVerified: '2026-05-17T14:15:04.650Z'
+      lastVerified: '2026-05-17T15:04:27.435Z'
     validate-codex-integration:
       path: .aiox-core/infrastructure/scripts/validate-codex-integration.js
       layer: L2
@@ -17767,7 +17769,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:0f45a49898528d708ef17871bf6abae4f60483ef8520ce30a9bd4f5e507c585f
-      lastVerified: '2026-05-17T14:15:04.650Z'
+      lastVerified: '2026-05-17T15:04:27.436Z'
     validate-gemini-integration:
       path: .aiox-core/infrastructure/scripts/validate-gemini-integration.js
       layer: L2
@@ -17788,7 +17790,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:57a31b8a4b8c129189afaad961ed0261a205c02b55028d61146a9e599c112883
-      lastVerified: '2026-05-17T14:15:04.650Z'
+      lastVerified: '2026-05-17T15:04:27.436Z'
     validate-output-pattern:
       path: .aiox-core/infrastructure/scripts/validate-output-pattern.js
       layer: L2
@@ -17808,7 +17810,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:91111d656e8d7b38a20a1bda753e663b74318f75cdab2025c7e0b84c775fc83d
-      lastVerified: '2026-05-17T14:15:04.650Z'
+      lastVerified: '2026-05-17T15:04:27.436Z'
     validate-parity:
       path: .aiox-core/infrastructure/scripts/validate-parity.js
       layer: L2
@@ -17832,7 +17834,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7f651b869bd501e97d6dccb51dab434818492bc5b02f5eaea00db808cd17cd4c
-      lastVerified: '2026-05-17T14:15:04.651Z'
+      lastVerified: '2026-05-17T15:04:27.436Z'
     validate-paths:
       path: .aiox-core/infrastructure/scripts/validate-paths.js
       layer: L2
@@ -17852,7 +17854,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fb37d099b52eda54e47dec07259687bec6049941cad37281f1de9c3f4095bfd9
-      lastVerified: '2026-05-17T14:15:04.651Z'
+      lastVerified: '2026-05-17T15:04:27.436Z'
     validate-user-profile:
       path: .aiox-core/infrastructure/scripts/validate-user-profile.js
       layer: L2
@@ -17873,7 +17875,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a67e6385bb77d6359e91d87882c0641b1444a1f7acd1086203f20953a4f16a37
-      lastVerified: '2026-05-17T14:15:04.651Z'
+      lastVerified: '2026-05-17T15:04:27.437Z'
     visual-impact-generator:
       path: .aiox-core/infrastructure/scripts/visual-impact-generator.js
       layer: L2
@@ -17894,7 +17896,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:7771eb4d93b1d371149c15adf83db205c7bf600be6d098fc4364af2886776686
-      lastVerified: '2026-05-17T14:15:04.651Z'
+      lastVerified: '2026-05-17T15:04:27.437Z'
     worktree-manager:
       path: .aiox-core/infrastructure/scripts/worktree-manager.js
       layer: L2
@@ -17922,7 +17924,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:76ac6c2638b5ddf9d8a359ac9db887b926ca0993d77220f6511c58255f0cfbd3
-      lastVerified: '2026-05-17T14:15:04.652Z'
+      lastVerified: '2026-05-17T15:04:27.437Z'
     yaml-validator:
       path: .aiox-core/infrastructure/scripts/yaml-validator.js
       layer: L2
@@ -17945,12 +17947,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2039ecb9a9d3f639c734c65704018efd2c4656c4995f0b0e537670f7417bf23b
-      lastVerified: '2026-05-17T14:15:04.652Z'
+      lastVerified: '2026-05-17T15:04:27.438Z'
     bootstrap:
       path: .aiox-core/infrastructure/scripts/codex-skills-sync/bootstrap.js
       layer: L2
       type: script
-      purpose: ${title} Activator
+      purpose: Entity at .aiox-core/infrastructure/scripts/codex-skills-sync/bootstrap.js
       keywords:
         - bootstrap
         - ${title}
@@ -17965,12 +17967,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:56f4518586591d809cda89183e1af3b05c4e4c7369df992e7fdd7214ea5c6072
-      lastVerified: '2026-05-17T14:15:04.653Z'
+      lastVerified: '2026-05-17T15:04:27.438Z'
     index:
       path: .aiox-core/infrastructure/scripts/codex-skills-sync/index.js
       layer: L2
       type: script
-      purpose: AIOX ${title} Activator
+      purpose: Entity at .aiox-core/infrastructure/scripts/codex-skills-sync/index.js
       keywords:
         - index
         - aiox
@@ -17995,7 +17997,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2dc8637ba0095921e3cb5e99791dc05da61a12e375407b05f199696bcce7ea61
-      lastVerified: '2026-05-17T14:15:04.653Z'
+      lastVerified: '2026-05-17T15:04:27.438Z'
     validate:
       path: .aiox-core/infrastructure/scripts/codex-skills-sync/validate.js
       layer: L2
@@ -18017,7 +18019,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6c8f98f49e433fc3aa648034457d5273a2ca667b8c7e492157a89ed6d0582c96
-      lastVerified: '2026-05-17T14:15:04.653Z'
+      lastVerified: '2026-05-17T15:04:27.439Z'
     brownfield-analyzer:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/brownfield-analyzer.js
       layer: L2
@@ -18038,7 +18040,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a5d1a200767592554778f12cfd3594b89dd11d25e1668e81876c34753753df04
-      lastVerified: '2026-05-17T14:15:04.654Z'
+      lastVerified: '2026-05-17T15:04:27.439Z'
     config-generator:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/config-generator.js
       layer: L2
@@ -18059,7 +18061,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:bed3eb82140bf4ed547ec1f5c8992cbcd3ce8587a8814f7bef0962c7788965ee
-      lastVerified: '2026-05-17T14:15:04.654Z'
+      lastVerified: '2026-05-17T15:04:27.439Z'
     deployment-config-loader:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/deployment-config-loader.js
       layer: L2
@@ -18081,7 +18083,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c58e84348a50a7587de3068fe7dcf69a22478cd4e96a5c44d9b9f7f814c64925
-      lastVerified: '2026-05-17T14:15:04.654Z'
+      lastVerified: '2026-05-17T15:04:27.439Z'
     doc-generator:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/doc-generator.js
       layer: L2
@@ -18102,7 +18104,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6e58a80fc61b5af4780e98ac5c0c7070b1ed6281a776303d7550ad717b933afb
-      lastVerified: '2026-05-17T14:15:04.654Z'
+      lastVerified: '2026-05-17T15:04:27.439Z'
     gitignore-generator:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/gitignore-generator.js
       layer: L2
@@ -18124,7 +18126,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:fc79c0c5311f3043a07a9e08480a70c8a1328ac6e00679a5141de8226c5dd4ca
-      lastVerified: '2026-05-17T14:15:04.655Z'
+      lastVerified: '2026-05-17T15:04:27.440Z'
     documentation-integrity-index:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/index.js
       layer: L2
@@ -18148,7 +18150,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8e51de74ca904fccc4650df494e6a202766b57cba1883d3a1b5ef90d2831d7f7
-      lastVerified: '2026-05-17T14:15:04.655Z'
+      lastVerified: '2026-05-17T15:04:27.440Z'
     mode-detector:
       path: .aiox-core/infrastructure/scripts/documentation-integrity/mode-detector.js
       layer: L2
@@ -18170,7 +18172,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:955af283f28d088d844b6e3f388b48caf265d746ff499599973196cb07612730
-      lastVerified: '2026-05-17T14:15:04.655Z'
+      lastVerified: '2026-05-17T15:04:27.440Z'
     post-commit:
       path: .aiox-core/infrastructure/scripts/git-hooks/post-commit.js
       layer: L2
@@ -18189,7 +18191,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a7eea0e43a254804a09fc09a94c9c44d8da0b285ce5dc2ea6149d426732fd917
-      lastVerified: '2026-05-17T14:15:04.655Z'
+      lastVerified: '2026-05-17T15:04:27.441Z'
     agent-parser:
       path: .aiox-core/infrastructure/scripts/ide-sync/agent-parser.js
       layer: L2
@@ -18215,7 +18217,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f1ed4d0e6dda1a616efb0cb31157fe36063cf9481c19ee7b4bada26cb12e0e80
-      lastVerified: '2026-05-17T14:15:04.655Z'
+      lastVerified: '2026-05-17T15:04:27.441Z'
     gemini-commands:
       path: .aiox-core/infrastructure/scripts/ide-sync/gemini-commands.js
       layer: L2
@@ -18235,7 +18237,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ba02b21af0d485b14d6e248b6d5644090646dc792f78eac515d17b88680d8549
-      lastVerified: '2026-05-17T14:15:04.656Z'
+      lastVerified: '2026-05-17T15:04:27.441Z'
     ide-sync-index:
       path: .aiox-core/infrastructure/scripts/ide-sync/index.js
       layer: L2
@@ -18261,7 +18263,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2ea2fe3a070010da33be2fed3d75c305d3414cf515c1bf5fbafb334e0a7da5fa
-      lastVerified: '2026-05-17T14:15:04.656Z'
+      lastVerified: '2026-05-17T15:04:27.442Z'
     redirect-generator:
       path: .aiox-core/infrastructure/scripts/ide-sync/redirect-generator.js
       layer: L2
@@ -18283,7 +18285,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5bebf478e331716b4fb42d624076eb2570c90c4aa829427c700995d6b9ec361e
-      lastVerified: '2026-05-17T14:15:04.657Z'
+      lastVerified: '2026-05-17T15:04:27.442Z'
     validator:
       path: .aiox-core/infrastructure/scripts/ide-sync/validator.js
       layer: L2
@@ -18303,7 +18305,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:768eba65a0f8ff937c34f6f43fe1b4dc990f2d406e592bc1cda0f8ab5b4f7e0b
-      lastVerified: '2026-05-17T14:15:04.657Z'
+      lastVerified: '2026-05-17T15:04:27.442Z'
     install-llm-routing:
       path: .aiox-core/infrastructure/scripts/llm-routing/install-llm-routing.js
       layer: L2
@@ -18324,7 +18326,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c9faab7f6149a8046abe5c9a026055c5f386cfef700136b76e5fa579e60bed8
-      lastVerified: '2026-05-17T14:15:04.657Z'
+      lastVerified: '2026-05-17T15:04:27.442Z'
     antigravity:
       path: .aiox-core/infrastructure/scripts/ide-sync/transformers/antigravity.js
       layer: L2
@@ -18344,7 +18346,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e00910c008c8547a1943f79c676d0a4c0d014b638fc15c8a68e2574d6949744b
-      lastVerified: '2026-05-17T14:15:04.657Z'
+      lastVerified: '2026-05-17T15:04:27.442Z'
     claude-code:
       path: .aiox-core/infrastructure/scripts/ide-sync/transformers/claude-code.js
       layer: L2
@@ -18365,12 +18367,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:364ef939d1392397d13942dfc2360a3a75ff8edd77cd0ba88fc29622d5f75fd5
-      lastVerified: '2026-05-17T14:15:04.657Z'
+      lastVerified: '2026-05-17T15:04:27.443Z'
     cursor:
       path: .aiox-core/infrastructure/scripts/ide-sync/transformers/cursor.js
       layer: L2
       type: script
-      purpose: ${name} (@${agentData.id})
+      purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/transformers/cursor.js
       keywords:
         - cursor
         - ${name}
@@ -18388,7 +18390,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9a38f664747ea71472585d4f8c3e52b844dc75a39a526f5873e6bf97370a4723
-      lastVerified: '2026-05-17T14:15:04.658Z'
+      lastVerified: '2026-05-17T15:04:27.443Z'
     github-copilot:
       path: .aiox-core/infrastructure/scripts/ide-sync/transformers/github-copilot.js
       layer: L2
@@ -18409,12 +18411,12 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6d365be4a55e2f5ced316a0efbfa50fb925562f3e145d47a86c57a2c685343ac
-      lastVerified: '2026-05-17T14:15:04.658Z'
+      lastVerified: '2026-05-17T15:04:27.443Z'
     kimi:
       path: .aiox-core/infrastructure/scripts/ide-sync/transformers/kimi.js
       layer: L2
       type: script
-      purpose: '${icon} @${id} — ${name}${archetype !== ''Specialist'' ? ` (${archetype})` : ''''} | ${title}'
+      purpose: Entity at .aiox-core/infrastructure/scripts/ide-sync/transformers/kimi.js
       keywords:
         - kimi
         - ${icon}
@@ -18432,7 +18434,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:69a6b34e81ba956242ff38cfce4063d9a0d9e32818a5f36e0246d80e41940def
-      lastVerified: '2026-05-17T14:15:04.658Z'
+      lastVerified: '2026-05-17T15:04:27.443Z'
     llm-routing-usage-tracker-index:
       path: .aiox-core/infrastructure/scripts/llm-routing/usage-tracker/index.js
       layer: L2
@@ -18450,7 +18452,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b49216115de498113a754f9c87fe9834f6262abaa6db3b54c87c06fbdc632905
-      lastVerified: '2026-05-17T14:15:04.658Z'
+      lastVerified: '2026-05-17T15:04:27.444Z'
   infra-tools:
     README:
       path: .aiox-core/infrastructure/tools/README.md
@@ -18476,7 +18478,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2f8f4141b9f4a71ad51668d28fc9a12362835dd40eb45992c645f9bfe28f8a48
-      lastVerified: '2026-05-17T14:15:04.660Z'
+      lastVerified: '2026-05-17T15:04:27.445Z'
     github-cli:
       path: .aiox-core/infrastructure/tools/cli/github-cli.yaml
       layer: L2
@@ -18500,7 +18502,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:222ca6016e9487d2da13bead0af5cee6099885ea438b359ff5fa5a73c7cd4820
-      lastVerified: '2026-05-17T14:15:04.660Z'
+      lastVerified: '2026-05-17T15:04:27.445Z'
     llm-routing:
       path: .aiox-core/infrastructure/tools/cli/llm-routing.yaml
       layer: L2
@@ -18522,7 +18524,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d97183f254876933de02d9ad2c793ad7d06e37dd0c4f9da9fb68097a5d0eedb3
-      lastVerified: '2026-05-17T14:15:04.660Z'
+      lastVerified: '2026-05-17T15:04:27.445Z'
     railway-cli:
       path: .aiox-core/infrastructure/tools/cli/railway-cli.yaml
       layer: L2
@@ -18543,7 +18545,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cab769df07cfd0a65bfed0e7140dfde3bf3c54cd6940452d2d18e18f99a63e4a
-      lastVerified: '2026-05-17T14:15:04.661Z'
+      lastVerified: '2026-05-17T15:04:27.446Z'
     supabase-cli:
       path: .aiox-core/infrastructure/tools/cli/supabase-cli.yaml
       layer: L2
@@ -18565,7 +18567,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:659fefd3d8b182dd06fc5be560fcf386a028156386b2029cd51bbd7d3b5e6bfd
-      lastVerified: '2026-05-17T14:15:04.661Z'
+      lastVerified: '2026-05-17T15:04:27.446Z'
     ffmpeg:
       path: .aiox-core/infrastructure/tools/local/ffmpeg.yaml
       layer: L2
@@ -18584,7 +18586,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:d481a548e0eb327513412c7ac39e4a92ac27a283f4b9e6c43211fed52281df44
-      lastVerified: '2026-05-17T14:15:04.661Z'
+      lastVerified: '2026-05-17T15:04:27.446Z'
     21st-dev-magic:
       path: .aiox-core/infrastructure/tools/mcp/21st-dev-magic.yaml
       layer: L2
@@ -18605,7 +18607,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:5e1b575bdb51c6b5d446a2255fa068194d2010bce56c8c0dd0b2e98e3cf61f18
-      lastVerified: '2026-05-17T14:15:04.661Z'
+      lastVerified: '2026-05-17T15:04:27.446Z'
     browser:
       path: .aiox-core/infrastructure/tools/mcp/browser.yaml
       layer: L2
@@ -18626,7 +18628,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c28206d92a6127d299ca60955cd6f6d03c940ac8b221f1e9fc620dd7efd7b471
-      lastVerified: '2026-05-17T14:15:04.661Z'
+      lastVerified: '2026-05-17T15:04:27.446Z'
     clickup:
       path: .aiox-core/infrastructure/tools/mcp/clickup.yaml
       layer: L2
@@ -18645,7 +18647,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:aa7c34786e8e332a3486b136f40ec997dcc2a7e408bbc99a8899b0653baac6ee
-      lastVerified: '2026-05-17T14:15:04.662Z'
+      lastVerified: '2026-05-17T15:04:27.454Z'
     context7:
       path: .aiox-core/infrastructure/tools/mcp/context7.yaml
       layer: L2
@@ -18671,7 +18673,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:321e0e23a787c36260efdbb1a3953235fa7dc57e77b211610ffaf33bc21fca02
-      lastVerified: '2026-05-17T14:15:04.662Z'
+      lastVerified: '2026-05-17T15:04:27.454Z'
     desktop-commander:
       path: .aiox-core/infrastructure/tools/mcp/desktop-commander.yaml
       layer: L2
@@ -18690,7 +18692,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec1a5db7def48d1762e68d4477ad0574bbb54a6783256870f5451c666ebdc213
-      lastVerified: '2026-05-17T14:15:04.662Z'
+      lastVerified: '2026-05-17T15:04:27.455Z'
     exa:
       path: .aiox-core/infrastructure/tools/mcp/exa.yaml
       layer: L2
@@ -18710,7 +18712,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:02576ff68b8de8a2d4e6aaffaeade78d5c208b95380feeacb37e2105c6f83541
-      lastVerified: '2026-05-17T14:15:04.662Z'
+      lastVerified: '2026-05-17T15:04:27.455Z'
     google-workspace:
       path: .aiox-core/infrastructure/tools/mcp/google-workspace.yaml
       layer: L2
@@ -18730,7 +18732,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f017c3154e9d480f37d94c7ddd7c3d24766b4fa7e0ee9e722600e85da75734b4
-      lastVerified: '2026-05-17T14:15:04.663Z'
+      lastVerified: '2026-05-17T15:04:27.456Z'
     n8n:
       path: .aiox-core/infrastructure/tools/mcp/n8n.yaml
       layer: L2
@@ -18749,7 +18751,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f9d9536ec47f9911e634083c3ac15cb920214ea0f052e78d4c6a27a17e9ec408
-      lastVerified: '2026-05-17T14:15:04.663Z'
+      lastVerified: '2026-05-17T15:04:27.456Z'
     supabase:
       path: .aiox-core/infrastructure/tools/mcp/supabase.yaml
       layer: L2
@@ -18769,7 +18771,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:350bd31537dfef9c3df55bd477434ccbe644cdf0dd3408bf5a8a6d0c5ba78aa2
-      lastVerified: '2026-05-17T14:15:04.664Z'
+      lastVerified: '2026-05-17T15:04:27.459Z'
   product-checklists:
     accessibility-wcag-checklist:
       path: .aiox-core/product/checklists/accessibility-wcag-checklist.md
@@ -18791,7 +18793,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:56126182b25e9b7bdde43f75315e33167eb49b1f9a9cb0e9a37bc068af40aeab
-      lastVerified: '2026-05-17T14:15:04.664Z'
+      lastVerified: '2026-05-17T15:04:27.460Z'
     architect-checklist:
       path: .aiox-core/product/checklists/architect-checklist.md
       layer: L2
@@ -18814,7 +18816,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ecbcc8e6b34f813bc73ebcc28482c045ef12c6b17808ee6f70a808eee1818911
-      lastVerified: '2026-05-17T14:15:04.665Z'
+      lastVerified: '2026-05-17T15:04:27.460Z'
     change-checklist:
       path: .aiox-core/product/checklists/change-checklist.md
       layer: L2
@@ -18845,7 +18847,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:edaa126d5db726fce3a422be6441928b1177fe13e5e8defe2d2cb8959acd1439
-      lastVerified: '2026-05-17T14:15:04.665Z'
+      lastVerified: '2026-05-17T15:04:27.461Z'
     component-quality-checklist:
       path: .aiox-core/product/checklists/component-quality-checklist.md
       layer: L2
@@ -18866,7 +18868,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:ec4e34a3fc4a071d346a8ba473f521d2a38e5eb07d1656fee6ff108e5cd7b62f
-      lastVerified: '2026-05-17T14:15:04.666Z'
+      lastVerified: '2026-05-17T15:04:27.461Z'
     database-design-checklist:
       path: .aiox-core/product/checklists/database-design-checklist.md
       layer: L2
@@ -18887,7 +18889,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6d3cf038f0320db0e6daf9dba61e4c29269ed73c793df5618e155ebd07b6c200
-      lastVerified: '2026-05-17T14:15:04.666Z'
+      lastVerified: '2026-05-17T15:04:27.461Z'
     dba-predeploy-checklist:
       path: .aiox-core/product/checklists/dba-predeploy-checklist.md
       layer: L2
@@ -18909,7 +18911,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:482136936a2414600b59d4d694526c008287e3376ed73c9a93de78d7d7bd3285
-      lastVerified: '2026-05-17T14:15:04.666Z'
+      lastVerified: '2026-05-17T15:04:27.461Z'
     dba-rollback-checklist:
       path: .aiox-core/product/checklists/dba-rollback-checklist.md
       layer: L2
@@ -18930,7 +18932,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:060847cba7ef223591c2c1830c65994fd6cf8135625d6953a3a5b874301129c5
-      lastVerified: '2026-05-17T14:15:04.666Z'
+      lastVerified: '2026-05-17T15:04:27.462Z'
     migration-readiness-checklist:
       path: .aiox-core/product/checklists/migration-readiness-checklist.md
       layer: L2
@@ -18951,7 +18953,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6231576966f24b30c00fe7cc836359e10c870c266a30e5d88c6b3349ad2f1d17
-      lastVerified: '2026-05-17T14:15:04.666Z'
+      lastVerified: '2026-05-17T15:04:27.462Z'
     pattern-audit-checklist:
       path: .aiox-core/product/checklists/pattern-audit-checklist.md
       layer: L2
@@ -18972,7 +18974,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2eb28cb0e7abd8900170123c1d080c1bbb81ccb857eeb162c644f40616b0875e
-      lastVerified: '2026-05-17T14:15:04.667Z'
+      lastVerified: '2026-05-17T15:04:27.463Z'
     pm-checklist:
       path: .aiox-core/product/checklists/pm-checklist.md
       layer: L2
@@ -18997,7 +18999,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:6828efd3acf32638e31b8081ca0c6f731aa5710c8413327db5a8096b004aeb2b
-      lastVerified: '2026-05-17T14:15:04.667Z'
+      lastVerified: '2026-05-17T15:04:27.468Z'
     po-master-checklist:
       path: .aiox-core/product/checklists/po-master-checklist.md
       layer: L2
@@ -19033,7 +19035,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:506a3032f461c7ae96c338600208575be4f4823d2fe7c92fe304a4ff07cc5390
-      lastVerified: '2026-05-17T14:15:04.667Z'
+      lastVerified: '2026-05-17T15:04:27.468Z'
     pre-push-checklist:
       path: .aiox-core/product/checklists/pre-push-checklist.md
       layer: L2
@@ -19057,7 +19059,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8b96f7216101676b86b314c347fa8c6d616cde21dbc77ef8f77b8d0b5770af2a
-      lastVerified: '2026-05-17T14:15:04.667Z'
+      lastVerified: '2026-05-17T15:04:27.468Z'
     release-checklist:
       path: .aiox-core/product/checklists/release-checklist.md
       layer: L2
@@ -19078,7 +19080,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:a5e66e27d115abd544834a70f3dda429bc486fbcb569870031c4f79fd8ac6187
-      lastVerified: '2026-05-17T14:15:04.668Z'
+      lastVerified: '2026-05-17T15:04:27.468Z'
     self-critique-checklist:
       path: .aiox-core/product/checklists/self-critique-checklist.md
       layer: L2
@@ -19102,7 +19104,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9f257660bb386ea315fe4ab8b259897058d279e66338801db234c25750be9c2c
-      lastVerified: '2026-05-17T14:15:04.668Z'
+      lastVerified: '2026-05-17T15:04:27.469Z'
     story-dod-checklist:
       path: .aiox-core/product/checklists/story-dod-checklist.md
       layer: L2
@@ -19127,7 +19129,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:725b60a16a41886a92794e54b9efa8359eab5f09813cd584fa9e8e1519c78dc4
-      lastVerified: '2026-05-17T14:15:04.668Z'
+      lastVerified: '2026-05-17T15:04:27.469Z'
     story-draft-checklist:
       path: .aiox-core/product/checklists/story-draft-checklist.md
       layer: L2
@@ -19152,7 +19154,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:cf500e2a8a471573d25f3d73439a41fffea9f5351963c598fd2285ec909f96ce
-      lastVerified: '2026-05-17T14:15:04.669Z'
+      lastVerified: '2026-05-17T15:04:27.469Z'
   product-data:
     atomic-design-principles:
       path: .aiox-core/product/data/atomic-design-principles.md
@@ -19173,7 +19175,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:66153135e28394178c4f8f33441c45a2404587c2f07d25ad09dde54f3f5e1746
-      lastVerified: '2026-05-17T14:15:04.669Z'
+      lastVerified: '2026-05-17T15:04:27.470Z'
     brainstorming-techniques:
       path: .aiox-core/product/data/brainstorming-techniques.md
       layer: L2
@@ -19193,7 +19195,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4c5a558d21eb620a8c820d8ca9807b2d12c299375764289482838f81ef63dbce
-      lastVerified: '2026-05-17T14:15:04.670Z'
+      lastVerified: '2026-05-17T15:04:27.470Z'
     consolidation-algorithms:
       path: .aiox-core/product/data/consolidation-algorithms.md
       layer: L2
@@ -19213,7 +19215,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:2f2561be9e6281f6352f05e1c672954001f919c4664e3fecd6fcde24fdd4d240
-      lastVerified: '2026-05-17T14:15:04.670Z'
+      lastVerified: '2026-05-17T15:04:27.470Z'
     database-best-practices:
       path: .aiox-core/product/data/database-best-practices.md
       layer: L2
@@ -19234,7 +19236,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8331f001e903283633f0123d123546ef3d4682ed0e0f9516b4df391fe57b9b7d
-      lastVerified: '2026-05-17T14:15:04.670Z'
+      lastVerified: '2026-05-17T15:04:27.471Z'
     design-token-best-practices:
       path: .aiox-core/product/data/design-token-best-practices.md
       layer: L2
@@ -19255,7 +19257,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:10cf3c824bba452ee598e2325b8bfb2068f188d9ac3058b9e034ddf34bf4791a
-      lastVerified: '2026-05-17T14:15:04.670Z'
+      lastVerified: '2026-05-17T15:04:27.471Z'
     elicitation-methods:
       path: .aiox-core/product/data/elicitation-methods.md
       layer: L2
@@ -19275,7 +19277,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f8e46f90bd0acc1e9697086d7a2008c7794bc767e99d0037c64e6800e9d17ef4
-      lastVerified: '2026-05-17T14:15:04.670Z'
+      lastVerified: '2026-05-17T15:04:27.471Z'
     integration-patterns:
       path: .aiox-core/product/data/integration-patterns.md
       layer: L2
@@ -19295,7 +19297,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b771f999fb452dcabf835d5f5e5ae3982c48cece5941cc5a276b6f280062db43
-      lastVerified: '2026-05-17T14:15:04.670Z'
+      lastVerified: '2026-05-17T15:04:27.471Z'
     migration-safety-guide:
       path: .aiox-core/product/data/migration-safety-guide.md
       layer: L2
@@ -19316,7 +19318,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:42200ca180d4586447304dfc7f8035ccd09860b6ac34c72b63d284e57c94d2db
-      lastVerified: '2026-05-17T14:15:04.671Z'
+      lastVerified: '2026-05-17T15:04:27.472Z'
     mode-selection-best-practices:
       path: .aiox-core/product/data/mode-selection-best-practices.md
       layer: L2
@@ -19337,7 +19339,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4ed5ee7aaeadb2e3c12029b7cae9a6063f3a7b016fdd0d53f9319d461ddf3ea1
-      lastVerified: '2026-05-17T14:15:04.671Z'
+      lastVerified: '2026-05-17T15:04:27.472Z'
     postgres-tuning-guide:
       path: .aiox-core/product/data/postgres-tuning-guide.md
       layer: L2
@@ -19359,7 +19361,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:4715262241ae6ba2da311865506781bd7273fa6ee1bd55e15968dfda542c2bec
-      lastVerified: '2026-05-17T14:15:04.671Z'
+      lastVerified: '2026-05-17T15:04:27.472Z'
     rls-security-patterns:
       path: .aiox-core/product/data/rls-security-patterns.md
       layer: L2
@@ -19382,7 +19384,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:e3e12a06b483c1bda645e7eb361a230bdef106cc5d1140a69b443a4fc2ad70ef
-      lastVerified: '2026-05-17T14:15:04.671Z'
+      lastVerified: '2026-05-17T15:04:27.472Z'
     roi-calculation-guide:
       path: .aiox-core/product/data/roi-calculation-guide.md
       layer: L2
@@ -19402,7 +19404,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:f00a3c039297b3cb6e00f68d5feb6534a27c2a0ad02afd14df50e4e0cf285aa4
-      lastVerified: '2026-05-17T14:15:04.671Z'
+      lastVerified: '2026-05-17T15:04:27.472Z'
     supabase-patterns:
       path: .aiox-core/product/data/supabase-patterns.md
       layer: L2
@@ -19422,7 +19424,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:9ed119bc89f859125a0489036d747ff13b6c475a9db53946fdb7f3be02b41e0a
-      lastVerified: '2026-05-17T14:15:04.671Z'
+      lastVerified: '2026-05-17T15:04:27.473Z'
     test-levels-framework:
       path: .aiox-core/product/data/test-levels-framework.md
       layer: L2
@@ -19442,7 +19444,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:b9a50f9c3b5b153280c93ea30f823f30deb2ba7aea588039b5a2bdea0b23891e
-      lastVerified: '2026-05-17T14:15:04.671Z'
+      lastVerified: '2026-05-17T15:04:27.473Z'
     test-priorities-matrix:
       path: .aiox-core/product/data/test-priorities-matrix.md
       layer: L2
@@ -19462,7 +19464,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:c97c7279f23ed42ea2588814f204432a93d658d9b5a9914e34647db796a70a60
-      lastVerified: '2026-05-17T14:15:04.672Z'
+      lastVerified: '2026-05-17T15:04:27.473Z'
     wcag-compliance-guide:
       path: .aiox-core/product/data/wcag-compliance-guide.md
       layer: L2
@@ -19482,7 +19484,7 @@ entities:
         constraints: []
         extensionPoints: []
       checksum: sha256:8f5a97e1522da2193e2a2eae18dc68c4477acf3e2471b50b46885163cefa40e6
-      lastVerified: '2026-05-17T14:15:04.672Z'
+      lastVerified: '2026-05-17T15:04:27.473Z'
 categories:
   - id: tasks
     description: Executable task workflows for agent operations

--- a/.aiox-core/development/scripts/populate-entity-registry.js
+++ b/.aiox-core/development/scripts/populate-entity-registry.js
@@ -165,16 +165,42 @@ function extractKeywords(filePath, content) {
 }
 
 function extractPurpose(content, filePath) {
+  // Strategy 1: YAML frontmatter — most reliable when present.
+  // Looks for `description:` (and aliases) ONLY inside the frontmatter block
+  // delimited by `---` at the top of the file. Avoids matching example output
+  // or body text that happens to contain the same words.
+  const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+  if (frontmatterMatch) {
+    const fm = frontmatterMatch[1];
+    const fmDescMatch = fm.match(/^(?:description|purpose|summary)\s*:\s*(.+)$/im);
+    if (fmDescMatch) {
+      const cleaned = fmDescMatch[1].trim().replace(/^["']|["']$/g, '');
+      if (cleaned) return cleaned.substring(0, 200);
+    }
+  }
+
+  // Strategy 2: `## Purpose` section — first non-empty line.
   const purposeMatch = content.match(/^##\s*Purpose\s*\n+([\s\S]*?)(?=\n##|\n---|\n$)/im);
   if (purposeMatch) {
-    return purposeMatch[1].trim().split('\n')[0].substring(0, 200);
+    const firstLine = purposeMatch[1].trim().split('\n')[0];
+    if (firstLine) return firstLine.substring(0, 200);
   }
 
-  const descMatch = content.match(/(?:description|purpose|summary)[:]\s*(.+)/i);
-  if (descMatch) {
-    return descMatch[1].trim().substring(0, 200);
+  // Strategy 3: `## Overview` section — same shape as Purpose. Many guides
+  // use Overview instead of Purpose (e.g. component-creation-guide.md).
+  const overviewMatch = content.match(/^##\s*Overview\s*\n+([\s\S]*?)(?=\n##|\n---|\n$)/im);
+  if (overviewMatch) {
+    const firstLine = overviewMatch[1].trim().split('\n')[0];
+    if (firstLine) return firstLine.substring(0, 200);
   }
 
+  // Strategy 4: First `# Title` heading — the document's name.
+  // Note: we used to fall back to a body-level regex matching ANY
+  // `description:` / `purpose:` / `summary:` occurrence here, but that
+  // matched example output inside fenced code blocks and installer
+  // transcripts, producing nonsense purposes like "Analyzes provided
+  // dataset to identify patterns and insights" for a component creation
+  // guide. The body fallback was removed deliberately.
   const headerMatch = content.match(/^#\s+(.+)/m);
   if (headerMatch) {
     return headerMatch[1].trim().substring(0, 200);
@@ -650,10 +676,11 @@ function populate(options = {}) {
     basePath: c.basePath,
   }));
 
+  const lastUpdated = new Date().toISOString();
   const registry = {
     metadata: {
       version: '1.0.0',
-      lastUpdated: new Date().toISOString(),
+      lastUpdated,
       entityCount: totalCount,
       checksumAlgorithm: 'sha256',
       resolutionRate: rate,
@@ -661,6 +688,17 @@ function populate(options = {}) {
     entities: allEntities,
     categories,
   };
+
+  // Sync the self-entry for `.aiox-core/data/entity-registry.yaml` so the
+  // file's registry metadata reflects the regen. `lastVerified` mirrors
+  // `metadata.lastUpdated` exactly (single source of truth for this regen
+  // event). `checksum` is intentionally set to a sentinel value because
+  // hashing the registry file from inside the file itself is circular —
+  // any hash we compute would invalidate itself as soon as it's written.
+  // Downstream validators recognize the sentinel and skip the checksum
+  // comparison for self-references.
+  const SELF_CHECKSUM_SENTINEL = 'sha256:<self-reference>';
+  syncSelfRegistryEntry(registry, lastUpdated, SELF_CHECKSUM_SENTINEL);
 
   const yamlContent = yaml.dump(registry, {
     lineWidth: 120,
@@ -677,6 +715,41 @@ function populate(options = {}) {
   console.log(`[IDS] Total entities: ${totalCount}`);
 
   return registry;
+}
+
+/**
+ * Sync the self-entry for `.aiox-core/data/entity-registry.yaml`.
+ *
+ * The registry contains a record for itself (under `entities.data.entity-registry`)
+ * because the data layer scan picks up every `.yaml` it finds. That record's
+ * `lastVerified` was previously stuck at whatever value the last scan happened to
+ * write — never matching the actual regen timestamp. This function syncs it.
+ *
+ * `checksum` is set to a sentinel (`sha256:<self-reference>`) because hashing
+ * the file from inside the file is circular: any computed hash invalidates
+ * itself the moment it's written. The sentinel signals "skip this comparison"
+ * to downstream validators.
+ *
+ * @param {object} registry - The assembled registry (mutated in place)
+ * @param {string} lastUpdated - ISO timestamp of this regen (same as metadata.lastUpdated)
+ * @param {string} sentinelChecksum - Sentinel value for the self-entry checksum
+ */
+function syncSelfRegistryEntry(registry, lastUpdated, sentinelChecksum) {
+  const dataEntities = registry?.entities?.data;
+  if (!dataEntities) return;
+
+  const selfEntry = dataEntities['entity-registry'];
+  if (!selfEntry) return;
+
+  // Only sync if the entry actually points to the registry yaml file we
+  // just wrote — the `.js` module at .aiox-core/core/doctor/checks/entity-registry.js
+  // gets its own legitimate entry under `entities.modules` (or wherever
+  // the modules scan places it) and is not self-referential.
+  const expectedPath = '.aiox-core/data/entity-registry.yaml';
+  if (selfEntry.path !== expectedPath) return;
+
+  selfEntry.lastVerified = lastUpdated;
+  selfEntry.checksum = sentinelChecksum;
 }
 
 function getCategoryDescription(category) {

--- a/.aiox-core/development/scripts/populate-entity-registry.js
+++ b/.aiox-core/development/scripts/populate-entity-registry.js
@@ -164,6 +164,56 @@ function extractKeywords(filePath, content) {
   return [...new Set(parts.map((p) => p.toLowerCase()))];
 }
 
+/**
+ * Detects whether a candidate purpose string is actually a template placeholder
+ * or unfilled literal, rather than a real description.
+ *
+ * Examples of garbage purposes seen in registry pre-fix:
+ *   - `{Brief description of what this task does and when to use it}`
+ *   - `{One-line description}`
+ *   - `{{TASK_TITLE}}`
+ *   - `*${taskName.replace(/-/g, '-')}`
+ *   - `${context.componentName}`
+ *   - `Generated: ${new Date().toISOString()}`
+ *   - `Spec: {{story-title}}`
+ *
+ * These slip in because the source files (templates, generators) contain
+ * literal handlebars/JS interpolation that was meant to be filled at use-time,
+ * not at scan-time. The extractor was happily pulling those raw.
+ *
+ * The check is conservative: a purpose with one or two `${var}` mentions but
+ * still describing something useful (e.g. `Hello ${name}, welcome!`) is kept.
+ * Only when the placeholder dominates do we discard the candidate.
+ *
+ * @param {string} candidate - The purpose string from a higher-priority strategy
+ * @returns {boolean} true if the string looks like an unfilled placeholder
+ */
+function looksLikePlaceholder(candidate) {
+  if (!candidate || typeof candidate !== 'string') return false;
+  const s = candidate.trim();
+  if (!s) return false;
+
+  // Whole string is a single placeholder: `{...}`, `{{...}}`, or `${...}`.
+  if (/^\{[A-Za-z][^}]*\}$/.test(s)) return true;
+  if (/^\{\{[^}]+\}\}$/.test(s)) return true;
+  if (/^\$\{[^}]+\}$/.test(s)) return true;
+
+  // Starts with a literal placeholder followed by anything: `*${name}foo`,
+  // `${ctx.x} bar baz`, `{Brief} extra`. The leading token is the literal.
+  if (/^[*]?\$\{/.test(s)) return true;
+  if (/^\{[A-Za-z][^}]*\}/.test(s) && s.length < 80) return true;
+
+  // Dominant placeholder load — more than 30% of the string is `${...}` or
+  // `{{...}}` interpolation. Catches cases like
+  //   `${icon} @${id} — ${name}${archetype !== 'Specialist' ? ...} | ${title}`
+  // where the whole string is a JS template literal that escaped.
+  const interpolationMatches = s.match(/\$\{[^}]+\}|\{\{[^}]+\}\}/g) || [];
+  const interpolationLength = interpolationMatches.reduce((sum, m) => sum + m.length, 0);
+  if (interpolationLength > 0 && interpolationLength / s.length > 0.3) return true;
+
+  return false;
+}
+
 function extractPurpose(content, filePath) {
   // Strategy 1: YAML frontmatter — most reliable when present.
   // Looks for `description:` (and aliases) ONLY inside the frontmatter block
@@ -175,7 +225,9 @@ function extractPurpose(content, filePath) {
     const fmDescMatch = fm.match(/^(?:description|purpose|summary)\s*:\s*(.+)$/im);
     if (fmDescMatch) {
       const cleaned = fmDescMatch[1].trim().replace(/^["']|["']$/g, '');
-      if (cleaned) return cleaned.substring(0, 200);
+      if (cleaned && !looksLikePlaceholder(cleaned)) {
+        return cleaned.substring(0, 200);
+      }
     }
   }
 
@@ -183,7 +235,9 @@ function extractPurpose(content, filePath) {
   const purposeMatch = content.match(/^##\s*Purpose\s*\n+([\s\S]*?)(?=\n##|\n---|\n$)/im);
   if (purposeMatch) {
     const firstLine = purposeMatch[1].trim().split('\n')[0];
-    if (firstLine) return firstLine.substring(0, 200);
+    if (firstLine && !looksLikePlaceholder(firstLine)) {
+      return firstLine.substring(0, 200);
+    }
   }
 
   // Strategy 3: `## Overview` section — same shape as Purpose. Many guides
@@ -191,7 +245,9 @@ function extractPurpose(content, filePath) {
   const overviewMatch = content.match(/^##\s*Overview\s*\n+([\s\S]*?)(?=\n##|\n---|\n$)/im);
   if (overviewMatch) {
     const firstLine = overviewMatch[1].trim().split('\n')[0];
-    if (firstLine) return firstLine.substring(0, 200);
+    if (firstLine && !looksLikePlaceholder(firstLine)) {
+      return firstLine.substring(0, 200);
+    }
   }
 
   // Strategy 4: First `# Title` heading — the document's name.
@@ -203,7 +259,10 @@ function extractPurpose(content, filePath) {
   // guide. The body fallback was removed deliberately.
   const headerMatch = content.match(/^#\s+(.+)/m);
   if (headerMatch) {
-    return headerMatch[1].trim().substring(0, 200);
+    const candidate = headerMatch[1].trim();
+    if (!looksLikePlaceholder(candidate)) {
+      return candidate.substring(0, 200);
+    }
   }
 
   return `Entity at ${path.relative(REPO_ROOT, filePath)}`;
@@ -793,6 +852,7 @@ module.exports = {
   resolveRelativeDependencyId,
   extractKeywords,
   extractPurpose,
+  looksLikePlaceholder,
   detectDependencies,
   extractYamlDependencies,
   extractMarkdownCrossReferences,

--- a/.aiox-core/development/scripts/populate-entity-registry.js
+++ b/.aiox-core/development/scripts/populate-entity-registry.js
@@ -853,6 +853,7 @@ module.exports = {
   extractKeywords,
   extractPurpose,
   looksLikePlaceholder,
+  syncSelfRegistryEntry,
   detectDependencies,
   extractYamlDependencies,
   extractMarkdownCrossReferences,

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.2.6
-generated_at: "2026-05-17T13:54:51.096Z"
+generated_at: "2026-05-17T14:19:01.092Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1128
 files:
@@ -1297,9 +1297,9 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:3e172132eba884da71f3be868e7749feea9e7515c729cddb64542111808d384d
+    hash: sha256:d022e49f6ee5c2cbc13b106e62a13ee55a9176ce2212682b47524c662a657150
     type: data
-    size: 571670
+    size: 574936
   - path: data/learned-patterns.yaml
     hash: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
     type: data
@@ -1669,9 +1669,9 @@ files:
     type: script
     size: 23410
   - path: development/scripts/populate-entity-registry.js
-    hash: sha256:418fcbf6ca3a6259f8d13e3290e8e49d6a16917b304039a6470264c5fdece89e
+    hash: sha256:2bdf871a3435304f69044bd7463c94647316f7d43e5b891c80c5f181f0f01401
     type: script
-    size: 25077
+    size: 28901
   - path: development/scripts/refactoring-suggester.js
     hash: sha256:d50ea6b609c9cf8385979386fee4b4385d11ebcde15460260f66d04c705f6cd9
     type: script

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.2.6
-generated_at: "2026-05-17T15:12:58.541Z"
+generated_at: "2026-05-17T19:14:46.622Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1128
 files:
@@ -1669,9 +1669,9 @@ files:
     type: script
     size: 23410
   - path: development/scripts/populate-entity-registry.js
-    hash: sha256:65cc968e9fa82bb18390ee0ed7063082b5341a441b83a9778638f1ce4064ab23
+    hash: sha256:67a64f3bf0118eaa58401f4450e04f99643a33903d6b57d433929604b9061315
     type: script
-    size: 31446
+    size: 31471
   - path: development/scripts/refactoring-suggester.js
     hash: sha256:d50ea6b609c9cf8385979386fee4b4385d11ebcde15460260f66d04c705f6cd9
     type: script

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.2.6
-generated_at: "2026-05-17T14:19:01.092Z"
+generated_at: "2026-05-17T15:06:55.681Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1128
 files:
@@ -1297,9 +1297,9 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:d022e49f6ee5c2cbc13b106e62a13ee55a9176ce2212682b47524c662a657150
+    hash: sha256:2090e36a0b63f1e5910c46cdacef5ee5b3258a987d5b75adf988ce7ba3987fb7
     type: data
-    size: 574936
+    size: 575594
   - path: data/learned-patterns.yaml
     hash: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
     type: data
@@ -1669,9 +1669,9 @@ files:
     type: script
     size: 23410
   - path: development/scripts/populate-entity-registry.js
-    hash: sha256:2bdf871a3435304f69044bd7463c94647316f7d43e5b891c80c5f181f0f01401
+    hash: sha256:65cc968e9fa82bb18390ee0ed7063082b5341a441b83a9778638f1ce4064ab23
     type: script
-    size: 28901
+    size: 31446
   - path: development/scripts/refactoring-suggester.js
     hash: sha256:d50ea6b609c9cf8385979386fee4b4385d11ebcde15460260f66d04c705f6cd9
     type: script

--- a/tests/core/ids/populate-entity-registry.test.js
+++ b/tests/core/ids/populate-entity-registry.test.js
@@ -155,10 +155,22 @@ describe('populate-entity-registry (AC: 3, 4, 12)', () => {
       expect(purpose).toBe('This is the purpose line.');
     });
 
-    it('extracts from description field', () => {
-      const content = 'description: My awesome description here';
+    it('extracts from YAML frontmatter `description:` field', () => {
+      const content = '---\ndescription: My awesome description here\nversion: 1.0\n---\n\n# Title';
       const purpose = extractPurpose(content, '/test.md');
       expect(purpose).toBe('My awesome description here');
+    });
+
+    it('handles quoted YAML frontmatter description', () => {
+      const content = '---\ndescription: "A quoted description"\n---\n\n# Title';
+      const purpose = extractPurpose(content, '/test.md');
+      expect(purpose).toBe('A quoted description');
+    });
+
+    it('falls back to ## Overview when no Purpose section', () => {
+      const content = '# Title\n\n## Overview\n\nThis guide walks you through X.\n\n## Other';
+      const purpose = extractPurpose(content, '/test.md');
+      expect(purpose).toBe('This guide walks you through X.');
     });
 
     it('falls back to header', () => {
@@ -176,6 +188,40 @@ describe('populate-entity-registry (AC: 3, 4, 12)', () => {
       const longPurpose = '## Purpose\n\n' + 'x'.repeat(300);
       const purpose = extractPurpose(longPurpose, '/test.md');
       expect(purpose.length).toBeLessThanOrEqual(200);
+    });
+
+    // Regression test for the bug that motivated the priority-chain refactor:
+    // a body-level `description:` line inside example output or a code block
+    // used to be matched and treated as the doc's purpose. That was the source
+    // of `component-creation-guide.md` getting "Analyzes provided dataset" as
+    // its purpose (which was example installer transcript output, not a real
+    // description of the guide).
+    it('does NOT match body-level `description:` outside frontmatter', () => {
+      const content = [
+        '# Component Creation Guide',
+        '',
+        '## Overview',
+        '',
+        'This guide walks you through creating components.',
+        '',
+        '## Example Output',
+        '',
+        '```',
+        '? Task description: Analyzes provided dataset to identify patterns',
+        '```',
+      ].join('\n');
+      const purpose = extractPurpose(content, '/test.md');
+      // Should pick up Overview section, NOT the body-level "description:"
+      expect(purpose).toBe('This guide walks you through creating components.');
+      expect(purpose).not.toContain('Analyzes');
+    });
+
+    it('does NOT extract from `description:` lines without YAML frontmatter delimiters', () => {
+      const content = 'description: This should not be matched\n\n# Title';
+      const purpose = extractPurpose(content, '/test.md');
+      // No `---` delimiters → not frontmatter → falls through to `# Title`
+      expect(purpose).toBe('Title');
+      expect(purpose).not.toContain('This should not');
     });
   });
 

--- a/tests/core/ids/populate-entity-registry.test.js
+++ b/tests/core/ids/populate-entity-registry.test.js
@@ -7,6 +7,7 @@ const {
   extractKeywords,
   extractPurpose,
   looksLikePlaceholder,
+  syncSelfRegistryEntry,
   detectDependencies,
   extractYamlDependencies,
   extractMarkdownCrossReferences,
@@ -302,6 +303,77 @@ describe('populate-entity-registry (AC: 3, 4, 12)', () => {
         looksLikePlaceholder('Generate user stories from product requirements documents'),
       ).toBe(false);
       expect(looksLikePlaceholder('Validation summary')).toBe(false);
+    });
+  });
+
+  describe('syncSelfRegistryEntry()', () => {
+    const SELF_PATH = '.aiox-core/data/entity-registry.yaml';
+    const SENTINEL = 'sha256:<self-reference>';
+
+    it('updates lastVerified and checksum on the self-entry when path matches', () => {
+      const registry = {
+        entities: {
+          data: {
+            'entity-registry': {
+              path: SELF_PATH,
+              checksum: 'sha256:stale-old-hash-1234567890abcdef',
+              lastVerified: '2026-01-01T00:00:00.000Z',
+              purpose: 'Entity at .aiox-core/data/entity-registry.yaml',
+            },
+          },
+        },
+      };
+      const newTimestamp = '2026-05-17T15:00:00.000Z';
+
+      syncSelfRegistryEntry(registry, newTimestamp, SENTINEL);
+
+      expect(registry.entities.data['entity-registry'].lastVerified).toBe(newTimestamp);
+      expect(registry.entities.data['entity-registry'].checksum).toBe(SENTINEL);
+    });
+
+    it('does NOT mutate entries whose path is different (other entity-registry pointing to .js module)', () => {
+      const registry = {
+        entities: {
+          data: {
+            'entity-registry': {
+              path: '.aiox-core/core/doctor/checks/entity-registry.js',
+              checksum: 'sha256:legitimate-js-module-hash-do-not-touch',
+              lastVerified: '2026-01-01T00:00:00.000Z',
+            },
+          },
+        },
+      };
+      const newTimestamp = '2026-05-17T15:00:00.000Z';
+
+      syncSelfRegistryEntry(registry, newTimestamp, SENTINEL);
+
+      expect(registry.entities.data['entity-registry'].checksum).toBe(
+        'sha256:legitimate-js-module-hash-do-not-touch',
+      );
+      expect(registry.entities.data['entity-registry'].lastVerified).toBe('2026-01-01T00:00:00.000Z');
+    });
+
+    it('is a no-op when entities.data does not exist', () => {
+      const registry = { entities: { agents: { foo: { path: 'irrelevant' } } } };
+      expect(() => syncSelfRegistryEntry(registry, '2026-05-17T15:00:00.000Z', SENTINEL)).not.toThrow();
+    });
+
+    it('is a no-op when self-entry is missing', () => {
+      const registry = {
+        entities: {
+          data: {
+            'some-other-data': { path: '.aiox-core/data/something.yaml', checksum: 'sha256:keep' },
+          },
+        },
+      };
+      syncSelfRegistryEntry(registry, '2026-05-17T15:00:00.000Z', SENTINEL);
+      // Other entries unchanged
+      expect(registry.entities.data['some-other-data'].checksum).toBe('sha256:keep');
+    });
+
+    it('is a no-op when registry is malformed (missing entities)', () => {
+      expect(() => syncSelfRegistryEntry({}, '2026-05-17T15:00:00.000Z', SENTINEL)).not.toThrow();
+      expect(() => syncSelfRegistryEntry(null, '2026-05-17T15:00:00.000Z', SENTINEL)).not.toThrow();
     });
   });
 

--- a/tests/core/ids/populate-entity-registry.test.js
+++ b/tests/core/ids/populate-entity-registry.test.js
@@ -6,6 +6,7 @@ const {
   extractEntityId,
   extractKeywords,
   extractPurpose,
+  looksLikePlaceholder,
   detectDependencies,
   extractYamlDependencies,
   extractMarkdownCrossReferences,
@@ -222,6 +223,85 @@ describe('populate-entity-registry (AC: 3, 4, 12)', () => {
       // No `---` delimiters → not frontmatter → falls through to `# Title`
       expect(purpose).toBe('Title');
       expect(purpose).not.toContain('This should not');
+    });
+
+    // Regression: unfilled template placeholders / JS literals should be
+    // skipped through the priority chain, not adopted as the purpose.
+    it('skips placeholder `{Brief description}` in frontmatter and falls through to header', () => {
+      const content = '---\ndescription: "{Brief description of what this task does}"\n---\n\n# Real Task Title';
+      const purpose = extractPurpose(content, '/test.md');
+      expect(purpose).toBe('Real Task Title');
+    });
+
+    it('skips `{{HANDLEBAR}}` in Purpose section and falls through to header', () => {
+      const content = '# Real Title\n\n## Purpose\n\n{{TASK_TITLE}}';
+      const purpose = extractPurpose(content, '/test.md');
+      expect(purpose).toBe('Real Title');
+    });
+
+    it('skips JS template literal `${var}` placeholders and falls through to fallback', () => {
+      const content = '# ${name} Activator';
+      const purpose = extractPurpose(content, '/some/path/test.md');
+      expect(purpose).toContain('test.md');
+    });
+
+    it('falls through ALL placeholders to file-path fallback when nothing real exists', () => {
+      const content = '---\ndescription: "{One-line description}"\n---\n\n## Purpose\n\n{{var}}\n\n# *${taskName}';
+      const purpose = extractPurpose(content, '/some/path/orphan.md');
+      expect(purpose).toContain('orphan.md');
+    });
+  });
+
+  describe('looksLikePlaceholder()', () => {
+    it('detects single `{Title}` placeholder', () => {
+      expect(looksLikePlaceholder('{Brief description of what this task does}')).toBe(true);
+      expect(looksLikePlaceholder('{One-line description}')).toBe(true);
+    });
+
+    it('detects `{{handlebars}}` placeholders', () => {
+      expect(looksLikePlaceholder('{{TASK_TITLE}}')).toBe(true);
+      expect(looksLikePlaceholder('{{var}}')).toBe(true);
+    });
+
+    it('detects `${...}` JS template literals', () => {
+      expect(looksLikePlaceholder('${context.componentName}')).toBe(true);
+      expect(looksLikePlaceholder('*${taskName.replace(/-/g, "-")}')).toBe(true);
+    });
+
+    it('detects dominant interpolation (>30% of string)', () => {
+      expect(
+        looksLikePlaceholder(
+          '${icon} @${id} — ${name}${archetype !== \'Specialist\' ? ` (${archetype})` : \'\'} | ${title}',
+        ),
+      ).toBe(true);
+    });
+
+    it('does NOT flag normal prose containing curly braces', () => {
+      // CSS-like content with single { is fine if not a placeholder pattern.
+      expect(looksLikePlaceholder('Manage feature flags with { enabled: true } syntax')).toBe(false);
+    });
+
+    it('does NOT flag prose with a single `${name}` interpolation mention', () => {
+      // < 30% interpolation, dominated by real prose.
+      expect(
+        looksLikePlaceholder(
+          'Use this skill when the operator wants to send a message ${variable not present}',
+        ),
+      ).toBe(false);
+    });
+
+    it('does NOT flag empty / whitespace strings (caller handles)', () => {
+      expect(looksLikePlaceholder('')).toBe(false);
+      expect(looksLikePlaceholder('   ')).toBe(false);
+      expect(looksLikePlaceholder(null)).toBe(false);
+      expect(looksLikePlaceholder(undefined)).toBe(false);
+    });
+
+    it('does NOT flag real descriptive prose', () => {
+      expect(
+        looksLikePlaceholder('Generate user stories from product requirements documents'),
+      ).toBe(false);
+      expect(looksLikePlaceholder('Validation summary')).toBe(false);
     });
   });
 


### PR DESCRIPTION
Follow-up to PR #748. With body-level matching gone, the priority chain still picked up garbage purposes from files that have literal unfilled template placeholders or JS interpolation in the sources the chain reads. The extractor was working — the source data was the problem (~16 entries in the registry had purposes like `{Brief description...}`, `{{TASK_TITLE}}`, `*${taskName.replace(...)}`).

## Changes

New `looksLikePlaceholder(candidate)` detects:

1. Whole-string single placeholder: `{Brief...}`, `{{var}}`, `${ctx.x}`
2. Leading-token placeholder: `*${name}foo`, `${ctx.x} bar`, `{Title} extra`
3. Dominant interpolation (>30% of string): catches `${icon} @${id} — ${name}${archetype !== ...}` where most of the string is `${}` blocks

Conservative on real prose:
- `Manage feature flags with { enabled: true } syntax` → keeps
- `Use this skill when... ${variable not present}` (<30% interpolation) → keeps

Wired into all 4 `extractPurpose` strategies (frontmatter, `## Purpose`, `## Overview`, `# Title`). When a strategy produces a placeholder, falls through to next. When all produce placeholders, returns generic `Entity at <path>` fallback.

## Validation

```
$ grep -E "purpose: ['\"]?\{[A-Z]|purpose:.*\{\{|purpose:.*\\\$\\{" \
    .aiox-core/data/entity-registry.yaml | wc -l
# Before: 16
# After:  0
```

## Tests

12 new tests added — 4 cover priority-chain fall-through at each placeholder boundary, 8 cover `looksLikePlaceholder` directly (positive + negative cases).

Suite: **91/91 pass** (was 79/79 on PR #748).

## Why not fix the source files?

Placeholders live in templates/generators — they're SUPPOSED to be unfilled when stored. They get filled at use-time when the template instantiates. Registry inference reading template bodies as finished docs is the actual bug. Fixing the inference (this PR) is correct; trying to fill templates would break their template-ness.

## Related

- PR #748 — original purpose inference refactor (frontmatter/Overview priority chain)
- Cosmetic follow-up trail: started with CodeRabbit comment on PR #747 about `entity-registry` self-entry + `component-creation-guide` purpose drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Registry generation now centralizes a regeneration timestamp and updates the registry's own entry with verification metadata and a sentinel checksum.

* **Bug Fixes**
  * Registry entries no longer capture template or placeholder fragments; purpose text is prioritized from frontmatter and purpose/overview headers.

* **Tests**
  * Added tests for purpose extraction and robust placeholder detection across several template syntaxes.

* **Chores**
  * Updated install manifest metadata for regenerated files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/749?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->