### PR TITLE
fix(ci): use require.resolve() in smoke_test_exports — fixes #755

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -511,7 +511,7 @@ jobs:
           echo "❌ ${CORE_SPEC} not visible after 90s — cannot run exports smoke"
           exit 1
 
-      - name: Force require() resolution to trigger exports gate
+      - name: Force require.resolve() to trigger exports gate
         env:
           CORE_SPEC: '@aiox-squads/core@${{ needs.build.outputs.version }}'
         run: |
@@ -520,13 +520,16 @@ jobs:
           cd "${SMOKE_DIR}"
           npm init -y >/dev/null 2>&1
           npm install "${CORE_SPEC}" 2>&1 | tail -3
-          # External require() forces Node's package-exports gate. If bin/*
-          # is not declared in exports, this fails with ERR_PACKAGE_PATH_NOT_EXPORTED.
+          # External require.resolve() forces Node's package-exports gate. If
+          # bin/* is not declared in exports, this fails with ERR_PACKAGE_PATH_NOT_EXPORTED.
+          # Uses resolve() instead of require() to avoid loading the CLI's wizard
+          # in non-TTY runners (Node 24 surfaced ERR_USE_AFTER_CLOSE on readline
+          # close in non-interactive contexts — false positive, not exports drift).
           # set -o pipefail above ensures node's exit status survives the head pipe.
-          if node -e "require('@aiox-squads/core/bin/aiox.js')" 2>&1 | head -20; then
-            echo "✅ require('@aiox-squads/core/bin/aiox.js') succeeds on Node ${{ matrix.node }}"
+          if node -e "require.resolve('@aiox-squads/core/bin/aiox.js')" 2>&1 | head -20; then
+            echo "✅ require.resolve('@aiox-squads/core/bin/aiox.js') succeeds on Node ${{ matrix.node }}"
           else
-            echo "❌ REGRESSION: require() blocked by exports field on Node ${{ matrix.node }}"
+            echo "❌ REGRESSION: require.resolve() blocked by exports field on Node ${{ matrix.node }}"
             echo "❌ Issue #734 has returned — check exports field in package.json"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Replaces `node -e "require('@aiox-squads/core/bin/aiox.js')"` with `require.resolve()` in the `smoke_test_exports` job of `.github/workflows/npm-publish.yml`. Eliminates a Node 24 false positive (ERR_USE_AFTER_CLOSE on readline close in non-TTY runners) while preserving the original intent of the gate — validating that `bin/aiox.js` is reachable through the package-exports field.

## Why

- The exports-gate check needs to fail with `ERR_PACKAGE_PATH_NOT_EXPORTED` if bin/* is not declared in exports — `require.resolve()` triggers the same check.
- `require()` also loads and executes the module, which boots the CLI's readline interface; in non-TTY runners on Node 24 this surfaces `ERR_USE_AFTER_CLOSE` after the banner already prints, killing the exit code with a misleading error.
- Observed on the 5.2.7 publish workflow run: `smoke_test_exports (Node 24)` reported failure even though the banner "Installer v5.2.7" printed correctly. CLI loaded fine — the readline lifecycle in non-interactive context was the culprit, not exports drift.

## Test plan

- [ ] Workflow file syntax valid (yamllint or `act --list`)
- [ ] After merge: trigger a manual run or wait for next publish; confirm `smoke_test_exports` matrix Node 20/22/24 all pass GREEN
- [ ] Regression guard intact: if anyone breaks the exports field in `package.json`, `ERR_PACKAGE_PATH_NOT_EXPORTED` still surfaces (verified by tracing Node's resolution algorithm — `require.resolve()` follows the same `pkg.exports` walk as `require()` up to the load step)

## Issue

Closes #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package export validation process in the CI/CD pipeline to improve reliability of export checking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/759?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->