### PR TITLE
fix(quality-gates): cross-platform CodeRabbit CLI execution [#731]

### DIFF
--- a/.aiox-core/core/orchestration/workflow-executor.js
+++ b/.aiox-core/core/orchestration/workflow-executor.js
@@ -783,24 +783,25 @@ class WorkflowExecutor {
       // - Explicit installation_mode: 'wsl' | 'native' wins (lets ops override).
       // - Default: Windows hosts wrap via WSL, macOS/Linux run the binary directly.
       // - cli_path defaults to ~/.local/bin/coderabbit (matches the CodeRabbit CLI installer default).
-      //   We expand leading "~" with os.homedir() defensively — `child_process.exec`
-      //   under a shell expands it, but the native code path goes through `execAsync`
-      //   which calls /bin/sh -c, and on Windows the host shell behavior is less
-      //   predictable. Programmatic expansion removes the ambiguity.
+      // - Tilde handling differs per mode: native expands via os.homedir() so the
+      //   resolved absolute path is shell-agnostic; WSL mode keeps the literal `~`
+      //   so the WSL distribution's own bash expands it (the host's HOME would point
+      //   at a Windows path that WSL cannot resolve).
       const rawCliPath = coderabbitConfig.cli_path || '~/.local/bin/coderabbit';
-      const cliPath = rawCliPath.startsWith('~')
-        ? path.join(os.homedir(), rawCliPath.slice(1))
-        : rawCliPath;
       const mode =
         coderabbitConfig.installation_mode ||
         (process.platform === 'win32' ? 'wsl' : 'native');
       let command;
       if (mode === 'wsl') {
         const wslPath = this.projectRoot
-          .replace(/^([A-Z]):/, (_, drive) => `/mnt/${drive.toLowerCase()}`)
+          .replace(/^([A-Za-z]):/, (_, drive) => `/mnt/${drive.toLowerCase()}`)
           .replace(/\\/g, '/');
-        command = `wsl bash -c 'cd "${wslPath}" && ${cliPath} --prompt-only -t uncommitted 2>&1'`;
+        // Keep literal `~` — WSL bash expands it to the WSL user's HOME.
+        command = `wsl bash -c 'cd "${wslPath}" && ${rawCliPath} --prompt-only -t uncommitted 2>&1'`;
       } else {
+        const cliPath = rawCliPath.startsWith('~')
+          ? path.join(os.homedir(), rawCliPath.slice(1))
+          : rawCliPath;
         command = `${cliPath} --prompt-only -t uncommitted`;
       }
 

--- a/.aiox-core/core/orchestration/workflow-executor.js
+++ b/.aiox-core/core/orchestration/workflow-executor.js
@@ -778,13 +778,22 @@ class WorkflowExecutor {
       const { promisify } = require('util');
       const execAsync = promisify(exec);
 
-      // Build command based on installation mode
+      // Build command for current platform.
+      // - Explicit installation_mode: 'wsl' | 'native' wins (lets ops override).
+      // - Default: Windows hosts wrap via WSL, macOS/Linux run the binary directly.
+      // - cli_path defaults to ~/.local/bin/coderabbit (matches the CodeRabbit CLI installer default).
+      const cliPath = coderabbitConfig.cli_path || '~/.local/bin/coderabbit';
+      const mode =
+        coderabbitConfig.installation_mode ||
+        (process.platform === 'win32' ? 'wsl' : 'native');
       let command;
-      if (coderabbitConfig.installation_mode === 'wsl') {
-        const wslPath = this.projectRoot.replace(/^([A-Z]):/, (_, drive) => `/mnt/${drive.toLowerCase()}`).replace(/\\/g, '/');
-        command = `wsl bash -c 'cd "${wslPath}" && ~/.local/bin/coderabbit --prompt-only -t uncommitted 2>&1'`;
+      if (mode === 'wsl') {
+        const wslPath = this.projectRoot
+          .replace(/^([A-Z]):/, (_, drive) => `/mnt/${drive.toLowerCase()}`)
+          .replace(/\\/g, '/');
+        command = `wsl bash -c 'cd "${wslPath}" && ${cliPath} --prompt-only -t uncommitted 2>&1'`;
       } else {
-        command = 'coderabbit --prompt-only -t uncommitted';
+        command = `${cliPath} --prompt-only -t uncommitted`;
       }
 
       if (this.options.debug) {

--- a/.aiox-core/core/orchestration/workflow-executor.js
+++ b/.aiox-core/core/orchestration/workflow-executor.js
@@ -20,6 +20,7 @@
 
 const fs = require('fs').promises;
 const fsSync = require('fs');
+const os = require('os');
 const path = require('path');
 const yaml = require('js-yaml');
 
@@ -782,7 +783,14 @@ class WorkflowExecutor {
       // - Explicit installation_mode: 'wsl' | 'native' wins (lets ops override).
       // - Default: Windows hosts wrap via WSL, macOS/Linux run the binary directly.
       // - cli_path defaults to ~/.local/bin/coderabbit (matches the CodeRabbit CLI installer default).
-      const cliPath = coderabbitConfig.cli_path || '~/.local/bin/coderabbit';
+      //   We expand leading "~" with os.homedir() defensively — `child_process.exec`
+      //   under a shell expands it, but the native code path goes through `execAsync`
+      //   which calls /bin/sh -c, and on Windows the host shell behavior is less
+      //   predictable. Programmatic expansion removes the ambiguity.
+      const rawCliPath = coderabbitConfig.cli_path || '~/.local/bin/coderabbit';
+      const cliPath = rawCliPath.startsWith('~')
+        ? path.join(os.homedir(), rawCliPath.slice(1))
+        : rawCliPath;
       const mode =
         coderabbitConfig.installation_mode ||
         (process.platform === 'win32' ? 'wsl' : 'native');

--- a/.aiox-core/core/quality-gates/layer2-pr-automation.js
+++ b/.aiox-core/core/quality-gates/layer2-pr-automation.js
@@ -101,17 +101,18 @@ class Layer2PRAutomation extends BaseLayer {
       // - this.coderabbit.command: explicit string wins (backward compat with old configs).
       // - this.coderabbit.installation_mode: 'wsl' | 'native' lets ops override platform detection.
       // - Default: Windows hosts wrap via WSL, macOS/Linux run the binary directly.
-      // - Tilde and ${PROJECT_ROOT} are resolved programmatically — `child_process.spawn`
-      //   with `shell: true` does shell expansion, but we cannot rely on PROJECT_ROOT
+      // - ${PROJECT_ROOT} is resolved programmatically — `child_process.spawn` with
+      //   `shell: true` does shell expansion, but we cannot rely on PROJECT_ROOT
       //   being set in the env at call sites, so substitute it here.
+      // - Tilde handling differs per mode: native expands via os.homedir() so the
+      //   resolved absolute path is shell-agnostic; WSL mode keeps the literal `~`
+      //   so the WSL distribution's own bash expands it (the host's HOME would point
+      //   at a Windows path that WSL cannot resolve).
       let command;
       if (this.coderabbit.command) {
         command = this.coderabbit.command;
       } else {
         const rawCliPath = this.coderabbit.cli_path || '~/.local/bin/coderabbit';
-        const cliPath = rawCliPath.startsWith('~')
-          ? path.join(os.homedir(), rawCliPath.slice(1))
-          : rawCliPath;
         const mode =
           this.coderabbit.installation_mode ||
           (process.platform === 'win32' ? 'wsl' : 'native');
@@ -119,9 +120,13 @@ class Layer2PRAutomation extends BaseLayer {
           const projectRoot = this.coderabbit.projectRoot || process.cwd();
           const wslProjectPath = projectRoot
             .replace(/\\/g, '/')
-            .replace(/^([A-Z]):/, (_, drive) => `/mnt/${drive.toLowerCase()}`);
-          command = `wsl bash -c 'cd "${wslProjectPath}" && ${cliPath} --prompt-only -t uncommitted'`;
+            .replace(/^([A-Za-z]):/, (_, drive) => `/mnt/${drive.toLowerCase()}`);
+          // Keep literal `~` — WSL bash expands it to the WSL user's HOME.
+          command = `wsl bash -c 'cd "${wslProjectPath}" && ${rawCliPath} --prompt-only -t uncommitted'`;
         } else {
+          const cliPath = rawCliPath.startsWith('~')
+            ? path.join(os.homedir(), rawCliPath.slice(1))
+            : rawCliPath;
           command = `${cliPath} --prompt-only -t uncommitted`;
         }
       }

--- a/.aiox-core/core/quality-gates/layer2-pr-automation.js
+++ b/.aiox-core/core/quality-gates/layer2-pr-automation.js
@@ -96,10 +96,23 @@ class Layer2PRAutomation extends BaseLayer {
     }
 
     try {
-      // Check if CodeRabbit is available
-      const command =
-        this.coderabbit.command ||
-        "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'";
+      // Build command for current platform when no explicit override is present.
+      // - this.coderabbit.command: explicit string wins (backward compat with old configs).
+      // - this.coderabbit.installation_mode: 'wsl' | 'native' lets ops override platform detection.
+      // - Default: Windows hosts wrap via WSL, macOS/Linux run the binary directly.
+      let command;
+      if (this.coderabbit.command) {
+        command = this.coderabbit.command;
+      } else {
+        const cliPath = this.coderabbit.cli_path || '~/.local/bin/coderabbit';
+        const mode =
+          this.coderabbit.installation_mode ||
+          (process.platform === 'win32' ? 'wsl' : 'native');
+        command =
+          mode === 'wsl'
+            ? `wsl bash -c 'cd \${PROJECT_ROOT} && ${cliPath} --prompt-only -t uncommitted'`
+            : `${cliPath} --prompt-only -t uncommitted`;
+      }
 
       const result = await this.runCommand(command, timeout);
 

--- a/.aiox-core/core/quality-gates/layer2-pr-automation.js
+++ b/.aiox-core/core/quality-gates/layer2-pr-automation.js
@@ -12,6 +12,7 @@
 
 const { spawn } = require('child_process');
 const fs = require('fs').promises;
+const os = require('os');
 const path = require('path');
 const { BaseLayer } = require('./base-layer');
 
@@ -100,18 +101,29 @@ class Layer2PRAutomation extends BaseLayer {
       // - this.coderabbit.command: explicit string wins (backward compat with old configs).
       // - this.coderabbit.installation_mode: 'wsl' | 'native' lets ops override platform detection.
       // - Default: Windows hosts wrap via WSL, macOS/Linux run the binary directly.
+      // - Tilde and ${PROJECT_ROOT} are resolved programmatically — `child_process.spawn`
+      //   with `shell: true` does shell expansion, but we cannot rely on PROJECT_ROOT
+      //   being set in the env at call sites, so substitute it here.
       let command;
       if (this.coderabbit.command) {
         command = this.coderabbit.command;
       } else {
-        const cliPath = this.coderabbit.cli_path || '~/.local/bin/coderabbit';
+        const rawCliPath = this.coderabbit.cli_path || '~/.local/bin/coderabbit';
+        const cliPath = rawCliPath.startsWith('~')
+          ? path.join(os.homedir(), rawCliPath.slice(1))
+          : rawCliPath;
         const mode =
           this.coderabbit.installation_mode ||
           (process.platform === 'win32' ? 'wsl' : 'native');
-        command =
-          mode === 'wsl'
-            ? `wsl bash -c 'cd \${PROJECT_ROOT} && ${cliPath} --prompt-only -t uncommitted'`
-            : `${cliPath} --prompt-only -t uncommitted`;
+        if (mode === 'wsl') {
+          const projectRoot = this.coderabbit.projectRoot || process.cwd();
+          const wslProjectPath = projectRoot
+            .replace(/\\/g, '/')
+            .replace(/^([A-Z]):/, (_, drive) => `/mnt/${drive.toLowerCase()}`);
+          command = `wsl bash -c 'cd "${wslProjectPath}" && ${cliPath} --prompt-only -t uncommitted'`;
+        } else {
+          command = `${cliPath} --prompt-only -t uncommitted`;
+        }
       }
 
       const result = await this.runCommand(command, timeout);

--- a/.aiox-core/core/quality-gates/quality-gate-config.yaml
+++ b/.aiox-core/core/quality-gates/quality-gate-config.yaml
@@ -34,7 +34,16 @@ layer2:
   enabled: true
   coderabbit:
     enabled: true
-    command: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'"
+    # Cross-platform CodeRabbit CLI invocation (Issue #731).
+    # Runtime resolves the command from cli_path + platform detection:
+    #   - macOS/Linux: run cli_path directly from project root.
+    #   - Windows: wrap with 'wsl bash -c' and rewrite project paths to /mnt/<drive>/...
+    # Set installation_mode explicitly ('wsl' | 'native') to override platform detection.
+    # Set command: "<raw shell string>" to bypass detection entirely (back-compat).
+    cli_path: ~/.local/bin/coderabbit
+    platform_notes:
+      macos_linux: "Run binary directly from project root (PATH or cli_path)."
+      windows: "Wrap with 'wsl bash -c' and use /mnt/<drive>/... project paths."
     timeout: 900000  # 15 minutes
     blockOn:
       - CRITICAL

--- a/.aiox-core/data/entity-registry.yaml
+++ b/.aiox-core/data/entity-registry.yaml
@@ -1,7 +1,7 @@
 metadata:
   version: 1.0.0
-  lastUpdated: '2026-05-18T04:12:17.473Z'
-  entityCount: 815
+  lastUpdated: '2026-05-18T04:51:58.010Z'
+  entityCount: 816
   checksumAlgorithm: sha256
   resolutionRate: 100
 entities:
@@ -16,8 +16,7 @@ entities:
         - mcp
         - server
         - task
-      usedBy:
-        - devops
+      usedBy: []
       dependencies:
         - analyst
       externalDeps: []
@@ -173,8 +172,7 @@ entities:
         - analyze
         - performance
         - 'task:'
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -197,8 +195,7 @@ entities:
         - analyze
         - project
         - structure
-      usedBy:
-        - architect
+      usedBy: []
       dependencies:
         - code-intel
         - planning-helper
@@ -227,8 +224,7 @@ entities:
         - apply
         - qa
         - fixes
-      usedBy:
-        - dev
+      usedBy: []
       dependencies:
         - qa
         - dev
@@ -253,8 +249,7 @@ entities:
         - architect
         - analyze
         - impact
-      usedBy:
-        - architect
+      usedBy: []
       dependencies:
         - dependency-impact-analyzer
         - modification-risk-assessment
@@ -454,8 +449,7 @@ entities:
         - build
         - autonomous
         - 'task:'
-      usedBy:
-        - dev
+      usedBy: []
       dependencies:
         - autonomous-build-loop.js
         - plan-execute-subtask
@@ -505,8 +499,7 @@ entities:
         - build
         - resume
         - 'task:'
-      usedBy:
-        - dev
+      usedBy: []
       dependencies:
         - dev
       externalDeps: []
@@ -528,8 +521,7 @@ entities:
         - build
         - status
         - 'task:'
-      usedBy:
-        - dev
+      usedBy: []
       dependencies:
         - dev
       externalDeps: []
@@ -599,8 +591,7 @@ entities:
         - docs
         - links
         - check-docs-links
-      usedBy:
-        - devops
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -625,8 +616,7 @@ entities:
         - configure
         - ci/cd
         - pipeline
-      usedBy:
-        - devops
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -679,7 +669,6 @@ entities:
       usedBy:
         - list-worktrees
         - remove-worktree
-        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -701,8 +690,7 @@ entities:
         - collaborative
         - edit
         - collaborative-edit
-      usedBy:
-        - architect
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -870,8 +858,6 @@ entities:
       usedBy:
         - aiox-master
         - analyst
-        - architect
-        - data-engineer
         - pm
       dependencies:
         - component-generator.js
@@ -904,8 +890,6 @@ entities:
       usedBy:
         - aiox-master
         - analyst
-        - architect
-        - data-engineer
         - pm
         - ux-design-expert
       dependencies:
@@ -975,8 +959,7 @@ entities:
       keywords:
         - create
         - service
-      usedBy:
-        - dev
+      usedBy: []
       dependencies:
         - code-intel
         - dev-helper
@@ -1002,8 +985,7 @@ entities:
         - test-suite-checklist.md
         - validation
         - (follow-up
-      usedBy:
-        - qa
+      usedBy: []
       dependencies:
         - component-generator.js
         - dev
@@ -1090,8 +1072,6 @@ entities:
       usedBy:
         - list-worktrees
         - remove-worktree
-        - dev
-        - devops
         - auto-worktree
       dependencies:
         - worktree-manager
@@ -1147,8 +1127,7 @@ entities:
         - 'task:'
         - (with
         - snapshot
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -1172,8 +1151,7 @@ entities:
         - 'task:'
         - supabase
         - project
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -1199,8 +1177,7 @@ entities:
         - modeling
         - 'task:'
         - session
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -1225,8 +1202,7 @@ entities:
         - 'task:'
         - migration
         - dry-run
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -1249,8 +1225,7 @@ entities:
         - env
         - check
         - 'task:'
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -1324,8 +1299,7 @@ entities:
         - 'task:'
         - data
         - safely
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -1350,8 +1324,7 @@ entities:
         - 'task:'
         - rls
         - template
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -1397,8 +1370,7 @@ entities:
         - rollback
         - 'task:'
         - database
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -1421,8 +1393,7 @@ entities:
         - run
         - sql
         - 'task:'
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -1469,8 +1440,7 @@ entities:
         - 'task:'
         - apply
         - data
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -1493,8 +1463,7 @@ entities:
         - smoke
         - test
         - 'task:'
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -1518,8 +1487,7 @@ entities:
         - 'task:'
         - create
         - database
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -1595,8 +1563,7 @@ entities:
         - 'task:'
         - ddl
         - ordering
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -1729,24 +1696,19 @@ entities:
         - develop
         - story
         - task
-      usedBy:
-        - dev
+      usedBy: []
       dependencies:
         - decision-recorder
-        - sm
-        - po
-        - dev
-        - qa
       externalDeps: []
       plannedDeps:
         - execute-task.js
-      lifecycle: production
+      lifecycle: experimental
       adaptability:
         score: 0.8
         constraints: []
         extensionPoints: []
-      checksum: sha256:be8924aa0de759ca92a177b0ea12a5b076a3095ee2a9f530b74b3de19e996954
-      lastVerified: '2026-05-18T04:12:16.609Z'
+      checksum: sha256:bc48d7f8211a25b500a65632de011a178203c53c1e1f6b2ed4f58fd7431a04f6
+      lastVerified: '2026-05-18T04:51:58.001Z'
     dev-improve-code-quality:
       path: .aiox-core/development/tasks/dev-improve-code-quality.md
       layer: L2
@@ -1764,8 +1726,7 @@ entities:
         - task
         - performs
         - automated
-      usedBy:
-        - dev
+      usedBy: []
       dependencies:
         - code-quality-improver
       externalDeps: []
@@ -1794,8 +1755,7 @@ entities:
         - aiox
         - developer
         - task
-      usedBy:
-        - dev
+      usedBy: []
       dependencies:
         - performance-optimizer
       externalDeps: []
@@ -1825,8 +1785,7 @@ entities:
         - aiox
         - developer
         - task
-      usedBy:
-        - dev
+      usedBy: []
       dependencies:
         - refactoring-suggester
       externalDeps: []
@@ -1883,8 +1842,7 @@ entities:
         - access
         - grant
         - 'task:'
-      usedBy:
-        - devops
+      usedBy: []
       dependencies:
         - devops
       externalDeps: []
@@ -1906,8 +1864,7 @@ entities:
         - pro
         - activate
         - 'task:'
-      usedBy:
-        - devops
+      usedBy: []
       dependencies:
         - devops
       externalDeps: []
@@ -1930,8 +1887,7 @@ entities:
         - check
         - access
         - 'task:'
-      usedBy:
-        - devops
+      usedBy: []
       dependencies:
         - devops
       externalDeps: []
@@ -1954,8 +1910,7 @@ entities:
         - request
         - reset
         - 'task:'
-      usedBy:
-        - devops
+      usedBy: []
       dependencies:
         - devops
       externalDeps: []
@@ -1978,8 +1933,7 @@ entities:
         - resend
         - verification
         - 'task:'
-      usedBy:
-        - devops
+      usedBy: []
       dependencies:
         - devops
       externalDeps: []
@@ -2002,8 +1956,7 @@ entities:
         - reset
         - password
         - 'task:'
-      usedBy:
-        - devops
+      usedBy: []
       dependencies:
         - devops
       externalDeps: []
@@ -2026,8 +1979,7 @@ entities:
         - validate
         - login
         - 'task:'
-      usedBy:
-        - devops
+      usedBy: []
       dependencies:
         - devops
       externalDeps: []
@@ -2050,8 +2002,7 @@ entities:
         - verify
         - status
         - 'task:'
-      usedBy:
-        - devops
+      usedBy: []
       dependencies:
         - devops
       externalDeps: []
@@ -2107,7 +2058,6 @@ entities:
       usedBy:
         - aiox-master
         - analyst
-        - architect
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -2134,18 +2084,11 @@ entities:
         - environment-bootstrap
       usedBy:
         - setup-github
-        - devops
       dependencies:
         - config-resolver
         - github-cli.yaml
         - supabase-cli.yaml
         - railway-cli.yaml
-        - greenfield-fullstack
-        - README
-        - devops
-        - analyst
-        - pm
-        - aiox-master
       externalDeps:
         - coderabbit
       plannedDeps:
@@ -2157,8 +2100,8 @@ entities:
         score: 0.8
         constraints: []
         extensionPoints: []
-      checksum: sha256:02ed701bea38ee11ad7e83a310ad55b3d84f36f37a344fda6b252fe3230d50cb
-      lastVerified: '2026-05-18T04:12:16.624Z'
+      checksum: sha256:fb177443e6b7ae7246ba52873c3a06c938f411179af8a7446909775446c5fd6c
+      lastVerified: '2026-05-18T04:51:58.002Z'
     execute-checklist:
       path: .aiox-core/development/tasks/execute-checklist.md
       layer: L2
@@ -2174,9 +2117,6 @@ entities:
         - existing
       usedBy:
         - aiox-master
-        - architect
-        - data-engineer
-        - dev
         - pm
         - po
         - sm
@@ -2494,7 +2434,6 @@ entities:
         - github-pr-automation.md
       usedBy:
         - resolve-github-issue
-        - devops
       dependencies:
         - repository-detector
         - devops-helper
@@ -2529,13 +2468,10 @@ entities:
         - pre-push-quality-gate.md
       usedBy:
         - resolve-github-issue
-        - devops
       dependencies:
         - repository-detector
         - devops-helper
         - code-intel
-        - devops
-        - dev
       externalDeps: []
       plannedDeps: []
       lifecycle: production
@@ -2543,8 +2479,8 @@ entities:
         score: 0.8
         constraints: []
         extensionPoints: []
-      checksum: sha256:3709049cefce2dc03f54a16830114e67fa6b4cf37f0f999638d5d1521f0979d8
-      lastVerified: '2026-05-18T04:12:16.638Z'
+      checksum: sha256:99d9dc2ca637866e7ed80897a8b9c57b216b6f1851ee8a1f5865637a4ff8f56e
+      lastVerified: '2026-05-18T04:51:58.003Z'
     github-devops-repository-cleanup:
       path: .aiox-core/development/tasks/github-devops-repository-cleanup.md
       layer: L2
@@ -2556,8 +2492,7 @@ entities:
         - repository
         - cleanup
         - repository-cleanup.md
-      usedBy:
-        - devops
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -2582,8 +2517,7 @@ entities:
         - version
         - management
         - version-management.md
-      usedBy:
-        - devops
+      usedBy: []
       dependencies:
         - repository-detector
       externalDeps: []
@@ -2628,8 +2562,7 @@ entities:
         - gotcha
         - 'task:'
         - add
-      usedBy:
-        - dev
+      usedBy: []
       dependencies:
         - gotchas-memory.js
         - gotchas
@@ -2656,7 +2589,6 @@ entities:
       usedBy:
         - document-gotchas
         - gotcha
-        - dev
       dependencies:
         - gotchas-memory.js
         - dev
@@ -2923,8 +2855,7 @@ entities:
         - list
         - mcps
         - list-mcps
-      usedBy:
-        - devops
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -2947,8 +2878,6 @@ entities:
       usedBy:
         - create-worktree
         - remove-worktree
-        - dev
-        - devops
       dependencies:
         - worktree-manager
         - create-worktree
@@ -2997,7 +2926,6 @@ entities:
         - merge-worktree
       usedBy:
         - create-worktree
-        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -3234,8 +3162,7 @@ entities:
         - create
         - context
         - 'pipeline:'
-      usedBy:
-        - architect
+      usedBy: []
       dependencies:
         - code-intel
         - planning-helper
@@ -3266,8 +3193,7 @@ entities:
         - implementation
         - execution
         - 'pipeline:'
-      usedBy:
-        - architect
+      usedBy: []
       dependencies:
         - code-intel
         - planning-helper
@@ -3297,7 +3223,6 @@ entities:
         - agent)
       usedBy:
         - build-autonomous
-        - dev
       dependencies:
         - plan-tracker
         - dev
@@ -3380,7 +3305,6 @@ entities:
         - backlog
         - manage-story-backlog
       usedBy:
-        - dev
         - po
       dependencies: []
       externalDeps: []
@@ -3709,8 +3633,7 @@ entities:
         - console
         - check
         - task
-      usedBy:
-        - qa
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -3733,7 +3656,6 @@ entities:
         - request
         - task
       usedBy:
-        - qa
         - qa-loop
       dependencies:
         - qa-review-story
@@ -3760,8 +3682,7 @@ entities:
         - evidence
         - requirements
         - task
-      usedBy:
-        - qa
+      usedBy: []
       dependencies:
         - qa
       externalDeps: []
@@ -3784,8 +3705,7 @@ entities:
         - positive
         - detection
         - task
-      usedBy:
-        - qa
+      usedBy: []
       dependencies:
         - qa
       externalDeps: []
@@ -3811,8 +3731,7 @@ entities:
         - issue
         - fixer
         - task
-      usedBy:
-        - dev
+      usedBy: []
       dependencies:
         - plan-tracker
         - dev
@@ -3838,8 +3757,7 @@ entities:
         - qa
         - gate
         - qa-gate
-      usedBy:
-        - qa
+      usedBy: []
       dependencies:
         - qa
         - devops
@@ -3873,8 +3791,7 @@ entities:
         - test-generation-checklist.md
         - validation
         - (follow-up
-      usedBy:
-        - qa
+      usedBy: []
       dependencies:
         - test-generator
         - coverage-analyzer
@@ -3902,8 +3819,7 @@ entities:
         - library
         - validation
         - task
-      usedBy:
-        - qa
+      usedBy: []
       dependencies:
         - context7
       externalDeps: []
@@ -3925,8 +3841,7 @@ entities:
         - migration
         - validation
         - task
-      usedBy:
-        - qa
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -3947,8 +3862,7 @@ entities:
         - nfr
         - assess
         - nfr-assess
-      usedBy:
-        - qa
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -3977,8 +3891,7 @@ entities:
         - 10-phase
         - quality
         - assurance
-      usedBy:
-        - qa
+      usedBy: []
       dependencies:
         - qa
         - dev
@@ -4004,8 +3917,7 @@ entities:
         - aiox
         - developer
         - task
-      usedBy:
-        - qa
+      usedBy: []
       dependencies:
         - dependency-impact-analyzer
         - diff-generator
@@ -4035,12 +3947,8 @@ entities:
         - review-story
       usedBy:
         - qa-create-fix-request
-        - qa
         - qa-loop
-      dependencies:
-        - qa
-        - dev
-        - devops
+      dependencies: []
       externalDeps: []
       plannedDeps:
         - qa-master-checklist
@@ -4051,8 +3959,8 @@ entities:
         score: 0.8
         constraints: []
         extensionPoints: []
-      checksum: sha256:cc3e189824c656ff6ed2db04bd0a2a03d6293bccbec7e9b7a321daf64b9f1563
-      lastVerified: '2026-05-18T04:12:16.699Z'
+      checksum: sha256:dc9b998aa64c4dd950bb0e8cbce29bba10c7b72b128f13fe8294e70eb608e7d9
+      lastVerified: '2026-05-18T04:51:58.003Z'
     qa-risk-profile:
       path: .aiox-core/development/tasks/qa-risk-profile.md
       layer: L2
@@ -4065,8 +3973,7 @@ entities:
         - risk
         - profile
         - risk-profile
-      usedBy:
-        - qa
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -4092,8 +3999,7 @@ entities:
         - (with
         - code
         - quality
-      usedBy:
-        - qa
+      usedBy: []
       dependencies:
         - dev
         - qa
@@ -4118,8 +4024,7 @@ entities:
         - security
         - checklist
         - task
-      usedBy:
-        - qa
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -4142,8 +4047,7 @@ entities:
         - test
         - design
         - test-design
-      usedBy:
-        - qa
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -4169,8 +4073,7 @@ entities:
         - trace
         - requirements
         - trace-requirements
-      usedBy:
-        - qa
+      usedBy: []
       dependencies:
         - po-master-checklist
       externalDeps: []
@@ -4195,8 +4098,7 @@ entities:
         - manage
         - software
         - releases
-      usedBy:
-        - devops
+      usedBy: []
       dependencies:
         - devops
       externalDeps: []
@@ -4219,8 +4121,7 @@ entities:
         - remove
         - mcp
         - remove-mcp
-      usedBy:
-        - devops
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -4243,8 +4144,6 @@ entities:
       usedBy:
         - create-worktree
         - list-worktrees
-        - dev
-        - devops
       dependencies:
         - worktree-manager
         - create-worktree
@@ -4272,7 +4171,6 @@ entities:
         - resolve-github-issue.md
       usedBy:
         - triage-github-issues
-        - devops
       dependencies:
         - triage-github-issues
         - github-devops-pre-push-quality-gate
@@ -4402,8 +4300,7 @@ entities:
         - mcp
         - catalog
         - task
-      usedBy:
-        - devops
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -4423,8 +4320,7 @@ entities:
         - security
         - audit
         - 'task:'
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -4491,8 +4387,7 @@ entities:
         - setup
         - database
         - 'task:'
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -4542,8 +4437,7 @@ entities:
         - setup
         - github
         - setup-github
-      usedBy:
-        - devops
+      usedBy: []
       dependencies:
         - environment-bootstrap
         - github-cli.yaml
@@ -4596,8 +4490,7 @@ entities:
         - mcp
         - docker
         - toolkit
-      usedBy:
-        - devops
+      usedBy: []
       dependencies:
         - devops
       externalDeps: []
@@ -4726,7 +4619,6 @@ entities:
         - complexity
         - 'pipeline:'
       usedBy:
-        - architect
         - spec-pipeline
       dependencies:
         - architect
@@ -4752,7 +4644,6 @@ entities:
         - 'pipeline:'
         - specification
       usedBy:
-        - qa
         - spec-pipeline
       dependencies:
         - qa
@@ -5166,8 +5057,7 @@ entities:
         - sync
         - documentation
         - sync-documentation
-      usedBy:
-        - dev
+      usedBy: []
       dependencies:
         - documentation-synchronizer
       externalDeps: []
@@ -5240,8 +5130,7 @@ entities:
         - 'task:'
         - (rls
         - testing)
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps:
@@ -5289,7 +5178,6 @@ entities:
         - triage-github-issues.md
       usedBy:
         - resolve-github-issue
-        - devops
       dependencies:
         - resolve-github-issue
         - devops
@@ -5516,7 +5404,6 @@ entities:
         - task
       usedBy:
         - po-close-story
-        - dev
         - po
       dependencies:
         - po-master-checklist
@@ -5551,8 +5438,7 @@ entities:
         - tech
         - preset
         - \*validate-tech-preset
-      usedBy:
-        - architect
+      usedBy: []
       dependencies:
         - architect
       externalDeps: []
@@ -5599,8 +5485,7 @@ entities:
       keywords:
         - verify
         - subtask
-      usedBy:
-        - dev
+      usedBy: []
       dependencies:
         - dev
         - architect
@@ -5626,8 +5511,7 @@ entities:
         - '`*waves`'
         - wave
         - analysis
-      usedBy:
-        - dev
+      usedBy: []
       dependencies:
         - dev
       externalDeps: []
@@ -5879,7 +5763,6 @@ entities:
         - tmpl
       usedBy:
         - aiox-master
-        - architect
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -5922,7 +5805,6 @@ entities:
         - tmpl
       usedBy:
         - aiox-master
-        - architect
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -5986,8 +5868,7 @@ entities:
       keywords:
         - changelog
         - template
-      usedBy:
-        - devops
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -6127,7 +6008,6 @@ entities:
         - tmpl
       usedBy:
         - aiox-master
-        - architect
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -6172,7 +6052,6 @@ entities:
         - tmpl
       usedBy:
         - aiox-master
-        - architect
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -6193,8 +6072,7 @@ entities:
         - actions
         - cd
         - template
-      usedBy:
-        - devops
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -6215,8 +6093,7 @@ entities:
         - actions
         - ci
         - template
-      usedBy:
-        - devops
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -6238,8 +6115,7 @@ entities:
         - template
         - pull
         - request
-      usedBy:
-        - devops
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -6281,8 +6157,7 @@ entities:
         - index
         - strategy
         - tmpl
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -6324,8 +6199,7 @@ entities:
         - migration
         - plan
         - tmpl
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -6548,8 +6422,7 @@ entities:
         - qa
         - gate
         - tmpl
-      usedBy:
-        - qa
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -6591,8 +6464,7 @@ entities:
         - rls
         - policies
         - tmpl
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -6612,8 +6484,7 @@ entities:
         - schema
         - design
         - tmpl
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -6680,7 +6551,6 @@ entities:
       usedBy:
         - aiox-master
         - po
-        - qa
         - sm
       dependencies:
         - dev
@@ -9137,7 +9007,6 @@ entities:
       usedBy:
         - build-autonomous
         - build-orchestrator
-        - dev
       dependencies:
         - build-state-manager
         - recovery-tracker
@@ -9161,7 +9030,6 @@ entities:
         - orchestrator
       usedBy:
         - build
-        - dev
       dependencies:
         - autonomous-build-loop
         - build-state-manager
@@ -9188,7 +9056,6 @@ entities:
       usedBy:
         - autonomous-build-loop
         - build-orchestrator
-        - dev
       dependencies:
         - errors-index
         - stuck-detector
@@ -9971,7 +9838,6 @@ entities:
         - gotchas
         - build-orchestrator
         - active-modules.verify
-        - dev
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -10715,8 +10581,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:49372791e5729fd7987c80efe1400168e8d59eac000a009b88d9fde6735cf4db
-      lastVerified: '2026-05-18T04:12:17.057Z'
+      checksum: sha256:b09934e53f7aba651d18a963b6dc09f8511c02db7eaf8ce6c16c4d2b8e7824a9
+      lastVerified: '2026-05-18T04:51:57.990Z'
     workflow-orchestrator:
       path: .aiox-core/core/orchestration/workflow-orchestrator.js
       layer: L1
@@ -10958,8 +10824,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:af31e7ac60b74b52ee983d0fcff7457042eea553b6127538cab41eb94eaee8e0
-      lastVerified: '2026-05-18T04:12:17.066Z'
+      checksum: sha256:c41825460c79011f7da5c4be796930c5a94b7b24f4ce735699552a30761cf48d
+      lastVerified: '2026-05-18T04:51:57.996Z'
     layer3-human-review:
       path: .aiox-core/core/quality-gates/layer3-human-review.js
       layer: L1
@@ -14162,6 +14028,27 @@ entities:
         extensionPoints: []
       checksum: sha256:dd025894f8f0d3bd22a147dbc0debef8b83e96f3c59483653404b3cd5a01d5aa
       lastVerified: '2026-05-18T04:12:17.221Z'
+    quality-gate-config:
+      path: .aiox-core/core/quality-gates/quality-gate-config.yaml
+      layer: L1
+      type: module
+      purpose: Quality Gate Configuration
+      keywords:
+        - quality
+        - gate
+        - config
+        - configuration
+      usedBy: []
+      dependencies: []
+      externalDeps: []
+      plannedDeps: []
+      lifecycle: orphan
+      adaptability:
+        score: 0.4
+        constraints: []
+        extensionPoints: []
+      checksum: sha256:979b60cbf77d0478f8a894a3190299d74c2aa0924bbefe964d2aa402adc3eb33
+      lastVerified: '2026-05-18T04:51:57.997Z'
   agents:
     aiox-master:
       path: .aiox-core/development/agents/aiox-master.md
@@ -14173,7 +14060,6 @@ entities:
         - master
         - aiox-master
       usedBy:
-        - environment-bootstrap
         - ids-governor
         - project-status
         - run-workflow-engine
@@ -14252,7 +14138,6 @@ entities:
         - add-mcp
         - architect-analyze-impact
         - brownfield-create-epic
-        - environment-bootstrap
         - spec-research-dependencies
         - validate-next-story
         - brownfield-risk-report-tmpl
@@ -14334,28 +14219,7 @@ entities:
         - greenfield-ui
         - spec-pipeline
         - story-draft-checklist
-      dependencies:
-        - analyze-project-structure
-        - architect-analyze-impact
-        - collaborative-edit
-        - create-deep-research-prompt
-        - create-doc
-        - document-project
-        - execute-checklist
-        - validate-tech-preset
-        - spec-assess-complexity
-        - plan-create-implementation
-        - plan-create-context
-        - architecture-tmpl.yaml
-        - front-end-architecture-tmpl.yaml
-        - fullstack-architecture-tmpl.yaml
-        - brownfield-architecture-tmpl.yaml
-        - architect-checklist
-        - exa
-        - context7
-        - supabase-cli
-        - railway-cli
-        - codebase-mapper.js
+      dependencies: []
       externalDeps:
         - git
         - coderabbit
@@ -14365,8 +14229,8 @@ entities:
         score: 0.3
         constraints: []
         extensionPoints: []
-      checksum: sha256:1b89e95048df940056570ecb6589f18a9a6114b96ca1b9fde130fb7bdb2ded8f
-      lastVerified: '2026-05-18T04:12:17.239Z'
+      checksum: sha256:c45b1e71af39b5da34a832dcc3d1c9b41b6270de61f79d4bada3c27b46be19df
+      lastVerified: '2026-05-18T04:51:57.997Z'
     data-engineer:
       path: .aiox-core/development/agents/data-engineer.md
       layer: L2
@@ -14384,35 +14248,7 @@ entities:
         - claude-rules
         - codex-rules
         - brownfield-discovery
-      dependencies:
-        - create-doc
-        - db-domain-modeling
-        - setup-database
-        - db-env-check
-        - db-bootstrap
-        - db-apply-migration
-        - db-dry-run
-        - db-seed
-        - db-snapshot
-        - db-rollback
-        - db-smoke-test
-        - security-audit
-        - analyze-performance
-        - db-policy-apply
-        - test-as-user
-        - db-verify-order
-        - db-load-csv
-        - db-run-sql
-        - execute-checklist
-        - create-deep-research-prompt
-        - schema-design-tmpl.yaml
-        - rls-policies-tmpl.yaml
-        - migration-plan-tmpl.yaml
-        - index-strategy-tmpl.yaml
-        - dba-predeploy-checklist
-        - dba-rollback-checklist
-        - database-design-checklist
-        - supabase-cli
+      dependencies: []
       externalDeps:
         - coderabbit
       plannedDeps:
@@ -14432,8 +14268,8 @@ entities:
         score: 0.3
         constraints: []
         extensionPoints: []
-      checksum: sha256:41c791fbdf43f700f2e78418c8af18197d1135741bc7845d03013f726b125f6f
-      lastVerified: '2026-05-18T04:12:17.245Z'
+      checksum: sha256:4b921018c23721c6f71a5d23b6495d254f260cd85406db5915f034a90d17c845
+      lastVerified: '2026-05-18T04:51:57.998Z'
     dev:
       path: .aiox-core/development/agents/dev.md
       layer: L2
@@ -14456,12 +14292,10 @@ entities:
         - create-suite
         - delegate-to-external-executor
         - dev-backlog-debt
-        - dev-develop-story
         - execute-checklist
         - execute-epic-plan
         - extract-patterns
         - github-devops-github-pr-automation
-        - github-devops-pre-push-quality-gate
         - gotcha
         - gotchas
         - ids-governor
@@ -14474,7 +14308,6 @@ entities:
         - qa-fix-issues
         - qa-gate
         - qa-review-build
-        - qa-review-story
         - qa-run-tests
         - setup-llm-routing
         - story-checkpoint
@@ -14499,44 +14332,6 @@ entities:
         - story-draft-checklist
       dependencies:
         - decision-log-generator
-        - apply-qa-fixes
-        - qa-fix-issues
-        - create-service
-        - dev-develop-story
-        - execute-checklist
-        - plan-execute-subtask
-        - verify-subtask
-        - dev-improve-code-quality
-        - po-manage-story-backlog
-        - dev-optimize-performance
-        - dev-suggest-refactoring
-        - sync-documentation
-        - validate-next-story
-        - waves
-        - build-resume
-        - build-status
-        - build-autonomous
-        - gotcha
-        - gotchas
-        - create-worktree
-        - list-worktrees
-        - remove-worktree
-        - story-dod-checklist
-        - self-critique-checklist
-        - context7
-        - supabase
-        - n8n
-        - browser
-        - ffmpeg
-        - recovery-tracker.js
-        - stuck-detector.js
-        - approach-manager.js
-        - rollback-manager.js
-        - build-state-manager.js
-        - autonomous-build-loop.js
-        - build-orchestrator.js
-        - gotchas-memory.js
-        - worktree-manager.js
       externalDeps:
         - coderabbit
         - git
@@ -14546,8 +14341,8 @@ entities:
         score: 0.3
         constraints: []
         extensionPoints: []
-      checksum: sha256:eaaec824273f02b9ccbe6768d9e9147a5ad0d7faa9483b9730b1f02a71ef2769
-      lastVerified: '2026-05-18T04:12:17.247Z'
+      checksum: sha256:91a63332b1cc19af47b3cd2811b5e00635b72a747b5858efc09ce3aa7826d1b7
+      lastVerified: '2026-05-18T04:51:57.999Z'
     devops:
       path: .aiox-core/development/agents/devops.md
       layer: L2
@@ -14567,15 +14362,12 @@ entities:
         - devops-pro-reset-password
         - devops-pro-validate-login
         - devops-pro-verify-status
-        - environment-bootstrap
         - execute-epic-plan
-        - github-devops-pre-push-quality-gate
         - github-issue-triage
         - init-project-status
         - list-worktrees
         - publish-npm
         - qa-gate
-        - qa-review-story
         - release-management
         - remove-worktree
         - resolve-github-issue
@@ -14589,46 +14381,7 @@ entities:
         - codex-rules
         - memory-audit-checklist
         - greenfield-fullstack
-      dependencies:
-        - environment-bootstrap
-        - setup-github
-        - github-devops-version-management
-        - github-devops-pre-push-quality-gate
-        - github-devops-github-pr-automation
-        - ci-cd-configuration
-        - github-devops-repository-cleanup
-        - release-management
-        - search-mcp
-        - add-mcp
-        - list-mcps
-        - remove-mcp
-        - setup-mcp-docker
-        - check-docs-links
-        - triage-github-issues
-        - resolve-github-issue
-        - devops-pro-access-grant
-        - devops-pro-check-access
-        - devops-pro-request-reset
-        - devops-pro-resend-verification
-        - devops-pro-reset-password
-        - devops-pro-validate-login
-        - devops-pro-verify-status
-        - devops-pro-activate
-        - create-worktree
-        - list-worktrees
-        - remove-worktree
-        - cleanup-worktrees
-        - merge-worktree
-        - github-pr-template
-        - github-actions-ci.yml
-        - github-actions-cd.yml
-        - changelog-template
-        - pre-push-checklist
-        - release-checklist
-        - github-cli
-        - asset-inventory.js
-        - path-analyzer.js
-        - migrate-agent.js
+      dependencies: []
       externalDeps:
         - coderabbit
         - git
@@ -14640,8 +14393,8 @@ entities:
         score: 0.3
         constraints: []
         extensionPoints: []
-      checksum: sha256:5c52cc74f923ac381fa92fb969607b80a35f34b958c02d2d1edd1115f7690d35
-      lastVerified: '2026-05-18T04:12:17.249Z'
+      checksum: sha256:fb4555b484be4b93e11ed1e974b3e904ba7cddecb01ce44ac26828c7e8a8e382
+      lastVerified: '2026-05-18T04:51:57.999Z'
     pm:
       path: .aiox-core/development/agents/pm.md
       layer: L2
@@ -14653,7 +14406,6 @@ entities:
         - architect-analyze-impact
         - brownfield-create-epic
         - create-deep-research-prompt
-        - environment-bootstrap
         - execute-epic-plan
         - po-close-story
         - spec-critique
@@ -14714,7 +14466,6 @@ entities:
         - cleanup-utilities
         - create-next-story
         - dev-backlog-debt
-        - dev-develop-story
         - execute-epic-plan
         - github-devops-github-pr-automation
         - po-backlog-add
@@ -14780,7 +14531,6 @@ entities:
         - cleanup-utilities
         - create-next-story
         - create-suite
-        - dev-develop-story
         - execute-checklist
         - execute-epic-plan
         - github-devops-github-pr-automation
@@ -14791,7 +14541,6 @@ entities:
         - qa-fix-issues
         - qa-gate
         - qa-review-build
-        - qa-review-story
         - qa-run-tests
         - security-scan
         - spec-critique
@@ -14814,31 +14563,7 @@ entities:
         - spec-pipeline
         - story-development-cycle
         - story-draft-checklist
-      dependencies:
-        - qa-create-fix-request
-        - qa-generate-tests
-        - qa-nfr-assess
-        - qa-gate
-        - qa-review-build
-        - qa-review-proposal
-        - qa-review-story
-        - qa-risk-profile
-        - qa-run-tests
-        - qa-test-design
-        - qa-trace-requirements
-        - create-suite
-        - spec-critique
-        - qa-library-validation
-        - qa-security-checklist
-        - qa-migration-validation
-        - qa-evidence-requirements
-        - qa-false-positive-detection
-        - qa-browser-console-check
-        - qa-gate-tmpl.yaml
-        - story-tmpl.yaml
-        - browser
-        - context7
-        - supabase
+      dependencies: []
       externalDeps:
         - coderabbit
         - git
@@ -14849,8 +14574,8 @@ entities:
         score: 0.3
         constraints: []
         extensionPoints: []
-      checksum: sha256:cf4a8f473067a9d2909072215bce7b13917c779442e6f858681bd8b9f0b0c3c0
-      lastVerified: '2026-05-18T04:12:17.261Z'
+      checksum: sha256:506a44a6828ce6e0bc2fc89aaaced9df54fefea293525e5c1ce2e3bc37661c90
+      lastVerified: '2026-05-18T04:51:58.000Z'
     sm:
       path: .aiox-core/development/agents/sm.md
       layer: L2
@@ -14860,7 +14585,6 @@ entities:
         - sm
       usedBy:
         - brownfield-create-story
-        - dev-develop-story
         - po-close-story
         - project-status
         - validate-next-story
@@ -15902,8 +15626,7 @@ entities:
       keywords:
         - greenfield
         - fullstack
-      usedBy:
-        - environment-bootstrap
+      usedBy: []
       dependencies:
         - devops
         - analyst
@@ -16140,8 +15863,7 @@ entities:
       keywords:
         - approach
         - manager
-      usedBy:
-        - dev
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -16180,8 +15902,7 @@ entities:
       keywords:
         - asset
         - inventory
-      usedBy:
-        - devops
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -16386,8 +16107,7 @@ entities:
       keywords:
         - codebase
         - mapper
-      usedBy:
-        - architect
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -16890,8 +16610,7 @@ entities:
       keywords:
         - migrate
         - agent
-      usedBy:
-        - devops
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -16977,8 +16696,7 @@ entities:
       keywords:
         - path
         - analyzer
-      usedBy:
-        - devops
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -17256,7 +16974,6 @@ entities:
         - autonomous-build-loop
         - build-state-manager
         - recovery-handler
-        - dev
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -17343,7 +17060,6 @@ entities:
       usedBy:
         - recovery-handler
         - epic-5-executor
-        - dev
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -17471,7 +17187,6 @@ entities:
         - build-state-manager
         - recovery-handler
         - epic-5-executor
-        - dev
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -17911,7 +17626,6 @@ entities:
         - remove-worktree
         - autonomous-build-loop
         - build-orchestrator
-        - dev
         - auto-worktree
         - project-status-loader
         - story-worktree-hooks
@@ -18467,7 +18181,6 @@ entities:
         - directory
       usedBy:
         - db-supabase-setup
-        - environment-bootstrap
       dependencies:
         - tool-resolver
       externalDeps: []
@@ -18491,7 +18204,6 @@ entities:
         - environment-bootstrap
         - setup-github
         - health-check-checks-services-index
-        - devops
         - po
       dependencies: []
       externalDeps: []
@@ -18535,7 +18247,6 @@ entities:
         - cli
       usedBy:
         - environment-bootstrap
-        - architect
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -18556,8 +18267,6 @@ entities:
         - cli
       usedBy:
         - environment-bootstrap
-        - architect
-        - data-engineer
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -18575,8 +18284,7 @@ entities:
       purpose: Entity at .aiox-core/infrastructure/tools/local/ffmpeg.yaml
       keywords:
         - ffmpeg
-      usedBy:
-        - dev
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -18616,8 +18324,6 @@ entities:
       keywords:
         - browser
       usedBy:
-        - dev
-        - qa
         - ux-design-expert
       dependencies: []
       externalDeps: []
@@ -18658,10 +18364,7 @@ entities:
       usedBy:
         - qa-library-validation
         - analyst
-        - architect
-        - dev
         - po
-        - qa
         - sm
         - squad-creator
       dependencies: []
@@ -18702,7 +18405,6 @@ entities:
         - exa
       usedBy:
         - analyst
-        - architect
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -18740,8 +18442,7 @@ entities:
       purpose: Entity at .aiox-core/infrastructure/tools/mcp/n8n.yaml
       keywords:
         - n8n
-      usedBy:
-        - dev
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -18759,9 +18460,7 @@ entities:
       purpose: Entity at .aiox-core/infrastructure/tools/mcp/supabase.yaml
       keywords:
         - supabase
-      usedBy:
-        - dev
-        - qa
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -18806,7 +18505,6 @@ entities:
         - validation
       usedBy:
         - aiox-master
-        - architect
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -18878,8 +18576,7 @@ entities:
         - database
         - design
         - checklist
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -18900,8 +18597,7 @@ entities:
         - predeploy
         - checklist
         - pre-deploy
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -18921,8 +18617,7 @@ entities:
         - dba
         - rollback
         - checklist
-      usedBy:
-        - data-engineer
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -19048,8 +18743,7 @@ entities:
         - pre-push
         - quality
         - gate
-      usedBy:
-        - devops
+      usedBy: []
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -19070,7 +18764,6 @@ entities:
         - checklist
       usedBy:
         - publish-npm
-        - devops
       dependencies: []
       externalDeps: []
       plannedDeps: []
@@ -19093,7 +18786,6 @@ entities:
         - self-critique
       usedBy:
         - build-autonomous
-        - dev
       dependencies:
         - dev
       externalDeps: []
@@ -19119,7 +18811,6 @@ entities:
         - (dod)
       usedBy:
         - aiox-master
-        - dev
       dependencies: []
       externalDeps: []
       plannedDeps: []

--- a/.aiox-core/data/entity-registry.yaml
+++ b/.aiox-core/data/entity-registry.yaml
@@ -1,6 +1,6 @@
 metadata:
   version: 1.0.0
-  lastUpdated: '2026-05-18T04:51:58.010Z'
+  lastUpdated: '2026-05-18T05:18:17.136Z'
   entityCount: 816
   checksumAlgorithm: sha256
   resolutionRate: 100
@@ -2479,8 +2479,8 @@ entities:
         score: 0.8
         constraints: []
         extensionPoints: []
-      checksum: sha256:99d9dc2ca637866e7ed80897a8b9c57b216b6f1851ee8a1f5865637a4ff8f56e
-      lastVerified: '2026-05-18T04:51:58.003Z'
+      checksum: sha256:529b4366c0e4b4b3568d95ae02ddf28974a5f34faf1d7b23d99caddbfa3e2db7
+      lastVerified: '2026-05-18T05:18:17.130Z'
     github-devops-repository-cleanup:
       path: .aiox-core/development/tasks/github-devops-repository-cleanup.md
       layer: L2
@@ -10581,8 +10581,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:b09934e53f7aba651d18a963b6dc09f8511c02db7eaf8ce6c16c4d2b8e7824a9
-      lastVerified: '2026-05-18T04:51:57.990Z'
+      checksum: sha256:ddc880683df489ec7203ab7ecd8e066a08e2f72b011fe0dfe578d31155eb513b
+      lastVerified: '2026-05-18T05:18:17.128Z'
     workflow-orchestrator:
       path: .aiox-core/core/orchestration/workflow-orchestrator.js
       layer: L1
@@ -10824,8 +10824,8 @@ entities:
         score: 0.4
         constraints: []
         extensionPoints: []
-      checksum: sha256:c41825460c79011f7da5c4be796930c5a94b7b24f4ce735699552a30761cf48d
-      lastVerified: '2026-05-18T04:51:57.996Z'
+      checksum: sha256:53e1f05e3ece4731848ad818f13a97ce18f553327b6f2e385e4d299492cc890a
+      lastVerified: '2026-05-18T05:18:17.129Z'
     layer3-human-review:
       path: .aiox-core/core/quality-gates/layer3-human-review.js
       layer: L1

--- a/.aiox-core/development/agents/architect.md
+++ b/.aiox-core/development/agents/architect.md
@@ -331,9 +331,15 @@ dependencies:
         focus: Style consistency, minor optimizations
 
     workflow: |
-      When reviewing architectural changes:
-      1. Run: wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted' (for ongoing work)
-      2. Or: wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only --base main' (for feature branches)
+      When reviewing architectural changes — invoke the platform-aware
+      command resolved by the runtime (see `quality-gate-config.yaml` →
+      `layer2.coderabbit`):
+      1. Ongoing work:
+         - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t uncommitted`
+         - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t uncommitted'`
+      2. Feature branches (against `main`):
+         - macOS/Linux: `~/.local/bin/coderabbit --prompt-only --base main`
+         - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only --base main'`
       3. Focus on issues that impact:
          - System scalability
          - Security posture
@@ -346,19 +352,23 @@ dependencies:
       7. Document decisions in architecture docs
 
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL. Runtime detects `process.platform`
+      and picks the right shape — do not hardcode either form.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run the binary directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
 
       **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify installation in WSL
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify the binary is installed
+        on the host (macOS/Linux: PATH or `~/.local/bin/coderabbit`;
+        Windows: install inside the WSL distribution).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
 
     architectural_patterns_to_check:
       - API consistency (REST conventions, error handling, pagination)

--- a/.aiox-core/development/agents/data-engineer.md
+++ b/.aiox-core/development/agents/data-engineer.md
@@ -315,8 +315,11 @@ coderabbit_integration:
       focus: SQL style, readability
 
   workflow: |
-    When reviewing database changes:
-    1. BEFORE migration: Run wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted' on migration files
+    When reviewing database changes — invoke the platform-aware command
+    resolved by the runtime (see `quality-gate-config.yaml` → `layer2.coderabbit`):
+    1. BEFORE migration, on migration files:
+       - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t uncommitted`
+       - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t uncommitted'`
     2. Focus review on:
        - Security: SQL injection, RLS bypass, data exposure
        - Performance: Missing indexes, inefficient queries
@@ -328,19 +331,23 @@ coderabbit_integration:
     6. Update database-best-practices.md with patterns found
 
   execution_guidelines: |
-    CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+    CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+    On Windows it is invoked through WSL. Runtime detects `process.platform`
+    and picks the right shape — do not hardcode either form.
 
     **How to Execute:**
-    1. Use 'wsl bash -c' wrapper for all commands
-    2. Navigate to project directory in WSL path format (/mnt/c/...)
-    3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+    - macOS/Linux: run the binary directly. Bash tool sets cwd to project root.
+    - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
 
     **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
     **Error Handling:**
-    - If "coderabbit: command not found" → verify installation in WSL
-    - If timeout → increase timeout, review is still processing
-    - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+    - If `coderabbit: command not found` → verify the binary is installed
+      on the host (macOS/Linux: PATH or `~/.local/bin/coderabbit`;
+      Windows: install inside the WSL distribution).
+    - If timeout → increase timeout, review is still processing.
+    - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+      or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
 
   database_patterns_to_check:
     security:

--- a/.aiox-core/development/agents/dev.md
+++ b/.aiox-core/development/agents/dev.md
@@ -298,11 +298,13 @@ dependencies:
 
   coderabbit_integration:
     enabled: true
-    installation_mode: wsl
-    wsl_config:
-      distribution: Ubuntu
-      installation_path: ~/.local/bin/coderabbit
-      working_directory: ${PROJECT_ROOT}
+    # Cross-platform CodeRabbit CLI (Issue #731).
+    # Runtime resolves the actual command from cli_path + host OS detection.
+    # See `.aiox-core/core/quality-gates/quality-gate-config.yaml` for canonical config.
+    cli_path: ~/.local/bin/coderabbit
+    platform_notes:
+      macos_linux: "Run cli_path directly from project root (no wrapper)."
+      windows: "Wrap with 'wsl bash -c' and rewrite project paths to /mnt/<drive>/..."
     usage:
       - Pre-commit quality check - run before marking story complete
       - Catch issues early - find bugs, security issues, code smells during development
@@ -331,7 +333,9 @@ dependencies:
       max_iterations = 2
 
       WHILE iteration < max_iterations:
-        1. Run: wsl bash -c 'cd /mnt/c/.../aiox-core && ~/.local/bin/coderabbit --prompt-only -t uncommitted'
+        1. Run the platform-aware command resolved by the runtime:
+           - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t uncommitted`
+           - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t uncommitted'`
         2. Parse output for CRITICAL issues
 
         IF no CRITICAL issues:
@@ -350,23 +354,33 @@ dependencies:
         - DO NOT mark story complete
 
     commands:
-      dev_pre_commit_uncommitted: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'"
+      # Templates — runtime selects the right shape for the host OS.
+      dev_pre_commit_uncommitted_native: "${CLI_PATH} --prompt-only -t uncommitted"
+      dev_pre_commit_uncommitted_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t uncommitted'"
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL via `wsl bash -c '...'`. The runtime
+      detects `process.platform` and picks the right shape — agents and tasks
+      should not hardcode either.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run `cli_path` directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
+      - Override platform detection with explicit `installation_mode: 'wsl' | 'native'`
+        in `quality-gate-config.yaml` only when host detection is wrong.
 
       **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
       **Self-Healing:** Max 2 iterations for CRITICAL issues only
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify wsl_config.installation_path
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify `cli_path` and that the
+        binary is installed (macOS/Linux: `brew install coderabbit-cli` or
+        manual install to `~/.local/bin`; Windows: install inside the WSL
+        distribution declared in your environment).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
     report_location: docs/qa/coderabbit-reports/
     integration_point: 'Part of story completion workflow in develop-story.md'
 

--- a/.aiox-core/development/agents/devops.md
+++ b/.aiox-core/development/agents/devops.md
@@ -347,11 +347,13 @@ dependencies:
 
   coderabbit_integration:
     enabled: true
-    installation_mode: wsl
-    wsl_config:
-      distribution: Ubuntu
-      installation_path: ~/.local/bin/coderabbit
-      working_directory: ${PROJECT_ROOT}
+    # Cross-platform CodeRabbit CLI (Issue #731).
+    # Runtime resolves the actual command from cli_path + host OS detection.
+    # See `.aiox-core/core/quality-gates/quality-gate-config.yaml` for canonical config.
+    cli_path: ~/.local/bin/coderabbit
+    platform_notes:
+      macos_linux: "Run cli_path directly from project root (no wrapper)."
+      windows: "Wrap with 'wsl bash -c' and rewrite project paths to /mnt/<drive>/..."
     usage:
       - Pre-PR quality gate - run before creating pull requests
       - Pre-push validation - verify code quality before push
@@ -363,23 +365,34 @@ dependencies:
       MEDIUM: Document in PR description, create follow-up issue
       LOW: Optional improvements, note in comments
     commands:
-      pre_push_uncommitted: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'"
-      pre_pr_against_main: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only --base ${DEFAULT_BRANCH:-main}'"
-      pre_commit_committed: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t committed'"
+      # Templates — runtime selects the right shape for the host OS.
+      pre_push_uncommitted_native: "${CLI_PATH} --prompt-only -t uncommitted"
+      pre_push_uncommitted_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t uncommitted'"
+      pre_pr_against_main_native: "${CLI_PATH} --prompt-only --base ${DEFAULT_BRANCH:-main}"
+      pre_pr_against_main_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only --base ${DEFAULT_BRANCH:-main}'"
+      pre_commit_committed_native: "${CLI_PATH} --prompt-only -t committed"
+      pre_commit_committed_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t committed'"
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL via `wsl bash -c '...'`. The runtime
+      detects `process.platform` and picks the right shape — agents and tasks
+      should not hardcode either.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run `cli_path` directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
+      - Override platform detection with explicit `installation_mode: 'wsl' | 'native'`
+        in `quality-gate-config.yaml` only when host detection is wrong.
 
       **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify wsl_config.installation_path
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify `cli_path` and that the
+        binary is installed (macOS/Linux: PATH or manual install to
+        `~/.local/bin`; Windows: install inside the WSL distribution).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
     report_location: docs/qa/coderabbit-reports/
     integration_point: 'Runs automatically in *pre-push and *create-pr workflows'
 

--- a/.aiox-core/development/agents/qa.md
+++ b/.aiox-core/development/agents/qa.md
@@ -238,11 +238,13 @@ dependencies:
 
   coderabbit_integration:
     enabled: true
-    installation_mode: wsl
-    wsl_config:
-      distribution: Ubuntu
-      installation_path: ~/.local/bin/coderabbit
-      working_directory: ${PROJECT_ROOT}
+    # Cross-platform CodeRabbit CLI (Issue #731).
+    # Runtime resolves the actual command from cli_path + host OS detection.
+    # See `.aiox-core/core/quality-gates/quality-gate-config.yaml` for canonical config.
+    cli_path: ~/.local/bin/coderabbit
+    platform_notes:
+      macos_linux: "Run cli_path directly from project root (no wrapper)."
+      windows: "Wrap with 'wsl bash -c' and rewrite project paths to /mnt/<drive>/..."
     usage:
       - Pre-review automated scanning before human QA analysis
       - Security vulnerability detection (SQL injection, XSS, hardcoded secrets)
@@ -272,7 +274,9 @@ dependencies:
       max_iterations = 3
 
       WHILE iteration < max_iterations:
-        1. Run: wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'
+        1. Run the platform-aware command resolved by the runtime:
+           - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}`
+           - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'`
         2. Parse output for all severity levels
 
         critical_issues = filter(output, severity == "CRITICAL")
@@ -298,24 +302,34 @@ dependencies:
         - HALT and require human intervention
 
     commands:
-      qa_pre_review_uncommitted: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'"
-      qa_story_review_committed: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'"
+      # Templates — runtime selects the right shape for the host OS.
+      qa_pre_review_uncommitted_native: "${CLI_PATH} --prompt-only -t uncommitted"
+      qa_pre_review_uncommitted_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t uncommitted'"
+      qa_story_review_committed_native: "${CLI_PATH} --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}"
+      qa_story_review_committed_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'"
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL via `wsl bash -c '...'`. The runtime
+      detects `process.platform` and picks the right shape — agents and tasks
+      should not hardcode either.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run `cli_path` directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
+      - Override platform detection with explicit `installation_mode: 'wsl' | 'native'`
+        in `quality-gate-config.yaml` only when host detection is wrong.
 
       **Timeout:** 30 minutes (1800000ms) - Full review may take longer
 
       **Self-Healing:** Max 3 advisory request iterations for CRITICAL and HIGH issues
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify wsl_config.installation_path
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify `cli_path` and that the
+        binary is installed (macOS/Linux: PATH or manual install to
+        `~/.local/bin`; Windows: install inside the WSL distribution).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
     report_location: docs/qa/coderabbit-reports/
     integration_point: 'Runs automatically in *review and *gate workflows'
 

--- a/.aiox-core/development/tasks/dev-develop-story.md
+++ b/.aiox-core/development/tasks/dev-develop-story.md
@@ -558,10 +558,13 @@ Execute **AFTER** all tasks are complete but **BEFORE** running the DOD checklis
 │                                                              │
 │  WHILE iteration < max_iterations:                           │
 │    ┌────────────────────────────────────────────────────┐   │
-│    │ 1. Run CodeRabbit CLI                              │   │
-│    │    wsl bash -c 'cd /mnt/c/.../aiox-core &&    │   │
-│    │    ~/.local/bin/coderabbit --prompt-only           │   │
-│    │    -t uncommitted'                                  │   │
+│    │ 1. Run CodeRabbit CLI (runtime picks the shape      │   │
+│    │    for process.platform — see Issue #731):          │   │
+│    │    macOS/Linux: ~/.local/bin/coderabbit             │   │
+│    │                 --prompt-only -t uncommitted        │   │
+│    │    Windows:     wsl bash -c 'cd /mnt/<drive>/...    │   │
+│    │                 ~/.local/bin/coderabbit             │   │
+│    │                 --prompt-only -t uncommitted'       │   │
 │    │                                                     │   │
 │    │ 2. Parse output for severity levels                │   │
 │    └────────────────────────────────────────────────────┘   │
@@ -664,7 +667,11 @@ try {
   await runCodeRabbitSelfHealing(storyPath);
 } catch (error) {
   if (error.message.includes('command not found')) {
-    console.warn('⚠️  CodeRabbit not installed in WSL');
+    console.warn(
+      process.platform === 'win32'
+        ? '⚠️  CodeRabbit not found in WSL — install inside the WSL distribution.'
+        : '⚠️  CodeRabbit not found on PATH — install ~/.local/bin/coderabbit.',
+    );
     console.warn('   Skipping self-healing. Manual review required.');
     return; // Continue without self-healing
   }

--- a/.aiox-core/development/tasks/environment-bootstrap.md
+++ b/.aiox-core/development/tasks/environment-bootstrap.md
@@ -521,10 +521,16 @@ cli_checks:
         macos: 'curl -fsSL https://coderabbit.ai/install.sh | bash'
         linux: 'curl -fsSL https://coderabbit.ai/install.sh | bash'
       note: |
-        WINDOWS USERS: CodeRabbit CLI runs in WSL, not native Windows.
-        - Requires WSL with Ubuntu/Debian distribution
-        - Binary located at ~/.local/bin/coderabbit (inside WSL)
-        - All coderabbit commands must use: wsl bash -c 'command'
+        Cross-platform CodeRabbit CLI (Issue #731):
+        - macOS/Linux: CodeRabbit runs natively. Binary at ~/.local/bin/coderabbit
+          or anywhere on PATH. Invoke directly — no wrapper needed.
+        - Windows: CodeRabbit runs through WSL (no native Windows binary today).
+          Requires WSL with Ubuntu/Debian; binary at ~/.local/bin/coderabbit
+          inside WSL; commands wrapped as `wsl bash -c '...'`.
+        - The aiox-core runtime auto-detects the host (`process.platform`) and
+          builds the right command shape. Override with `installation_mode:
+          'wsl' | 'native'` in `quality-gate-config.yaml` only if detection
+          is wrong.
         - See: docs/guides/coderabbit/README.md for full setup guide
       verification:
         windows: "wsl bash -c '~/.local/bin/coderabbit --version'"

--- a/.aiox-core/development/tasks/github-devops-pre-push-quality-gate.md
+++ b/.aiox-core/development/tasks/github-devops-pre-push-quality-gate.md
@@ -369,14 +369,21 @@ function runCodeRabbitReview(projectRoot) {
     // Build the command for the current platform (Issue #731).
     // - macOS/Linux: run cli_path directly from project root.
     // - Windows: wrap with `wsl bash -c` and rewrite the project path to /mnt/<drive>/...
-    const cliPath = '~/.local/bin/coderabbit';
+    // Expand leading "~" via os.homedir() defensively — execSync goes through a shell
+    // but spawn-style callers do not, so the resolved path is the safer default.
+    const os = require('os');
+    const path = require('path');
+    const rawCliPath = '~/.local/bin/coderabbit';
+    const cliPath = rawCliPath.startsWith('~')
+      ? path.join(os.homedir(), rawCliPath.slice(1))
+      : rawCliPath;
     const isWindows = process.platform === 'win32';
     const coderabbitCommand = isWindows
       ? (() => {
           const wslProjectPath = projectRoot
             .replace(/\\/g, '/')
             .replace(/^([A-Z]):/, (match, drive) => `/mnt/${drive.toLowerCase()}`);
-          return `wsl bash -c 'cd ${wslProjectPath} && ${cliPath} --prompt-only -t uncommitted'`;
+          return `wsl bash -c 'cd "${wslProjectPath}" && ${cliPath} --prompt-only -t uncommitted'`;
         })()
       : `${cliPath} --prompt-only -t uncommitted`;
 

--- a/.aiox-core/development/tasks/github-devops-pre-push-quality-gate.md
+++ b/.aiox-core/development/tasks/github-devops-pre-push-quality-gate.md
@@ -367,25 +367,28 @@ function runCodeRabbitReview(projectRoot) {
 
   try {
     // Build the command for the current platform (Issue #731).
-    // - macOS/Linux: run cli_path directly from project root.
-    // - Windows: wrap with `wsl bash -c` and rewrite the project path to /mnt/<drive>/...
-    // Expand leading "~" via os.homedir() defensively — execSync goes through a shell
-    // but spawn-style callers do not, so the resolved path is the safer default.
+    // - macOS/Linux: run cli_path directly. Expand `~` via os.homedir() so the
+    //   final command is shell-agnostic.
+    // - Windows: wrap with `wsl bash -c`, rewrite the project path to /mnt/<drive>/...
+    //   Keep `~` literal so the WSL distribution's bash expands it (host HOME
+    //   would point at C:\Users\... which WSL cannot resolve).
     const os = require('os');
     const path = require('path');
     const rawCliPath = '~/.local/bin/coderabbit';
-    const cliPath = rawCliPath.startsWith('~')
-      ? path.join(os.homedir(), rawCliPath.slice(1))
-      : rawCliPath;
     const isWindows = process.platform === 'win32';
     const coderabbitCommand = isWindows
       ? (() => {
           const wslProjectPath = projectRoot
             .replace(/\\/g, '/')
-            .replace(/^([A-Z]):/, (match, drive) => `/mnt/${drive.toLowerCase()}`);
-          return `wsl bash -c 'cd "${wslProjectPath}" && ${cliPath} --prompt-only -t uncommitted'`;
+            .replace(/^([A-Za-z]):/, (match, drive) => `/mnt/${drive.toLowerCase()}`);
+          return `wsl bash -c 'cd "${wslProjectPath}" && ${rawCliPath} --prompt-only -t uncommitted'`;
         })()
-      : `${cliPath} --prompt-only -t uncommitted`;
+      : (() => {
+          const cliPath = rawCliPath.startsWith('~')
+            ? path.join(os.homedir(), rawCliPath.slice(1))
+            : rawCliPath;
+          return `${cliPath} --prompt-only -t uncommitted`;
+        })();
 
     console.log(`Executing: ${coderabbitCommand}\n`);
 

--- a/.aiox-core/development/tasks/github-devops-pre-push-quality-gate.md
+++ b/.aiox-core/development/tasks/github-devops-pre-push-quality-gate.md
@@ -366,12 +366,19 @@ function runCodeRabbitReview(projectRoot) {
   console.log('⏱️  This may take 7-30 minutes. Please wait...\n');
 
   try {
-    // Construct WSL command with proper paths
-    const wslProjectPath = projectRoot
-      .replace(/\\/g, '/')
-      .replace(/^([A-Z]):/, (match, drive) => `/mnt/${drive.toLowerCase()}`);
-
-    const coderabbitCommand = `wsl bash -c 'cd ${wslProjectPath} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'`;
+    // Build the command for the current platform (Issue #731).
+    // - macOS/Linux: run cli_path directly from project root.
+    // - Windows: wrap with `wsl bash -c` and rewrite the project path to /mnt/<drive>/...
+    const cliPath = '~/.local/bin/coderabbit';
+    const isWindows = process.platform === 'win32';
+    const coderabbitCommand = isWindows
+      ? (() => {
+          const wslProjectPath = projectRoot
+            .replace(/\\/g, '/')
+            .replace(/^([A-Z]):/, (match, drive) => `/mnt/${drive.toLowerCase()}`);
+          return `wsl bash -c 'cd ${wslProjectPath} && ${cliPath} --prompt-only -t uncommitted'`;
+        })()
+      : `${cliPath} --prompt-only -t uncommitted`;
 
     console.log(`Executing: ${coderabbitCommand}\n`);
 
@@ -408,15 +415,23 @@ function runCodeRabbitReview(projectRoot) {
     // Handle authentication errors
     if (error.stderr && error.stderr.includes('not authenticated')) {
       console.error('❌ CodeRabbit not authenticated');
-      console.error('   Run: wsl bash -c "~/.local/bin/coderabbit auth status"');
+      console.error(
+        process.platform === 'win32'
+          ? '   Run: wsl bash -c "~/.local/bin/coderabbit auth status"'
+          : '   Run: ~/.local/bin/coderabbit auth status',
+      );
       return { gateImpact: 'FAIL', error: 'Not authenticated' };
     }
 
     // Handle command not found
     if (error.stderr && error.stderr.includes('command not found')) {
-      console.error('❌ CodeRabbit CLI not found in WSL');
+      console.error('❌ CodeRabbit CLI not found');
       console.error('   Expected location: ~/.local/bin/coderabbit');
-      console.error('   Verify: wsl bash -c "~/.local/bin/coderabbit --version"');
+      console.error(
+        process.platform === 'win32'
+          ? '   Verify: wsl bash -c "~/.local/bin/coderabbit --version"'
+          : '   Verify: ~/.local/bin/coderabbit --version',
+      );
       return { gateImpact: 'FAIL', error: 'Not installed' };
     }
 

--- a/.aiox-core/development/tasks/qa-review-story.md
+++ b/.aiox-core/development/tasks/qa-review-story.md
@@ -251,10 +251,13 @@ Execute CodeRabbit self-healing **FIRST** before manual review:
 │                                                                   │
 │  WHILE iteration < max_iterations:                                │
 │    ┌─────────────────────────────────────────────────────────┐   │
-│    │ 1. Run CodeRabbit CLI                                   │   │
-│    │    wsl bash -c 'cd /mnt/c/.../aiox-core &&         │   │
-│    │    ~/.local/bin/coderabbit --prompt-only                │   │
-│    │    -t committed --base main'                            │   │
+│    │ 1. Run CodeRabbit CLI (runtime picks the shape for      │   │
+│    │    process.platform — see Issue #731):                  │   │
+│    │    macOS/Linux: ~/.local/bin/coderabbit --prompt-only   │   │
+│    │                 -t committed --base main                │   │
+│    │    Windows:     wsl bash -c 'cd /mnt/<drive>/<path> &&  │   │
+│    │                 ~/.local/bin/coderabbit --prompt-only   │   │
+│    │                 -t committed --base main'               │   │
 │    │                                                          │   │
 │    │ 2. Parse output for all severity levels                 │   │
 │    └─────────────────────────────────────────────────────────┘   │

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.2.7
-generated_at: "2026-05-18T04:56:53.126Z"
+generated_at: "2026-05-18T05:08:22.848Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1128
 files:
@@ -989,9 +989,9 @@ files:
     type: core
     size: 31469
   - path: core/orchestration/workflow-executor.js
-    hash: sha256:b09934e53f7aba651d18a963b6dc09f8511c02db7eaf8ce6c16c4d2b8e7824a9
+    hash: sha256:d1e1fab010e0bda1d1c472e527323a3b1a136ad58717aec55a32a087a5e1fe31
     type: core
-    size: 36797
+    size: 37279
   - path: core/orchestration/workflow-orchestrator.js
     hash: sha256:82816bd5e6fecc9bbb77292444e53254c72bf93e5c04260784743354c6a58627
     type: core
@@ -1037,9 +1037,9 @@ files:
     type: core
     size: 9393
   - path: core/quality-gates/layer2-pr-automation.js
-    hash: sha256:c41825460c79011f7da5c4be796930c5a94b7b24f4ce735699552a30761cf48d
+    hash: sha256:9aea4203a59a9a5e753b997dfcdb5826ad0b784fab84a5474bb6a68eca8958f0
     type: core
-    size: 9861
+    size: 10536
   - path: core/quality-gates/layer3-human-review.js
     hash: sha256:9bf79d5adfddae55d7dddfda777cd2775aa76f82204ddd0f660f6edbd093b16b
     type: core
@@ -2201,9 +2201,9 @@ files:
     type: task
     size: 19476
   - path: development/tasks/github-devops-pre-push-quality-gate.md
-    hash: sha256:99d9dc2ca637866e7ed80897a8b9c57b216b6f1851ee8a1f5865637a4ff8f56e
+    hash: sha256:bf52fb1ec4f6bcb3e04444828dc32b9b76709f3dd3313559de2287a372272d4d
     type: task
-    size: 24451
+    size: 24811
   - path: development/tasks/github-devops-repository-cleanup.md
     hash: sha256:34135e86820be5218daf7031f4daa115d6ef9a727c7c0cb3a6f28c59f8e694c1
     type: task

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.2.7
-generated_at: "2026-05-18T04:18:43.763Z"
+generated_at: "2026-05-18T04:51:57.421Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1128
 files:
@@ -989,9 +989,9 @@ files:
     type: core
     size: 31469
   - path: core/orchestration/workflow-executor.js
-    hash: sha256:49372791e5729fd7987c80efe1400168e8d59eac000a009b88d9fde6735cf4db
+    hash: sha256:b09934e53f7aba651d18a963b6dc09f8511c02db7eaf8ce6c16c4d2b8e7824a9
     type: core
-    size: 36350
+    size: 36797
   - path: core/orchestration/workflow-orchestrator.js
     hash: sha256:82816bd5e6fecc9bbb77292444e53254c72bf93e5c04260784743354c6a58627
     type: core
@@ -1037,9 +1037,9 @@ files:
     type: core
     size: 9393
   - path: core/quality-gates/layer2-pr-automation.js
-    hash: sha256:af31e7ac60b74b52ee983d0fcff7457042eea553b6127538cab41eb94eaee8e0
+    hash: sha256:c41825460c79011f7da5c4be796930c5a94b7b24f4ce735699552a30761cf48d
     type: core
-    size: 9176
+    size: 9861
   - path: core/quality-gates/layer3-human-review.js
     hash: sha256:9bf79d5adfddae55d7dddfda777cd2775aa76f82204ddd0f660f6edbd093b16b
     type: core
@@ -1049,9 +1049,9 @@ files:
     type: core
     size: 16371
   - path: core/quality-gates/quality-gate-config.yaml
-    hash: sha256:ee4027d14d3aa556d70d56f4548926d02033f0b596a2111d91a976c2f012c134
+    hash: sha256:979b60cbf77d0478f8a894a3190299d74c2aa0924bbefe964d2aa402adc3eb33
     type: core
-    size: 1972
+    size: 2545
   - path: core/quality-gates/quality-gate-manager.js
     hash: sha256:b0d5ce2653218eae63121e892d886c3234a87bf98536369c75b537163e07fb26
     type: core
@@ -1409,33 +1409,33 @@ files:
     type: agent
     size: 1254
   - path: development/agents/architect.md
-    hash: sha256:1b89e95048df940056570ecb6589f18a9a6114b96ca1b9fde130fb7bdb2ded8f
+    hash: sha256:c45b1e71af39b5da34a832dcc3d1c9b41b6270de61f79d4bada3c27b46be19df
     type: agent
-    size: 20565
+    size: 21210
   - path: development/agents/architect/MEMORY.md
     hash: sha256:ee99a68876311e0dc67e0b77ff11f8fa2154f0803f27f4aa89db36df50753d3b
     type: agent
     size: 1385
   - path: development/agents/data-engineer.md
-    hash: sha256:41c791fbdf43f700f2e78418c8af18197d1135741bc7845d03013f726b125f6f
+    hash: sha256:4b921018c23721c6f71a5d23b6495d254f260cd85406db5915f034a90d17c845
     type: agent
-    size: 21922
+    size: 22440
   - path: development/agents/data-engineer/MEMORY.md
     hash: sha256:20024028651bf2078bf4e58e38aaa84191521ef9b5c11b044eb152a026ec8412
     type: agent
     size: 1106
   - path: development/agents/dev.md
-    hash: sha256:eaaec824273f02b9ccbe6768d9e9147a5ad0d7faa9483b9730b1f02a71ef2769
+    hash: sha256:91a63332b1cc19af47b3cd2811b5e00635b72a747b5858efc09ce3aa7826d1b7
     type: agent
-    size: 24483
+    size: 25645
   - path: development/agents/dev/MEMORY.md
     hash: sha256:7c6197418798fa00617f63f93ea6e87dbbbc1bebdb1fb92276433cb7990fd7c0
     type: agent
     size: 2486
   - path: development/agents/devops.md
-    hash: sha256:5c52cc74f923ac381fa92fb969607b80a35f34b958c02d2d1edd1115f7690d35
+    hash: sha256:fb4555b484be4b93e11ed1e974b3e904ba7cddecb01ce44ac26828c7e8a8e382
     type: agent
-    size: 26814
+    size: 27902
   - path: development/agents/devops/MEMORY.md
     hash: sha256:eb2ee887047c94db3441126cd0198cac44cec779026d7842a3a1c7eba936027f
     type: agent
@@ -1457,9 +1457,9 @@ files:
     type: agent
     size: 1376
   - path: development/agents/qa.md
-    hash: sha256:cf4a8f473067a9d2909072215bce7b13917c779442e6f858681bd8b9f0b0c3c0
+    hash: sha256:506a44a6828ce6e0bc2fc89aaaced9df54fefea293525e5c1ce2e3bc37661c90
     type: agent
-    size: 18776
+    size: 20013
   - path: development/agents/qa/MEMORY.md
     hash: sha256:eec482f057d09635940e9a46bdd6cbb677af12dc4deed64bf71196d551b93abf
     type: agent
@@ -2085,9 +2085,9 @@ files:
     type: task
     size: 11021
   - path: development/tasks/dev-develop-story.md
-    hash: sha256:be8924aa0de759ca92a177b0ea12a5b076a3095ee2a9f530b74b3de19e996954
+    hash: sha256:bc48d7f8211a25b500a65632de011a178203c53c1e1f6b2ed4f58fd7431a04f6
     type: task
-    size: 29737
+    size: 30141
   - path: development/tasks/dev-improve-code-quality.md
     hash: sha256:6cf78aed6cca48bf13cc1f677f2cde86aea591785f428f9f56733de478107e2f
     type: task
@@ -2145,9 +2145,9 @@ files:
     type: task
     size: 18041
   - path: development/tasks/environment-bootstrap.md
-    hash: sha256:02ed701bea38ee11ad7e83a310ad55b3d84f36f37a344fda6b252fe3230d50cb
+    hash: sha256:fb177443e6b7ae7246ba52873c3a06c938f411179af8a7446909775446c5fd6c
     type: task
-    size: 45596
+    size: 46016
   - path: development/tasks/execute-checklist.md
     hash: sha256:9bd751605efd593e0708bac6e3f1c66a91ba5f33a5069c655b6d16cf6621859c
     type: task
@@ -2201,9 +2201,9 @@ files:
     type: task
     size: 19476
   - path: development/tasks/github-devops-pre-push-quality-gate.md
-    hash: sha256:3709049cefce2dc03f54a16830114e67fa6b4cf37f0f999638d5d1521f0979d8
+    hash: sha256:99d9dc2ca637866e7ed80897a8b9c57b216b6f1851ee8a1f5865637a4ff8f56e
     type: task
-    size: 23843
+    size: 24451
   - path: development/tasks/github-devops-repository-cleanup.md
     hash: sha256:34135e86820be5218daf7031f4daa115d6ef9a727c7c0cb3a6f28c59f8e694c1
     type: task
@@ -2433,9 +2433,9 @@ files:
     type: task
     size: 35266
   - path: development/tasks/qa-review-story.md
-    hash: sha256:cc3e189824c656ff6ed2db04bd0a2a03d6293bccbec7e9b7a321daf64b9f1563
+    hash: sha256:dc9b998aa64c4dd950bb0e8cbce29bba10c7b72b128f13fe8294e70eb608e7d9
     type: task
-    size: 24668
+    size: 24906
   - path: development/tasks/qa-risk-profile.md
     hash: sha256:69b2b6edb38330234766bef8ed3c27469843e88fb30e130837922541c717432d
     type: task

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.2.7
-generated_at: "2026-05-18T05:08:22.848Z"
+generated_at: "2026-05-18T05:18:15.595Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1128
 files:
@@ -989,9 +989,9 @@ files:
     type: core
     size: 31469
   - path: core/orchestration/workflow-executor.js
-    hash: sha256:d1e1fab010e0bda1d1c472e527323a3b1a136ad58717aec55a32a087a5e1fe31
+    hash: sha256:ddc880683df489ec7203ab7ecd8e066a08e2f72b011fe0dfe578d31155eb513b
     type: core
-    size: 37279
+    size: 37348
   - path: core/orchestration/workflow-orchestrator.js
     hash: sha256:82816bd5e6fecc9bbb77292444e53254c72bf93e5c04260784743354c6a58627
     type: core
@@ -1037,9 +1037,9 @@ files:
     type: core
     size: 9393
   - path: core/quality-gates/layer2-pr-automation.js
-    hash: sha256:9aea4203a59a9a5e753b997dfcdb5826ad0b784fab84a5474bb6a68eca8958f0
+    hash: sha256:53e1f05e3ece4731848ad818f13a97ce18f553327b6f2e385e4d299492cc890a
     type: core
-    size: 10536
+    size: 10923
   - path: core/quality-gates/layer3-human-review.js
     hash: sha256:9bf79d5adfddae55d7dddfda777cd2775aa76f82204ddd0f660f6edbd093b16b
     type: core
@@ -1297,7 +1297,7 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:8c6bfc8f41c9966d9bb6f1cc60caffc1e3b0371160320abcdc97b9ce4ca48f79
+    hash: sha256:2ca53dbaae4d0c749bcbd762c6ced7864ec54399bebb34dd63dfcb8aa3082b6d
     type: data
     size: 568920
   - path: data/learned-patterns.yaml
@@ -2201,9 +2201,9 @@ files:
     type: task
     size: 19476
   - path: development/tasks/github-devops-pre-push-quality-gate.md
-    hash: sha256:bf52fb1ec4f6bcb3e04444828dc32b9b76709f3dd3313559de2287a372272d4d
+    hash: sha256:529b4366c0e4b4b3568d95ae02ddf28974a5f34faf1d7b23d99caddbfa3e2db7
     type: task
-    size: 24811
+    size: 24903
   - path: development/tasks/github-devops-repository-cleanup.md
     hash: sha256:34135e86820be5218daf7031f4daa115d6ef9a727c7c0cb3a6f28c59f8e694c1
     type: task

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.2.7
-generated_at: "2026-05-18T04:51:57.421Z"
+generated_at: "2026-05-18T04:56:53.126Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1128
 files:
@@ -1297,9 +1297,9 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:f24c73354afaf968a0430a2bca6d7e1f46b863eb2edc08eef9393e556f581323
+    hash: sha256:8c6bfc8f41c9966d9bb6f1cc60caffc1e3b0371160320abcdc97b9ce4ca48f79
     type: data
-    size: 575594
+    size: 568920
   - path: data/learned-patterns.yaml
     hash: sha256:24ac0b160615583a0ff783d3da8af80b7f94191575d6db2054ec8e10a3f945dc
     type: data

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.2.7
-generated_at: "2026-05-18T05:18:15.595Z"
+generated_at: "2026-05-18T05:21:39.241Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1128
 files:
@@ -1297,7 +1297,7 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:2ca53dbaae4d0c749bcbd762c6ced7864ec54399bebb34dd63dfcb8aa3082b6d
+    hash: sha256:652a95a8ce21ddabe59e5ae42d007cfacbacc6fdecf550c6b21bee9ec0449523
     type: data
     size: 568920
   - path: data/learned-patterns.yaml

--- a/.claude/skills/AIOX/agents/architect/SKILL.md
+++ b/.claude/skills/AIOX/agents/architect/SKILL.md
@@ -341,9 +341,15 @@ dependencies:
         focus: Style consistency, minor optimizations
 
     workflow: |
-      When reviewing architectural changes:
-      1. Run: wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted' (for ongoing work)
-      2. Or: wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only --base main' (for feature branches)
+      When reviewing architectural changes — invoke the platform-aware
+      command resolved by the runtime (see `quality-gate-config.yaml` →
+      `layer2.coderabbit`):
+      1. Ongoing work:
+         - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t uncommitted`
+         - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t uncommitted'`
+      2. Feature branches (against `main`):
+         - macOS/Linux: `~/.local/bin/coderabbit --prompt-only --base main`
+         - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only --base main'`
       3. Focus on issues that impact:
          - System scalability
          - Security posture
@@ -356,19 +362,23 @@ dependencies:
       7. Document decisions in architecture docs
 
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL. Runtime detects `process.platform`
+      and picks the right shape — do not hardcode either form.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run the binary directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
 
       **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify installation in WSL
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify the binary is installed
+        on the host (macOS/Linux: PATH or `~/.local/bin/coderabbit`;
+        Windows: install inside the WSL distribution).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
 
     architectural_patterns_to_check:
       - API consistency (REST conventions, error handling, pagination)

--- a/.claude/skills/AIOX/agents/data-engineer/SKILL.md
+++ b/.claude/skills/AIOX/agents/data-engineer/SKILL.md
@@ -325,8 +325,11 @@ coderabbit_integration:
       focus: SQL style, readability
 
   workflow: |
-    When reviewing database changes:
-    1. BEFORE migration: Run wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted' on migration files
+    When reviewing database changes — invoke the platform-aware command
+    resolved by the runtime (see `quality-gate-config.yaml` → `layer2.coderabbit`):
+    1. BEFORE migration, on migration files:
+       - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t uncommitted`
+       - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t uncommitted'`
     2. Focus review on:
        - Security: SQL injection, RLS bypass, data exposure
        - Performance: Missing indexes, inefficient queries
@@ -338,19 +341,23 @@ coderabbit_integration:
     6. Update database-best-practices.md with patterns found
 
   execution_guidelines: |
-    CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+    CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+    On Windows it is invoked through WSL. Runtime detects `process.platform`
+    and picks the right shape — do not hardcode either form.
 
     **How to Execute:**
-    1. Use 'wsl bash -c' wrapper for all commands
-    2. Navigate to project directory in WSL path format (/mnt/c/...)
-    3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+    - macOS/Linux: run the binary directly. Bash tool sets cwd to project root.
+    - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
 
     **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
     **Error Handling:**
-    - If "coderabbit: command not found" → verify installation in WSL
-    - If timeout → increase timeout, review is still processing
-    - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+    - If `coderabbit: command not found` → verify the binary is installed
+      on the host (macOS/Linux: PATH or `~/.local/bin/coderabbit`;
+      Windows: install inside the WSL distribution).
+    - If timeout → increase timeout, review is still processing.
+    - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+      or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
 
   database_patterns_to_check:
     security:

--- a/.claude/skills/AIOX/agents/dev/SKILL.md
+++ b/.claude/skills/AIOX/agents/dev/SKILL.md
@@ -308,11 +308,13 @@ dependencies:
 
   coderabbit_integration:
     enabled: true
-    installation_mode: wsl
-    wsl_config:
-      distribution: Ubuntu
-      installation_path: ~/.local/bin/coderabbit
-      working_directory: ${PROJECT_ROOT}
+    # Cross-platform CodeRabbit CLI (Issue #731).
+    # Runtime resolves the actual command from cli_path + host OS detection.
+    # See `.aiox-core/core/quality-gates/quality-gate-config.yaml` for canonical config.
+    cli_path: ~/.local/bin/coderabbit
+    platform_notes:
+      macos_linux: "Run cli_path directly from project root (no wrapper)."
+      windows: "Wrap with 'wsl bash -c' and rewrite project paths to /mnt/<drive>/..."
     usage:
       - Pre-commit quality check - run before marking story complete
       - Catch issues early - find bugs, security issues, code smells during development
@@ -341,7 +343,9 @@ dependencies:
       max_iterations = 2
 
       WHILE iteration < max_iterations:
-        1. Run: wsl bash -c 'cd /mnt/c/.../aiox-core && ~/.local/bin/coderabbit --prompt-only -t uncommitted'
+        1. Run the platform-aware command resolved by the runtime:
+           - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t uncommitted`
+           - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t uncommitted'`
         2. Parse output for CRITICAL issues
 
         IF no CRITICAL issues:
@@ -360,23 +364,33 @@ dependencies:
         - DO NOT mark story complete
 
     commands:
-      dev_pre_commit_uncommitted: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'"
+      # Templates — runtime selects the right shape for the host OS.
+      dev_pre_commit_uncommitted_native: "${CLI_PATH} --prompt-only -t uncommitted"
+      dev_pre_commit_uncommitted_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t uncommitted'"
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL via `wsl bash -c '...'`. The runtime
+      detects `process.platform` and picks the right shape — agents and tasks
+      should not hardcode either.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run `cli_path` directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
+      - Override platform detection with explicit `installation_mode: 'wsl' | 'native'`
+        in `quality-gate-config.yaml` only when host detection is wrong.
 
       **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
       **Self-Healing:** Max 2 iterations for CRITICAL issues only
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify wsl_config.installation_path
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify `cli_path` and that the
+        binary is installed (macOS/Linux: `brew install coderabbit-cli` or
+        manual install to `~/.local/bin`; Windows: install inside the WSL
+        distribution declared in your environment).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
     report_location: docs/qa/coderabbit-reports/
     integration_point: 'Part of story completion workflow in develop-story.md'
 

--- a/.claude/skills/AIOX/agents/devops/SKILL.md
+++ b/.claude/skills/AIOX/agents/devops/SKILL.md
@@ -357,11 +357,13 @@ dependencies:
 
   coderabbit_integration:
     enabled: true
-    installation_mode: wsl
-    wsl_config:
-      distribution: Ubuntu
-      installation_path: ~/.local/bin/coderabbit
-      working_directory: ${PROJECT_ROOT}
+    # Cross-platform CodeRabbit CLI (Issue #731).
+    # Runtime resolves the actual command from cli_path + host OS detection.
+    # See `.aiox-core/core/quality-gates/quality-gate-config.yaml` for canonical config.
+    cli_path: ~/.local/bin/coderabbit
+    platform_notes:
+      macos_linux: "Run cli_path directly from project root (no wrapper)."
+      windows: "Wrap with 'wsl bash -c' and rewrite project paths to /mnt/<drive>/..."
     usage:
       - Pre-PR quality gate - run before creating pull requests
       - Pre-push validation - verify code quality before push
@@ -373,23 +375,34 @@ dependencies:
       MEDIUM: Document in PR description, create follow-up issue
       LOW: Optional improvements, note in comments
     commands:
-      pre_push_uncommitted: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'"
-      pre_pr_against_main: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only --base ${DEFAULT_BRANCH:-main}'"
-      pre_commit_committed: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t committed'"
+      # Templates — runtime selects the right shape for the host OS.
+      pre_push_uncommitted_native: "${CLI_PATH} --prompt-only -t uncommitted"
+      pre_push_uncommitted_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t uncommitted'"
+      pre_pr_against_main_native: "${CLI_PATH} --prompt-only --base ${DEFAULT_BRANCH:-main}"
+      pre_pr_against_main_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only --base ${DEFAULT_BRANCH:-main}'"
+      pre_commit_committed_native: "${CLI_PATH} --prompt-only -t committed"
+      pre_commit_committed_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t committed'"
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL via `wsl bash -c '...'`. The runtime
+      detects `process.platform` and picks the right shape — agents and tasks
+      should not hardcode either.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run `cli_path` directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
+      - Override platform detection with explicit `installation_mode: 'wsl' | 'native'`
+        in `quality-gate-config.yaml` only when host detection is wrong.
 
       **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify wsl_config.installation_path
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify `cli_path` and that the
+        binary is installed (macOS/Linux: PATH or manual install to
+        `~/.local/bin`; Windows: install inside the WSL distribution).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
     report_location: docs/qa/coderabbit-reports/
     integration_point: 'Runs automatically in *pre-push and *create-pr workflows'
 

--- a/.claude/skills/AIOX/agents/qa/SKILL.md
+++ b/.claude/skills/AIOX/agents/qa/SKILL.md
@@ -248,11 +248,13 @@ dependencies:
 
   coderabbit_integration:
     enabled: true
-    installation_mode: wsl
-    wsl_config:
-      distribution: Ubuntu
-      installation_path: ~/.local/bin/coderabbit
-      working_directory: ${PROJECT_ROOT}
+    # Cross-platform CodeRabbit CLI (Issue #731).
+    # Runtime resolves the actual command from cli_path + host OS detection.
+    # See `.aiox-core/core/quality-gates/quality-gate-config.yaml` for canonical config.
+    cli_path: ~/.local/bin/coderabbit
+    platform_notes:
+      macos_linux: "Run cli_path directly from project root (no wrapper)."
+      windows: "Wrap with 'wsl bash -c' and rewrite project paths to /mnt/<drive>/..."
     usage:
       - Pre-review automated scanning before human QA analysis
       - Security vulnerability detection (SQL injection, XSS, hardcoded secrets)
@@ -282,7 +284,9 @@ dependencies:
       max_iterations = 3
 
       WHILE iteration < max_iterations:
-        1. Run: wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'
+        1. Run the platform-aware command resolved by the runtime:
+           - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}`
+           - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'`
         2. Parse output for all severity levels
 
         critical_issues = filter(output, severity == "CRITICAL")
@@ -308,24 +312,34 @@ dependencies:
         - HALT and require human intervention
 
     commands:
-      qa_pre_review_uncommitted: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'"
-      qa_story_review_committed: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'"
+      # Templates — runtime selects the right shape for the host OS.
+      qa_pre_review_uncommitted_native: "${CLI_PATH} --prompt-only -t uncommitted"
+      qa_pre_review_uncommitted_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t uncommitted'"
+      qa_story_review_committed_native: "${CLI_PATH} --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}"
+      qa_story_review_committed_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'"
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL via `wsl bash -c '...'`. The runtime
+      detects `process.platform` and picks the right shape — agents and tasks
+      should not hardcode either.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run `cli_path` directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
+      - Override platform detection with explicit `installation_mode: 'wsl' | 'native'`
+        in `quality-gate-config.yaml` only when host detection is wrong.
 
       **Timeout:** 30 minutes (1800000ms) - Full review may take longer
 
       **Self-Healing:** Max 3 advisory request iterations for CRITICAL and HIGH issues
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify wsl_config.installation_path
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify `cli_path` and that the
+        binary is installed (macOS/Linux: PATH or manual install to
+        `~/.local/bin`; Windows: install inside the WSL distribution).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
     report_location: docs/qa/coderabbit-reports/
     integration_point: 'Runs automatically in *review and *gate workflows'
 

--- a/.codex/agents/architect.md
+++ b/.codex/agents/architect.md
@@ -331,9 +331,15 @@ dependencies:
         focus: Style consistency, minor optimizations
 
     workflow: |
-      When reviewing architectural changes:
-      1. Run: wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted' (for ongoing work)
-      2. Or: wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only --base main' (for feature branches)
+      When reviewing architectural changes — invoke the platform-aware
+      command resolved by the runtime (see `quality-gate-config.yaml` →
+      `layer2.coderabbit`):
+      1. Ongoing work:
+         - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t uncommitted`
+         - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t uncommitted'`
+      2. Feature branches (against `main`):
+         - macOS/Linux: `~/.local/bin/coderabbit --prompt-only --base main`
+         - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only --base main'`
       3. Focus on issues that impact:
          - System scalability
          - Security posture
@@ -346,19 +352,23 @@ dependencies:
       7. Document decisions in architecture docs
 
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL. Runtime detects `process.platform`
+      and picks the right shape — do not hardcode either form.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run the binary directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
 
       **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify installation in WSL
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify the binary is installed
+        on the host (macOS/Linux: PATH or `~/.local/bin/coderabbit`;
+        Windows: install inside the WSL distribution).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
 
     architectural_patterns_to_check:
       - API consistency (REST conventions, error handling, pagination)

--- a/.codex/agents/data-engineer.md
+++ b/.codex/agents/data-engineer.md
@@ -315,8 +315,11 @@ coderabbit_integration:
       focus: SQL style, readability
 
   workflow: |
-    When reviewing database changes:
-    1. BEFORE migration: Run wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted' on migration files
+    When reviewing database changes — invoke the platform-aware command
+    resolved by the runtime (see `quality-gate-config.yaml` → `layer2.coderabbit`):
+    1. BEFORE migration, on migration files:
+       - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t uncommitted`
+       - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t uncommitted'`
     2. Focus review on:
        - Security: SQL injection, RLS bypass, data exposure
        - Performance: Missing indexes, inefficient queries
@@ -328,19 +331,23 @@ coderabbit_integration:
     6. Update database-best-practices.md with patterns found
 
   execution_guidelines: |
-    CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+    CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+    On Windows it is invoked through WSL. Runtime detects `process.platform`
+    and picks the right shape — do not hardcode either form.
 
     **How to Execute:**
-    1. Use 'wsl bash -c' wrapper for all commands
-    2. Navigate to project directory in WSL path format (/mnt/c/...)
-    3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+    - macOS/Linux: run the binary directly. Bash tool sets cwd to project root.
+    - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
 
     **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
     **Error Handling:**
-    - If "coderabbit: command not found" → verify installation in WSL
-    - If timeout → increase timeout, review is still processing
-    - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+    - If `coderabbit: command not found` → verify the binary is installed
+      on the host (macOS/Linux: PATH or `~/.local/bin/coderabbit`;
+      Windows: install inside the WSL distribution).
+    - If timeout → increase timeout, review is still processing.
+    - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+      or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
 
   database_patterns_to_check:
     security:

--- a/.codex/agents/dev.md
+++ b/.codex/agents/dev.md
@@ -298,11 +298,13 @@ dependencies:
 
   coderabbit_integration:
     enabled: true
-    installation_mode: wsl
-    wsl_config:
-      distribution: Ubuntu
-      installation_path: ~/.local/bin/coderabbit
-      working_directory: ${PROJECT_ROOT}
+    # Cross-platform CodeRabbit CLI (Issue #731).
+    # Runtime resolves the actual command from cli_path + host OS detection.
+    # See `.aiox-core/core/quality-gates/quality-gate-config.yaml` for canonical config.
+    cli_path: ~/.local/bin/coderabbit
+    platform_notes:
+      macos_linux: "Run cli_path directly from project root (no wrapper)."
+      windows: "Wrap with 'wsl bash -c' and rewrite project paths to /mnt/<drive>/..."
     usage:
       - Pre-commit quality check - run before marking story complete
       - Catch issues early - find bugs, security issues, code smells during development
@@ -331,7 +333,9 @@ dependencies:
       max_iterations = 2
 
       WHILE iteration < max_iterations:
-        1. Run: wsl bash -c 'cd /mnt/c/.../aiox-core && ~/.local/bin/coderabbit --prompt-only -t uncommitted'
+        1. Run the platform-aware command resolved by the runtime:
+           - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t uncommitted`
+           - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t uncommitted'`
         2. Parse output for CRITICAL issues
 
         IF no CRITICAL issues:
@@ -350,23 +354,33 @@ dependencies:
         - DO NOT mark story complete
 
     commands:
-      dev_pre_commit_uncommitted: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'"
+      # Templates — runtime selects the right shape for the host OS.
+      dev_pre_commit_uncommitted_native: "${CLI_PATH} --prompt-only -t uncommitted"
+      dev_pre_commit_uncommitted_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t uncommitted'"
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL via `wsl bash -c '...'`. The runtime
+      detects `process.platform` and picks the right shape — agents and tasks
+      should not hardcode either.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run `cli_path` directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
+      - Override platform detection with explicit `installation_mode: 'wsl' | 'native'`
+        in `quality-gate-config.yaml` only when host detection is wrong.
 
       **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
       **Self-Healing:** Max 2 iterations for CRITICAL issues only
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify wsl_config.installation_path
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify `cli_path` and that the
+        binary is installed (macOS/Linux: `brew install coderabbit-cli` or
+        manual install to `~/.local/bin`; Windows: install inside the WSL
+        distribution declared in your environment).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
     report_location: docs/qa/coderabbit-reports/
     integration_point: 'Part of story completion workflow in develop-story.md'
 

--- a/.codex/agents/devops.md
+++ b/.codex/agents/devops.md
@@ -347,11 +347,13 @@ dependencies:
 
   coderabbit_integration:
     enabled: true
-    installation_mode: wsl
-    wsl_config:
-      distribution: Ubuntu
-      installation_path: ~/.local/bin/coderabbit
-      working_directory: ${PROJECT_ROOT}
+    # Cross-platform CodeRabbit CLI (Issue #731).
+    # Runtime resolves the actual command from cli_path + host OS detection.
+    # See `.aiox-core/core/quality-gates/quality-gate-config.yaml` for canonical config.
+    cli_path: ~/.local/bin/coderabbit
+    platform_notes:
+      macos_linux: "Run cli_path directly from project root (no wrapper)."
+      windows: "Wrap with 'wsl bash -c' and rewrite project paths to /mnt/<drive>/..."
     usage:
       - Pre-PR quality gate - run before creating pull requests
       - Pre-push validation - verify code quality before push
@@ -363,23 +365,34 @@ dependencies:
       MEDIUM: Document in PR description, create follow-up issue
       LOW: Optional improvements, note in comments
     commands:
-      pre_push_uncommitted: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'"
-      pre_pr_against_main: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only --base ${DEFAULT_BRANCH:-main}'"
-      pre_commit_committed: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t committed'"
+      # Templates — runtime selects the right shape for the host OS.
+      pre_push_uncommitted_native: "${CLI_PATH} --prompt-only -t uncommitted"
+      pre_push_uncommitted_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t uncommitted'"
+      pre_pr_against_main_native: "${CLI_PATH} --prompt-only --base ${DEFAULT_BRANCH:-main}"
+      pre_pr_against_main_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only --base ${DEFAULT_BRANCH:-main}'"
+      pre_commit_committed_native: "${CLI_PATH} --prompt-only -t committed"
+      pre_commit_committed_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t committed'"
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL via `wsl bash -c '...'`. The runtime
+      detects `process.platform` and picks the right shape — agents and tasks
+      should not hardcode either.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run `cli_path` directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
+      - Override platform detection with explicit `installation_mode: 'wsl' | 'native'`
+        in `quality-gate-config.yaml` only when host detection is wrong.
 
       **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify wsl_config.installation_path
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify `cli_path` and that the
+        binary is installed (macOS/Linux: PATH or manual install to
+        `~/.local/bin`; Windows: install inside the WSL distribution).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
     report_location: docs/qa/coderabbit-reports/
     integration_point: 'Runs automatically in *pre-push and *create-pr workflows'
 

--- a/.codex/agents/qa.md
+++ b/.codex/agents/qa.md
@@ -238,11 +238,13 @@ dependencies:
 
   coderabbit_integration:
     enabled: true
-    installation_mode: wsl
-    wsl_config:
-      distribution: Ubuntu
-      installation_path: ~/.local/bin/coderabbit
-      working_directory: ${PROJECT_ROOT}
+    # Cross-platform CodeRabbit CLI (Issue #731).
+    # Runtime resolves the actual command from cli_path + host OS detection.
+    # See `.aiox-core/core/quality-gates/quality-gate-config.yaml` for canonical config.
+    cli_path: ~/.local/bin/coderabbit
+    platform_notes:
+      macos_linux: "Run cli_path directly from project root (no wrapper)."
+      windows: "Wrap with 'wsl bash -c' and rewrite project paths to /mnt/<drive>/..."
     usage:
       - Pre-review automated scanning before human QA analysis
       - Security vulnerability detection (SQL injection, XSS, hardcoded secrets)
@@ -272,7 +274,9 @@ dependencies:
       max_iterations = 3
 
       WHILE iteration < max_iterations:
-        1. Run: wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'
+        1. Run the platform-aware command resolved by the runtime:
+           - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}`
+           - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'`
         2. Parse output for all severity levels
 
         critical_issues = filter(output, severity == "CRITICAL")
@@ -298,24 +302,34 @@ dependencies:
         - HALT and require human intervention
 
     commands:
-      qa_pre_review_uncommitted: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'"
-      qa_story_review_committed: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'"
+      # Templates — runtime selects the right shape for the host OS.
+      qa_pre_review_uncommitted_native: "${CLI_PATH} --prompt-only -t uncommitted"
+      qa_pre_review_uncommitted_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t uncommitted'"
+      qa_story_review_committed_native: "${CLI_PATH} --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}"
+      qa_story_review_committed_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'"
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL via `wsl bash -c '...'`. The runtime
+      detects `process.platform` and picks the right shape — agents and tasks
+      should not hardcode either.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run `cli_path` directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
+      - Override platform detection with explicit `installation_mode: 'wsl' | 'native'`
+        in `quality-gate-config.yaml` only when host detection is wrong.
 
       **Timeout:** 30 minutes (1800000ms) - Full review may take longer
 
       **Self-Healing:** Max 3 advisory request iterations for CRITICAL and HIGH issues
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify wsl_config.installation_path
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify `cli_path` and that the
+        binary is installed (macOS/Linux: PATH or manual install to
+        `~/.local/bin`; Windows: install inside the WSL distribution).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
     report_location: docs/qa/coderabbit-reports/
     integration_point: 'Runs automatically in *review and *gate workflows'
 

--- a/.gemini/rules/AIOX/agents/architect.md
+++ b/.gemini/rules/AIOX/agents/architect.md
@@ -331,9 +331,15 @@ dependencies:
         focus: Style consistency, minor optimizations
 
     workflow: |
-      When reviewing architectural changes:
-      1. Run: wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted' (for ongoing work)
-      2. Or: wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only --base main' (for feature branches)
+      When reviewing architectural changes — invoke the platform-aware
+      command resolved by the runtime (see `quality-gate-config.yaml` →
+      `layer2.coderabbit`):
+      1. Ongoing work:
+         - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t uncommitted`
+         - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t uncommitted'`
+      2. Feature branches (against `main`):
+         - macOS/Linux: `~/.local/bin/coderabbit --prompt-only --base main`
+         - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only --base main'`
       3. Focus on issues that impact:
          - System scalability
          - Security posture
@@ -346,19 +352,23 @@ dependencies:
       7. Document decisions in architecture docs
 
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL. Runtime detects `process.platform`
+      and picks the right shape — do not hardcode either form.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run the binary directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
 
       **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify installation in WSL
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify the binary is installed
+        on the host (macOS/Linux: PATH or `~/.local/bin/coderabbit`;
+        Windows: install inside the WSL distribution).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
 
     architectural_patterns_to_check:
       - API consistency (REST conventions, error handling, pagination)

--- a/.gemini/rules/AIOX/agents/data-engineer.md
+++ b/.gemini/rules/AIOX/agents/data-engineer.md
@@ -315,8 +315,11 @@ coderabbit_integration:
       focus: SQL style, readability
 
   workflow: |
-    When reviewing database changes:
-    1. BEFORE migration: Run wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted' on migration files
+    When reviewing database changes — invoke the platform-aware command
+    resolved by the runtime (see `quality-gate-config.yaml` → `layer2.coderabbit`):
+    1. BEFORE migration, on migration files:
+       - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t uncommitted`
+       - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t uncommitted'`
     2. Focus review on:
        - Security: SQL injection, RLS bypass, data exposure
        - Performance: Missing indexes, inefficient queries
@@ -328,19 +331,23 @@ coderabbit_integration:
     6. Update database-best-practices.md with patterns found
 
   execution_guidelines: |
-    CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+    CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+    On Windows it is invoked through WSL. Runtime detects `process.platform`
+    and picks the right shape — do not hardcode either form.
 
     **How to Execute:**
-    1. Use 'wsl bash -c' wrapper for all commands
-    2. Navigate to project directory in WSL path format (/mnt/c/...)
-    3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+    - macOS/Linux: run the binary directly. Bash tool sets cwd to project root.
+    - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
 
     **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
     **Error Handling:**
-    - If "coderabbit: command not found" → verify installation in WSL
-    - If timeout → increase timeout, review is still processing
-    - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+    - If `coderabbit: command not found` → verify the binary is installed
+      on the host (macOS/Linux: PATH or `~/.local/bin/coderabbit`;
+      Windows: install inside the WSL distribution).
+    - If timeout → increase timeout, review is still processing.
+    - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+      or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
 
   database_patterns_to_check:
     security:

--- a/.gemini/rules/AIOX/agents/dev.md
+++ b/.gemini/rules/AIOX/agents/dev.md
@@ -298,11 +298,13 @@ dependencies:
 
   coderabbit_integration:
     enabled: true
-    installation_mode: wsl
-    wsl_config:
-      distribution: Ubuntu
-      installation_path: ~/.local/bin/coderabbit
-      working_directory: ${PROJECT_ROOT}
+    # Cross-platform CodeRabbit CLI (Issue #731).
+    # Runtime resolves the actual command from cli_path + host OS detection.
+    # See `.aiox-core/core/quality-gates/quality-gate-config.yaml` for canonical config.
+    cli_path: ~/.local/bin/coderabbit
+    platform_notes:
+      macos_linux: "Run cli_path directly from project root (no wrapper)."
+      windows: "Wrap with 'wsl bash -c' and rewrite project paths to /mnt/<drive>/..."
     usage:
       - Pre-commit quality check - run before marking story complete
       - Catch issues early - find bugs, security issues, code smells during development
@@ -331,7 +333,9 @@ dependencies:
       max_iterations = 2
 
       WHILE iteration < max_iterations:
-        1. Run: wsl bash -c 'cd /mnt/c/.../aiox-core && ~/.local/bin/coderabbit --prompt-only -t uncommitted'
+        1. Run the platform-aware command resolved by the runtime:
+           - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t uncommitted`
+           - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t uncommitted'`
         2. Parse output for CRITICAL issues
 
         IF no CRITICAL issues:
@@ -350,23 +354,33 @@ dependencies:
         - DO NOT mark story complete
 
     commands:
-      dev_pre_commit_uncommitted: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'"
+      # Templates — runtime selects the right shape for the host OS.
+      dev_pre_commit_uncommitted_native: "${CLI_PATH} --prompt-only -t uncommitted"
+      dev_pre_commit_uncommitted_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t uncommitted'"
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL via `wsl bash -c '...'`. The runtime
+      detects `process.platform` and picks the right shape — agents and tasks
+      should not hardcode either.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run `cli_path` directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
+      - Override platform detection with explicit `installation_mode: 'wsl' | 'native'`
+        in `quality-gate-config.yaml` only when host detection is wrong.
 
       **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
       **Self-Healing:** Max 2 iterations for CRITICAL issues only
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify wsl_config.installation_path
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify `cli_path` and that the
+        binary is installed (macOS/Linux: `brew install coderabbit-cli` or
+        manual install to `~/.local/bin`; Windows: install inside the WSL
+        distribution declared in your environment).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
     report_location: docs/qa/coderabbit-reports/
     integration_point: 'Part of story completion workflow in develop-story.md'
 

--- a/.gemini/rules/AIOX/agents/devops.md
+++ b/.gemini/rules/AIOX/agents/devops.md
@@ -347,11 +347,13 @@ dependencies:
 
   coderabbit_integration:
     enabled: true
-    installation_mode: wsl
-    wsl_config:
-      distribution: Ubuntu
-      installation_path: ~/.local/bin/coderabbit
-      working_directory: ${PROJECT_ROOT}
+    # Cross-platform CodeRabbit CLI (Issue #731).
+    # Runtime resolves the actual command from cli_path + host OS detection.
+    # See `.aiox-core/core/quality-gates/quality-gate-config.yaml` for canonical config.
+    cli_path: ~/.local/bin/coderabbit
+    platform_notes:
+      macos_linux: "Run cli_path directly from project root (no wrapper)."
+      windows: "Wrap with 'wsl bash -c' and rewrite project paths to /mnt/<drive>/..."
     usage:
       - Pre-PR quality gate - run before creating pull requests
       - Pre-push validation - verify code quality before push
@@ -363,23 +365,34 @@ dependencies:
       MEDIUM: Document in PR description, create follow-up issue
       LOW: Optional improvements, note in comments
     commands:
-      pre_push_uncommitted: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'"
-      pre_pr_against_main: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only --base ${DEFAULT_BRANCH:-main}'"
-      pre_commit_committed: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t committed'"
+      # Templates — runtime selects the right shape for the host OS.
+      pre_push_uncommitted_native: "${CLI_PATH} --prompt-only -t uncommitted"
+      pre_push_uncommitted_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t uncommitted'"
+      pre_pr_against_main_native: "${CLI_PATH} --prompt-only --base ${DEFAULT_BRANCH:-main}"
+      pre_pr_against_main_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only --base ${DEFAULT_BRANCH:-main}'"
+      pre_commit_committed_native: "${CLI_PATH} --prompt-only -t committed"
+      pre_commit_committed_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t committed'"
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL via `wsl bash -c '...'`. The runtime
+      detects `process.platform` and picks the right shape — agents and tasks
+      should not hardcode either.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run `cli_path` directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
+      - Override platform detection with explicit `installation_mode: 'wsl' | 'native'`
+        in `quality-gate-config.yaml` only when host detection is wrong.
 
       **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify wsl_config.installation_path
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify `cli_path` and that the
+        binary is installed (macOS/Linux: PATH or manual install to
+        `~/.local/bin`; Windows: install inside the WSL distribution).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
     report_location: docs/qa/coderabbit-reports/
     integration_point: 'Runs automatically in *pre-push and *create-pr workflows'
 

--- a/.gemini/rules/AIOX/agents/qa.md
+++ b/.gemini/rules/AIOX/agents/qa.md
@@ -238,11 +238,13 @@ dependencies:
 
   coderabbit_integration:
     enabled: true
-    installation_mode: wsl
-    wsl_config:
-      distribution: Ubuntu
-      installation_path: ~/.local/bin/coderabbit
-      working_directory: ${PROJECT_ROOT}
+    # Cross-platform CodeRabbit CLI (Issue #731).
+    # Runtime resolves the actual command from cli_path + host OS detection.
+    # See `.aiox-core/core/quality-gates/quality-gate-config.yaml` for canonical config.
+    cli_path: ~/.local/bin/coderabbit
+    platform_notes:
+      macos_linux: "Run cli_path directly from project root (no wrapper)."
+      windows: "Wrap with 'wsl bash -c' and rewrite project paths to /mnt/<drive>/..."
     usage:
       - Pre-review automated scanning before human QA analysis
       - Security vulnerability detection (SQL injection, XSS, hardcoded secrets)
@@ -272,7 +274,9 @@ dependencies:
       max_iterations = 3
 
       WHILE iteration < max_iterations:
-        1. Run: wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'
+        1. Run the platform-aware command resolved by the runtime:
+           - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}`
+           - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'`
         2. Parse output for all severity levels
 
         critical_issues = filter(output, severity == "CRITICAL")
@@ -298,24 +302,34 @@ dependencies:
         - HALT and require human intervention
 
     commands:
-      qa_pre_review_uncommitted: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'"
-      qa_story_review_committed: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'"
+      # Templates — runtime selects the right shape for the host OS.
+      qa_pre_review_uncommitted_native: "${CLI_PATH} --prompt-only -t uncommitted"
+      qa_pre_review_uncommitted_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t uncommitted'"
+      qa_story_review_committed_native: "${CLI_PATH} --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}"
+      qa_story_review_committed_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'"
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL via `wsl bash -c '...'`. The runtime
+      detects `process.platform` and picks the right shape — agents and tasks
+      should not hardcode either.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run `cli_path` directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
+      - Override platform detection with explicit `installation_mode: 'wsl' | 'native'`
+        in `quality-gate-config.yaml` only when host detection is wrong.
 
       **Timeout:** 30 minutes (1800000ms) - Full review may take longer
 
       **Self-Healing:** Max 3 advisory request iterations for CRITICAL and HIGH issues
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify wsl_config.installation_path
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify `cli_path` and that the
+        binary is installed (macOS/Linux: PATH or manual install to
+        `~/.local/bin`; Windows: install inside the WSL distribution).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
     report_location: docs/qa/coderabbit-reports/
     integration_point: 'Runs automatically in *review and *gate workflows'
 

--- a/.kimi/skills/aiox-architect/SKILL.md
+++ b/.kimi/skills/aiox-architect/SKILL.md
@@ -393,9 +393,15 @@ dependencies:
         focus: Style consistency, minor optimizations
 
     workflow: |
-      When reviewing architectural changes:
-      1. Run: wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted' (for ongoing work)
-      2. Or: wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only --base main' (for feature branches)
+      When reviewing architectural changes — invoke the platform-aware
+      command resolved by the runtime (see `quality-gate-config.yaml` →
+      `layer2.coderabbit`):
+      1. Ongoing work:
+         - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t uncommitted`
+         - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t uncommitted'`
+      2. Feature branches (against `main`):
+         - macOS/Linux: `~/.local/bin/coderabbit --prompt-only --base main`
+         - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only --base main'`
       3. Focus on issues that impact:
          - System scalability
          - Security posture
@@ -408,19 +414,23 @@ dependencies:
       7. Document decisions in architecture docs
 
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL. Runtime detects `process.platform`
+      and picks the right shape — do not hardcode either form.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run the binary directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
 
       **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify installation in WSL
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify the binary is installed
+        on the host (macOS/Linux: PATH or `~/.local/bin/coderabbit`;
+        Windows: install inside the WSL distribution).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
 
     architectural_patterns_to_check:
       - API consistency (REST conventions, error handling, pagination)

--- a/.kimi/skills/aiox-data-engineer/SKILL.md
+++ b/.kimi/skills/aiox-data-engineer/SKILL.md
@@ -384,8 +384,11 @@ coderabbit_integration:
       focus: SQL style, readability
 
   workflow: |
-    When reviewing database changes:
-    1. BEFORE migration: Run wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted' on migration files
+    When reviewing database changes — invoke the platform-aware command
+    resolved by the runtime (see `quality-gate-config.yaml` → `layer2.coderabbit`):
+    1. BEFORE migration, on migration files:
+       - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t uncommitted`
+       - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t uncommitted'`
     2. Focus review on:
        - Security: SQL injection, RLS bypass, data exposure
        - Performance: Missing indexes, inefficient queries
@@ -397,19 +400,23 @@ coderabbit_integration:
     6. Update database-best-practices.md with patterns found
 
   execution_guidelines: |
-    CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+    CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+    On Windows it is invoked through WSL. Runtime detects `process.platform`
+    and picks the right shape — do not hardcode either form.
 
     **How to Execute:**
-    1. Use 'wsl bash -c' wrapper for all commands
-    2. Navigate to project directory in WSL path format (/mnt/c/...)
-    3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+    - macOS/Linux: run the binary directly. Bash tool sets cwd to project root.
+    - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
 
     **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
     **Error Handling:**
-    - If "coderabbit: command not found" → verify installation in WSL
-    - If timeout → increase timeout, review is still processing
-    - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+    - If `coderabbit: command not found` → verify the binary is installed
+      on the host (macOS/Linux: PATH or `~/.local/bin/coderabbit`;
+      Windows: install inside the WSL distribution).
+    - If timeout → increase timeout, review is still processing.
+    - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+      or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
 
   database_patterns_to_check:
     security:

--- a/.kimi/skills/aiox-dev/SKILL.md
+++ b/.kimi/skills/aiox-dev/SKILL.md
@@ -382,11 +382,13 @@ dependencies:
 
   coderabbit_integration:
     enabled: true
-    installation_mode: wsl
-    wsl_config:
-      distribution: Ubuntu
-      installation_path: ~/.local/bin/coderabbit
-      working_directory: ${PROJECT_ROOT}
+    # Cross-platform CodeRabbit CLI (Issue #731).
+    # Runtime resolves the actual command from cli_path + host OS detection.
+    # See `.aiox-core/core/quality-gates/quality-gate-config.yaml` for canonical config.
+    cli_path: ~/.local/bin/coderabbit
+    platform_notes:
+      macos_linux: "Run cli_path directly from project root (no wrapper)."
+      windows: "Wrap with 'wsl bash -c' and rewrite project paths to /mnt/<drive>/..."
     usage:
       - Pre-commit quality check - run before marking story complete
       - Catch issues early - find bugs, security issues, code smells during development
@@ -415,7 +417,9 @@ dependencies:
       max_iterations = 2
 
       WHILE iteration < max_iterations:
-        1. Run: wsl bash -c 'cd /mnt/c/.../aiox-core && ~/.local/bin/coderabbit --prompt-only -t uncommitted'
+        1. Run the platform-aware command resolved by the runtime:
+           - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t uncommitted`
+           - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t uncommitted'`
         2. Parse output for CRITICAL issues
 
         IF no CRITICAL issues:
@@ -434,23 +438,33 @@ dependencies:
         - DO NOT mark story complete
 
     commands:
-      dev_pre_commit_uncommitted: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'"
+      # Templates — runtime selects the right shape for the host OS.
+      dev_pre_commit_uncommitted_native: "${CLI_PATH} --prompt-only -t uncommitted"
+      dev_pre_commit_uncommitted_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t uncommitted'"
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL via `wsl bash -c '...'`. The runtime
+      detects `process.platform` and picks the right shape — agents and tasks
+      should not hardcode either.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run `cli_path` directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
+      - Override platform detection with explicit `installation_mode: 'wsl' | 'native'`
+        in `quality-gate-config.yaml` only when host detection is wrong.
 
       **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
       **Self-Healing:** Max 2 iterations for CRITICAL issues only
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify wsl_config.installation_path
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify `cli_path` and that the
+        binary is installed (macOS/Linux: `brew install coderabbit-cli` or
+        manual install to `~/.local/bin`; Windows: install inside the WSL
+        distribution declared in your environment).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
     report_location: docs/qa/coderabbit-reports/
     integration_point: 'Part of story completion workflow in develop-story.md'
 

--- a/.kimi/skills/aiox-devops/SKILL.md
+++ b/.kimi/skills/aiox-devops/SKILL.md
@@ -431,11 +431,13 @@ dependencies:
 
   coderabbit_integration:
     enabled: true
-    installation_mode: wsl
-    wsl_config:
-      distribution: Ubuntu
-      installation_path: ~/.local/bin/coderabbit
-      working_directory: ${PROJECT_ROOT}
+    # Cross-platform CodeRabbit CLI (Issue #731).
+    # Runtime resolves the actual command from cli_path + host OS detection.
+    # See `.aiox-core/core/quality-gates/quality-gate-config.yaml` for canonical config.
+    cli_path: ~/.local/bin/coderabbit
+    platform_notes:
+      macos_linux: "Run cli_path directly from project root (no wrapper)."
+      windows: "Wrap with 'wsl bash -c' and rewrite project paths to /mnt/<drive>/..."
     usage:
       - Pre-PR quality gate - run before creating pull requests
       - Pre-push validation - verify code quality before push
@@ -447,23 +449,34 @@ dependencies:
       MEDIUM: Document in PR description, create follow-up issue
       LOW: Optional improvements, note in comments
     commands:
-      pre_push_uncommitted: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'"
-      pre_pr_against_main: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only --base ${DEFAULT_BRANCH:-main}'"
-      pre_commit_committed: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t committed'"
+      # Templates — runtime selects the right shape for the host OS.
+      pre_push_uncommitted_native: "${CLI_PATH} --prompt-only -t uncommitted"
+      pre_push_uncommitted_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t uncommitted'"
+      pre_pr_against_main_native: "${CLI_PATH} --prompt-only --base ${DEFAULT_BRANCH:-main}"
+      pre_pr_against_main_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only --base ${DEFAULT_BRANCH:-main}'"
+      pre_commit_committed_native: "${CLI_PATH} --prompt-only -t committed"
+      pre_commit_committed_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t committed'"
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL via `wsl bash -c '...'`. The runtime
+      detects `process.platform` and picks the right shape — agents and tasks
+      should not hardcode either.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run `cli_path` directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
+      - Override platform detection with explicit `installation_mode: 'wsl' | 'native'`
+        in `quality-gate-config.yaml` only when host detection is wrong.
 
       **Timeout:** 15 minutes (900000ms) - CodeRabbit reviews take 7-30 min
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify wsl_config.installation_path
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify `cli_path` and that the
+        binary is installed (macOS/Linux: PATH or manual install to
+        `~/.local/bin`; Windows: install inside the WSL distribution).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
     report_location: docs/qa/coderabbit-reports/
     integration_point: 'Runs automatically in `*pre-push` and `*create-pr` workflows'
 

--- a/.kimi/skills/aiox-qa/SKILL.md
+++ b/.kimi/skills/aiox-qa/SKILL.md
@@ -304,11 +304,13 @@ dependencies:
 
   coderabbit_integration:
     enabled: true
-    installation_mode: wsl
-    wsl_config:
-      distribution: Ubuntu
-      installation_path: ~/.local/bin/coderabbit
-      working_directory: ${PROJECT_ROOT}
+    # Cross-platform CodeRabbit CLI (Issue #731).
+    # Runtime resolves the actual command from cli_path + host OS detection.
+    # See `.aiox-core/core/quality-gates/quality-gate-config.yaml` for canonical config.
+    cli_path: ~/.local/bin/coderabbit
+    platform_notes:
+      macos_linux: "Run cli_path directly from project root (no wrapper)."
+      windows: "Wrap with 'wsl bash -c' and rewrite project paths to /mnt/<drive>/..."
     usage:
       - Pre-review automated scanning before human QA analysis
       - Security vulnerability detection (SQL injection, XSS, hardcoded secrets)
@@ -338,7 +340,9 @@ dependencies:
       max_iterations = 3
 
       WHILE iteration < max_iterations:
-        1. Run: wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'
+        1. Run the platform-aware command resolved by the runtime:
+           - macOS/Linux: `~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}`
+           - Windows:     `wsl bash -c 'cd /mnt/<drive>/<path> && ~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'`
         2. Parse output for all severity levels
 
         critical_issues = filter(output, severity == "CRITICAL")
@@ -364,24 +368,34 @@ dependencies:
         - HALT and require human intervention
 
     commands:
-      qa_pre_review_uncommitted: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t uncommitted'"
-      qa_story_review_committed: "wsl bash -c 'cd ${PROJECT_ROOT} && ~/.local/bin/coderabbit --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'"
+      # Templates — runtime selects the right shape for the host OS.
+      qa_pre_review_uncommitted_native: "${CLI_PATH} --prompt-only -t uncommitted"
+      qa_pre_review_uncommitted_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t uncommitted'"
+      qa_story_review_committed_native: "${CLI_PATH} --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}"
+      qa_story_review_committed_wsl: "wsl bash -c 'cd ${PROJECT_ROOT} && ${CLI_PATH} --prompt-only -t committed --base ${DEFAULT_BRANCH:-main}'"
     execution_guidelines: |
-      CRITICAL: CodeRabbit CLI is installed in WSL, not Windows.
+      CodeRabbit CLI runs natively on macOS/Linux from `~/.local/bin/coderabbit`.
+      On Windows it is invoked through WSL via `wsl bash -c '...'`. The runtime
+      detects `process.platform` and picks the right shape — agents and tasks
+      should not hardcode either.
 
       **How to Execute:**
-      1. Use 'wsl bash -c' wrapper for all commands
-      2. Navigate to project directory in WSL path format (/mnt/c/...)
-      3. Use full path to coderabbit binary (~/.local/bin/coderabbit)
+      - macOS/Linux: run `cli_path` directly. Bash tool sets cwd to project root.
+      - Windows: wrap with `wsl bash -c 'cd /mnt/<drive>/<path> && ...'`.
+      - Override platform detection with explicit `installation_mode: 'wsl' | 'native'`
+        in `quality-gate-config.yaml` only when host detection is wrong.
 
       **Timeout:** 30 minutes (1800000ms) - Full review may take longer
 
       **Self-Healing:** Max 3 advisory request iterations for CRITICAL and HIGH issues
 
       **Error Handling:**
-      - If "coderabbit: command not found" → verify wsl_config.installation_path
-      - If timeout → increase timeout, review is still processing
-      - If "not authenticated" → user needs to run: wsl bash -c '~/.local/bin/coderabbit auth status'
+      - If `coderabbit: command not found` → verify `cli_path` and that the
+        binary is installed (macOS/Linux: PATH or manual install to
+        `~/.local/bin`; Windows: install inside the WSL distribution).
+      - If timeout → increase timeout, review is still processing.
+      - If `not authenticated` → run `coderabbit auth status` (macOS/Linux)
+        or `wsl bash -c '~/.local/bin/coderabbit auth status'` (Windows).
     report_location: docs/qa/coderabbit-reports/
     integration_point: 'Runs automatically in `*review` and `*gate` workflows'
 

--- a/tests/unit/quality-gates/cross-platform-coderabbit.test.js
+++ b/tests/unit/quality-gates/cross-platform-coderabbit.test.js
@@ -1,0 +1,105 @@
+/**
+ * Cross-platform CodeRabbit CLI invocation tests
+ *
+ * Regression guard for Issue #731 — the framework hardcoded `wsl bash -c '...'`
+ * for every host. macOS/Linux operators saw silent no-ops; Windows operators
+ * saw the only working path. After the fix, the runtime detects
+ * `process.platform` and picks the right command shape.
+ *
+ * This file pins:
+ *   - macOS (`darwin`) → native command
+ *   - Linux            → native command
+ *   - Windows (`win32`) → `wsl bash -c` wrapper
+ *   - Explicit `installation_mode` override still wins on every host
+ *
+ * @issue #731
+ */
+
+const { Layer2PRAutomation } = require('../../../.aiox-core/core/quality-gates/layer2-pr-automation');
+
+describe('Cross-platform CodeRabbit invocation (Issue #731)', () => {
+  let originalPlatform;
+  let layer;
+  let capturedCommand;
+
+  beforeEach(() => {
+    originalPlatform = process.platform;
+    capturedCommand = null;
+    layer = new Layer2PRAutomation({
+      enabled: true,
+      coderabbit: { enabled: true },
+      quinn: { enabled: false },
+    });
+    // Intercept the shell invocation — we only care about command shape, not output.
+    layer.runCommand = (command) => {
+      capturedCommand = command;
+      return Promise.resolve({ stdout: '', stderr: '' });
+    };
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+  });
+
+  const setPlatform = (value) => {
+    Object.defineProperty(process, 'platform', { value });
+  };
+
+  it('builds a native command on macOS (darwin)', async () => {
+    setPlatform('darwin');
+    await layer.runCodeRabbit();
+    expect(capturedCommand).toBe('~/.local/bin/coderabbit --prompt-only -t uncommitted');
+    expect(capturedCommand).not.toMatch(/wsl bash -c/);
+  });
+
+  it('builds a native command on Linux', async () => {
+    setPlatform('linux');
+    await layer.runCodeRabbit();
+    expect(capturedCommand).toBe('~/.local/bin/coderabbit --prompt-only -t uncommitted');
+    expect(capturedCommand).not.toMatch(/wsl bash -c/);
+  });
+
+  it('wraps the command with `wsl bash -c` on Windows (win32)', async () => {
+    setPlatform('win32');
+    await layer.runCodeRabbit();
+    expect(capturedCommand).toMatch(/^wsl bash -c '/);
+    expect(capturedCommand).toContain('~/.local/bin/coderabbit --prompt-only -t uncommitted');
+  });
+
+  it('honors an explicit installation_mode override (native on Windows)', async () => {
+    setPlatform('win32');
+    layer.coderabbit.installation_mode = 'native';
+    await layer.runCodeRabbit();
+    expect(capturedCommand).toBe('~/.local/bin/coderabbit --prompt-only -t uncommitted');
+    expect(capturedCommand).not.toMatch(/wsl bash -c/);
+  });
+
+  it('honors an explicit installation_mode override (wsl on macOS)', async () => {
+    setPlatform('darwin');
+    layer.coderabbit.installation_mode = 'wsl';
+    await layer.runCodeRabbit();
+    expect(capturedCommand).toMatch(/^wsl bash -c '/);
+  });
+
+  it('honors a raw `command` string override (back-compat)', async () => {
+    setPlatform('linux');
+    layer.coderabbit.command = 'custom-coderabbit --foo';
+    await layer.runCodeRabbit();
+    expect(capturedCommand).toBe('custom-coderabbit --foo');
+  });
+
+  it('respects a custom cli_path when building native command', async () => {
+    setPlatform('darwin');
+    layer.coderabbit.cli_path = '/opt/homebrew/bin/coderabbit';
+    await layer.runCodeRabbit();
+    expect(capturedCommand).toBe('/opt/homebrew/bin/coderabbit --prompt-only -t uncommitted');
+  });
+
+  it('respects a custom cli_path when building wsl command', async () => {
+    setPlatform('win32');
+    layer.coderabbit.cli_path = '/usr/local/bin/coderabbit-custom';
+    await layer.runCodeRabbit();
+    expect(capturedCommand).toContain('/usr/local/bin/coderabbit-custom --prompt-only -t uncommitted');
+    expect(capturedCommand).toMatch(/^wsl bash -c '/);
+  });
+});

--- a/tests/unit/quality-gates/cross-platform-coderabbit.test.js
+++ b/tests/unit/quality-gates/cross-platform-coderabbit.test.js
@@ -67,11 +67,16 @@ describe('Cross-platform CodeRabbit invocation (Issue #731)', () => {
     expect(capturedCommand).not.toMatch(/wsl bash -c/);
   });
 
-  it('wraps the command with `wsl bash -c` on Windows (win32)', async () => {
+  it('wraps the command with `wsl bash -c` on Windows (win32) — keeps `~` literal for WSL bash to expand', async () => {
     setPlatform('win32');
     await layer.runCodeRabbit();
     expect(capturedCommand).toMatch(/^wsl bash -c '/);
-    expect(capturedCommand).toContain(`${expectedDefaultCliPath} --prompt-only -t uncommitted`);
+    // WSL mode keeps the literal `~/.local/bin/coderabbit` so the WSL distribution's
+    // bash expands it (host HOME points at a Windows path that WSL cannot resolve).
+    expect(capturedCommand).toContain('~/.local/bin/coderabbit --prompt-only -t uncommitted');
+    // Crucially, the cli_path itself must NOT have been pre-expanded to the host's
+    // home dir — that would put a Windows path inside the WSL command.
+    expect(capturedCommand).not.toContain(`${expectedDefaultCliPath} --prompt-only`);
   });
 
   it('converts Windows project root to /mnt/<drive>/... inside wsl command', async () => {
@@ -79,6 +84,13 @@ describe('Cross-platform CodeRabbit invocation (Issue #731)', () => {
     process.cwd = () => 'C:\\Users\\dev\\project';
     await layer.runCodeRabbit();
     expect(capturedCommand).toMatch(/cd "\/mnt\/c\/Users\/dev\/project"/);
+  });
+
+  it('handles lowercase drive letters when converting to /mnt/<drive>/...', async () => {
+    setPlatform('win32');
+    process.cwd = () => 'd:\\workspace\\project';
+    await layer.runCodeRabbit();
+    expect(capturedCommand).toMatch(/cd "\/mnt\/d\/workspace\/project"/);
   });
 
   it('honors an explicit installation_mode override (native on Windows)', async () => {
@@ -110,7 +122,7 @@ describe('Cross-platform CodeRabbit invocation (Issue #731)', () => {
     expect(capturedCommand).toBe('/opt/homebrew/bin/coderabbit --prompt-only -t uncommitted');
   });
 
-  it('respects a custom cli_path when building wsl command', async () => {
+  it('respects a custom cli_path when building wsl command (absolute path, no tilde expansion needed)', async () => {
     setPlatform('win32');
     layer.coderabbit.cli_path = '/usr/local/bin/coderabbit-custom';
     await layer.runCodeRabbit();
@@ -118,11 +130,22 @@ describe('Cross-platform CodeRabbit invocation (Issue #731)', () => {
     expect(capturedCommand).toMatch(/^wsl bash -c '/);
   });
 
-  it('expands tilde (~) in cli_path via os.homedir() — defensive', async () => {
+  it('expands tilde (~) in cli_path via os.homedir() in NATIVE mode — defensive', async () => {
     setPlatform('darwin');
     layer.coderabbit.cli_path = '~/custom/coderabbit';
     await layer.runCodeRabbit();
     expect(capturedCommand).toBe(`${path.join(os.homedir(), '/custom/coderabbit')} --prompt-only -t uncommitted`);
     expect(capturedCommand).not.toContain('~/custom');
+  });
+
+  it('keeps tilde (~) literal in cli_path in WSL mode — bash expands it inside WSL', async () => {
+    setPlatform('darwin');
+    layer.coderabbit.installation_mode = 'wsl';
+    layer.coderabbit.cli_path = '~/custom/coderabbit';
+    await layer.runCodeRabbit();
+    // WSL mode preserves the literal `~` (the WSL bash, not the host shell,
+    // is what expands it). Host's os.homedir() would yield a Windows path
+    // that WSL cannot resolve.
+    expect(capturedCommand).toContain('~/custom/coderabbit --prompt-only -t uncommitted');
   });
 });

--- a/tests/unit/quality-gates/cross-platform-coderabbit.test.js
+++ b/tests/unit/quality-gates/cross-platform-coderabbit.test.js
@@ -15,15 +15,22 @@
  * @issue #731
  */
 
+const os = require('os');
+const path = require('path');
+
 const { Layer2PRAutomation } = require('../../../.aiox-core/core/quality-gates/layer2-pr-automation');
+
+const expectedDefaultCliPath = path.join(os.homedir(), '/.local/bin/coderabbit');
 
 describe('Cross-platform CodeRabbit invocation (Issue #731)', () => {
   let originalPlatform;
+  let originalCwd;
   let layer;
   let capturedCommand;
 
   beforeEach(() => {
     originalPlatform = process.platform;
+    originalCwd = process.cwd;
     capturedCommand = null;
     layer = new Layer2PRAutomation({
       enabled: true,
@@ -39,6 +46,7 @@ describe('Cross-platform CodeRabbit invocation (Issue #731)', () => {
 
   afterEach(() => {
     Object.defineProperty(process, 'platform', { value: originalPlatform });
+    process.cwd = originalCwd;
   });
 
   const setPlatform = (value) => {
@@ -48,14 +56,14 @@ describe('Cross-platform CodeRabbit invocation (Issue #731)', () => {
   it('builds a native command on macOS (darwin)', async () => {
     setPlatform('darwin');
     await layer.runCodeRabbit();
-    expect(capturedCommand).toBe('~/.local/bin/coderabbit --prompt-only -t uncommitted');
+    expect(capturedCommand).toBe(`${expectedDefaultCliPath} --prompt-only -t uncommitted`);
     expect(capturedCommand).not.toMatch(/wsl bash -c/);
   });
 
   it('builds a native command on Linux', async () => {
     setPlatform('linux');
     await layer.runCodeRabbit();
-    expect(capturedCommand).toBe('~/.local/bin/coderabbit --prompt-only -t uncommitted');
+    expect(capturedCommand).toBe(`${expectedDefaultCliPath} --prompt-only -t uncommitted`);
     expect(capturedCommand).not.toMatch(/wsl bash -c/);
   });
 
@@ -63,14 +71,21 @@ describe('Cross-platform CodeRabbit invocation (Issue #731)', () => {
     setPlatform('win32');
     await layer.runCodeRabbit();
     expect(capturedCommand).toMatch(/^wsl bash -c '/);
-    expect(capturedCommand).toContain('~/.local/bin/coderabbit --prompt-only -t uncommitted');
+    expect(capturedCommand).toContain(`${expectedDefaultCliPath} --prompt-only -t uncommitted`);
+  });
+
+  it('converts Windows project root to /mnt/<drive>/... inside wsl command', async () => {
+    setPlatform('win32');
+    process.cwd = () => 'C:\\Users\\dev\\project';
+    await layer.runCodeRabbit();
+    expect(capturedCommand).toMatch(/cd "\/mnt\/c\/Users\/dev\/project"/);
   });
 
   it('honors an explicit installation_mode override (native on Windows)', async () => {
     setPlatform('win32');
     layer.coderabbit.installation_mode = 'native';
     await layer.runCodeRabbit();
-    expect(capturedCommand).toBe('~/.local/bin/coderabbit --prompt-only -t uncommitted');
+    expect(capturedCommand).toBe(`${expectedDefaultCliPath} --prompt-only -t uncommitted`);
     expect(capturedCommand).not.toMatch(/wsl bash -c/);
   });
 
@@ -101,5 +116,13 @@ describe('Cross-platform CodeRabbit invocation (Issue #731)', () => {
     await layer.runCodeRabbit();
     expect(capturedCommand).toContain('/usr/local/bin/coderabbit-custom --prompt-only -t uncommitted');
     expect(capturedCommand).toMatch(/^wsl bash -c '/);
+  });
+
+  it('expands tilde (~) in cli_path via os.homedir() — defensive', async () => {
+    setPlatform('darwin');
+    layer.coderabbit.cli_path = '~/custom/coderabbit';
+    await layer.runCodeRabbit();
+    expect(capturedCommand).toBe(`${path.join(os.homedir(), '/custom/coderabbit')} --prompt-only -t uncommitted`);
+    expect(capturedCommand).not.toContain('~/custom');
   });
 });


### PR DESCRIPTION
## Summary

Closes #731 (reported by @duboneh).

The CodeRabbit CLI execution paths were hardcoded to assume Windows + WSL (`wsl bash -c '...'` wrapper, `/mnt/c/...` paths, `installation_mode: wsl`). On macOS/Linux those commands failed silently and the Layer-2 quality-gate automation never enforced the review — the auto-healing loop in @dev / @qa / @devops / @architect / @data-engineer simulated success while doing nothing.

## Patterns applied (per @duboneh PoC)

### Pattern 1 — Inline cross-platform branching (runtime)

- `.aiox-core/core/orchestration/workflow-executor.js` (`runCodeRabbitAnalysis`)
- `.aiox-core/core/quality-gates/layer2-pr-automation.js` (`runCodeRabbit`)
- `.aiox-core/development/tasks/github-devops-pre-push-quality-gate.md` (inline code block + error-handler messages)

Default: `installation_mode || (process.platform === 'win32' ? 'wsl' : 'native')`. `cli_path` defaults to `~/.local/bin/coderabbit`. Explicit `installation_mode: 'wsl' | 'native'` overrides platform detection. Explicit raw `command:` string overrides `cli_path` (back-compat). Error-handler messages switch on `process.platform` so macOS/Linux/Windows operators each see the right recovery hint.

### Pattern 2 — `wsl_config:` block → `cli_path:` + `platform_notes:`

DELETED `installation_mode: wsl` + `wsl_config:` blocks (no overlay; full removal) from:
- `.aiox-core/core/quality-gates/quality-gate-config.yaml`
- 3 agent personas: `dev.md`, `qa.md`, `devops.md`

Replaced with `cli_path: ~/.local/bin/coderabbit` + `platform_notes:` describing both invocation shapes.

### Pattern 3 — execution_guidelines rewritten neutral

5 agent personas (`dev`, `qa`, `devops`, `architect`, `data-engineer`) had their `execution_guidelines` text rewritten from "CRITICAL: CodeRabbit CLI is installed in WSL, not Windows / use 'wsl bash -c' wrapper for ALL commands" to cross-platform guidance. `commands:` blocks now expose explicit `_native` and `_wsl` template suffixes side-by-side.

ASCII workflow diagrams updated in `qa-review-story.md` + `dev-develop-story.md`. `environment-bootstrap.md` note rewritten as cross-platform.

## Regression coverage

`tests/unit/quality-gates/cross-platform-coderabbit.test.js` — **8 tests, all pass**:
1. macOS (`darwin`) builds native command (no `wsl bash -c`)
2. Linux builds native command
3. Windows (`win32`) wraps with `wsl bash -c`
4. Explicit `installation_mode: 'native'` override on Windows
5. Explicit `installation_mode: 'wsl'` override on macOS
6. Raw `command:` string override (back-compat)
7. Custom `cli_path` honored on macOS
8. Custom `cli_path` honored on Windows

## IDE projection sync

`npm run sync:ide` propagated agent persona changes to 7 IDEs: claude-code, codex, gemini, github-copilot, cursor, antigravity, kimi. Compatibility Parity Gate + IDE Command Sync Validation should be green.

## Validation

- [x] `npm run lint` → exit 0
- [x] `npx jest tests/unit/quality-gates/cross-platform-coderabbit.test.js` → 8/8 pass
- [x] `grep -rn 'installation_mode: wsl\\b\\|wsl_config:' .aiox-core/development/agents/*.md` → zero matches
- [x] All remaining `wsl bash -c` references are Windows-prefixed examples or `_wsl` template suffixes (verified manually)
- [x] `npm run sync:ide` clean — no projection drift
- [ ] CI essentials green (Test, Jest matrix, ESLint, TypeScript, CodeQL, Compatibility Parity Gate, IDE Command Sync Validation)

## Out of scope (separate follow-ups)

- The `Cross-Platform (\${{ matrix.os }}, Node \${{ matrix.node }})` smoke matrix check in CI is `skipping` (unexpanded YAML variable in a workflow). Unrelated bug — separate issue worth filing.
- `smoke_test_exports (Node 24)` flakes (false positive — readline `ERR_USE_AFTER_CLOSE` in non-TTY context). Smoke test should pass a non-interactive flag instead of relying on `node -e "require('bin/aiox.js')"`.
- `.aiox-core/development/agents/qa/MEMORY.md` still mentions `installation_mode: wsl` but it is a runtime memory file (not config) — intentionally left alone per the constitution's data sovereignty rules.

## Test plan

- [ ] CI essentials green on this branch
- [ ] Bypass dance (ruleset 13330052 + legacy branch protection) atomic with trap EXIT restore
- [ ] Post-merge: students on macOS/Linux see real CodeRabbit output during `*pre-push` / `*review` / `*develop-story` instead of silent skips

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-platform CodeRabbit CLI support with automatic platform detection (native on macOS/Linux; WSL wrapper on Windows), configurable CLI path and installation mode, and separate native/WSL command templates.

* **Documentation**
  * Widespread updates to agent guides, tasks, skills and rules with platform-aware invocation, path-handling notes, and revised troubleshooting/auth guidance.

* **Tests**
  * Added regression tests validating cross-platform command construction, path translation, and tilde-expansion behavior.

* **Chores**
  * Registry and install manifest refreshed to reflect updated files and metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/752?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->