### PR TITLE
fix(ci): drop matrix template from skipped-job names — fixes #756

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,7 +549,7 @@ jobs:
 
   # SYNAPSE context engine benchmarks + E2E tests (Story SYN-12)
   synapse-benchmark:
-    name: SYNAPSE Benchmark (Node ${{ matrix.node }})
+    name: SYNAPSE Benchmark
     needs: changes
     if: github.event_name == 'pull_request' && (needs.changes.outputs.code == 'true' || needs.changes.outputs.tests == 'true')
     runs-on: ubuntu-latest
@@ -583,7 +583,7 @@ jobs:
   # Cross-platform testing - ONLY on main branch push
   # Moved from cross-platform-tests.yml (Story 6.1)
   cross-platform:
-    name: Cross-Platform (${{ matrix.os }}, Node ${{ matrix.node }})
+    name: Cross-Platform Tests
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: [changes, lint, typecheck, test]
     strategy:


### PR DESCRIPTION
## Summary

Two jobs in `ci.yml` had matrix-interpolated names that surfaced as literal templates in PR checks UI when the job was skipped (the common case for both):

- `synapse-benchmark` — gated by `if: code or tests changed`. PRs that don't touch those paths see `SYNAPSE Benchmark (Node ${{ matrix.node }})` unexpanded.
- `cross-platform` — gated by `if: ref == main && event == push`. PRs NEVER trigger it, so PR view always shows `Cross-Platform (${{ matrix.os }}, Node ${{ matrix.node }})` literal.

## Why this works

GitHub Actions doesn't expand `${{ matrix.* }}` in the `name:` field when the job is skipped at strategy-evaluation. When the job runs, GH auto-appends matrix values to the job display, so removing the explicit template keeps the run-time UX (e.g. `SYNAPSE Benchmark (18)` auto-rendered) while eliminating the literal template in the skipped-job case.

## Test plan

- [ ] Workflow syntax valid
- [ ] After merge: open a draft PR that doesn't change code/tests; confirm `SYNAPSE Benchmark` appears as `SYNAPSE Benchmark` (not literal)
- [ ] After main push: confirm `cross-platform` runs and displays as `Cross-Platform Tests (ubuntu-latest, 18)` etc auto-expanded by GH
- [ ] (Manual) verify CI checks UI list is cleaner on any future PR

## Issue

Closes #756

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified CI workflow job display names to improve clarity in build status reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->