### PR TITLE
feat(quality-gates): probe WSL availability before CodeRabbit invocation — fixes #757

### DIFF
--- a/.aiox-core/core/orchestration/workflow-executor.js
+++ b/.aiox-core/core/orchestration/workflow-executor.js
@@ -775,9 +775,9 @@ class WorkflowExecutor {
    */
   async runCodeRabbitAnalysis(coderabbitConfig) {
     try {
-      const { exec } = require('child_process');
+      const childProcess = require('child_process');
       const { promisify } = require('util');
-      const execAsync = promisify(exec);
+      const execAsync = promisify(childProcess.exec);
 
       // Build command for current platform.
       // - Explicit installation_mode: 'wsl' | 'native' wins (lets ops override).
@@ -793,6 +793,20 @@ class WorkflowExecutor {
         (process.platform === 'win32' ? 'wsl' : 'native');
       let command;
       if (mode === 'wsl') {
+        // Probe WSL availability before building the command. Gives a clearer
+        // diagnostic than cmd.exe's generic "'wsl' is not recognized" when WSL
+        // is not installed. ENOENT (binary missing) and non-zero exit (WSL
+        // feature present but no distribution installed) both fail this check.
+        const wslProbe = childProcess.spawnSync('wsl', ['-l'], { encoding: 'utf8' });
+        if (wslProbe.error || wslProbe.status !== 0) {
+          throw new Error(
+            'CodeRabbit CLI requires WSL on Windows hosts. Install WSL via ' +
+              '`wsl --install` (https://learn.microsoft.com/windows/wsl/install), ' +
+              'then install the CodeRabbit CLI inside the WSL distribution. ' +
+              'See docs/guides/installation-troubleshooting.md Issue 10. ' +
+              `To bypass this check, set coderabbit.installation_mode='native' in your config.`
+          );
+        }
         const wslPath = this.projectRoot
           .replace(/^([A-Za-z]):/, (_, drive) => `/mnt/${drive.toLowerCase()}`)
           .replace(/\\/g, '/');

--- a/.aiox-core/core/quality-gates/layer2-pr-automation.js
+++ b/.aiox-core/core/quality-gates/layer2-pr-automation.js
@@ -10,7 +10,7 @@
  * @story 2.10 - Quality Gate Manager
  */
 
-const { spawn } = require('child_process');
+const childProcess = require('child_process');
 const fs = require('fs').promises;
 const os = require('os');
 const path = require('path');
@@ -117,6 +117,21 @@ class Layer2PRAutomation extends BaseLayer {
           this.coderabbit.installation_mode ||
           (process.platform === 'win32' ? 'wsl' : 'native');
         if (mode === 'wsl') {
+          // Probe WSL availability before building the command. Gives a clearer
+          // diagnostic than cmd.exe's generic "'wsl' is not recognized" when
+          // WSL is not installed. ENOENT (binary missing) and non-zero exit
+          // (WSL feature present but no distribution installed) both fail this
+          // check.
+          const wslProbe = childProcess.spawnSync('wsl', ['-l'], { encoding: 'utf8' });
+          if (wslProbe.error || wslProbe.status !== 0) {
+            throw new Error(
+              'CodeRabbit CLI requires WSL on Windows hosts. Install WSL via ' +
+                '`wsl --install` (https://learn.microsoft.com/windows/wsl/install), ' +
+                'then install the CodeRabbit CLI inside the WSL distribution. ' +
+                'See docs/guides/installation-troubleshooting.md Issue 10. ' +
+                'To bypass this check, set coderabbit.installation_mode=\'native\' in your config.',
+            );
+          }
           const projectRoot = this.coderabbit.projectRoot || process.cwd();
           const wslProjectPath = projectRoot
             .replace(/\\/g, '/')
@@ -322,7 +337,7 @@ class Layer2PRAutomation extends BaseLayer {
         env: { ...process.env },
       };
 
-      const child = spawn(command, [], options);
+      const child = childProcess.spawn(command, [], options);
 
       let stdout = '';
       let stderr = '';

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.2.7
-generated_at: "2026-05-18T05:37:21.641Z"
+generated_at: "2026-05-18T11:40:45.332Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1128
 files:
@@ -989,9 +989,9 @@ files:
     type: core
     size: 31469
   - path: core/orchestration/workflow-executor.js
-    hash: sha256:ddc880683df489ec7203ab7ecd8e066a08e2f72b011fe0dfe578d31155eb513b
+    hash: sha256:5bc1c72b7565f3ae5794d4d379d2090c605ca6c383ebbb94a042c5f96b2b9102
     type: core
-    size: 37348
+    size: 38289
   - path: core/orchestration/workflow-orchestrator.js
     hash: sha256:82816bd5e6fecc9bbb77292444e53254c72bf93e5c04260784743354c6a58627
     type: core
@@ -1037,9 +1037,9 @@ files:
     type: core
     size: 9393
   - path: core/quality-gates/layer2-pr-automation.js
-    hash: sha256:53e1f05e3ece4731848ad818f13a97ce18f553327b6f2e385e4d299492cc890a
+    hash: sha256:19e52369efe5cf0df9d0b6a9675dd555fdd46c1ab19cf6dc45d9173ad6e6524e
     type: core
-    size: 10923
+    size: 11907
   - path: core/quality-gates/layer3-human-review.js
     hash: sha256:9bf79d5adfddae55d7dddfda777cd2775aa76f82204ddd0f660f6edbd093b16b
     type: core

--- a/tests/unit/quality-gates/cross-platform-coderabbit.test.js
+++ b/tests/unit/quality-gates/cross-platform-coderabbit.test.js
@@ -17,6 +17,7 @@
 
 const os = require('os');
 const path = require('path');
+const childProcess = require('child_process');
 
 const { Layer2PRAutomation } = require('../../../.aiox-core/core/quality-gates/layer2-pr-automation');
 
@@ -27,11 +28,21 @@ describe('Cross-platform CodeRabbit invocation (Issue #731)', () => {
   let originalCwd;
   let layer;
   let capturedCommand;
+  let spawnSyncSpy;
 
   beforeEach(() => {
     originalPlatform = process.platform;
     originalCwd = process.cwd;
     capturedCommand = null;
+    // Mock the WSL availability probe added for #757 so legacy command-shape
+    // tests don't fail on macOS/Linux dev boxes where `wsl` isn't installed.
+    // Tests covering the probe failure path override this on a per-test basis.
+    spawnSyncSpy = jest.spyOn(childProcess, 'spawnSync').mockImplementation((cmd) => {
+      if (cmd === 'wsl') {
+        return { status: 0, stdout: 'Ubuntu\n', stderr: '' };
+      }
+      return { status: 0, stdout: '', stderr: '' };
+    });
     layer = new Layer2PRAutomation({
       enabled: true,
       coderabbit: { enabled: true },
@@ -47,6 +58,7 @@ describe('Cross-platform CodeRabbit invocation (Issue #731)', () => {
   afterEach(() => {
     Object.defineProperty(process, 'platform', { value: originalPlatform });
     process.cwd = originalCwd;
+    spawnSyncSpy.mockRestore();
   });
 
   const setPlatform = (value) => {
@@ -147,5 +159,54 @@ describe('Cross-platform CodeRabbit invocation (Issue #731)', () => {
     // is what expands it). Host's os.homedir() would yield a Windows path
     // that WSL cannot resolve.
     expect(capturedCommand).toContain('~/custom/coderabbit --prompt-only -t uncommitted');
+  });
+
+  // Issue #757 — WSL availability probe before invoking CodeRabbit on Windows
+  describe('WSL availability probe (Issue #757)', () => {
+    it('surfaces a clear error when WSL binary is missing (ENOENT)', async () => {
+      setPlatform('win32');
+      spawnSyncSpy.mockImplementation((cmd) => {
+        if (cmd === 'wsl') {
+          return { error: Object.assign(new Error('ENOENT'), { code: 'ENOENT' }), status: null };
+        }
+        return { status: 0, stdout: '', stderr: '' };
+      });
+      const result = await layer.runCodeRabbit();
+      expect(spawnSyncSpy).toHaveBeenCalledWith('wsl', ['-l'], expect.any(Object));
+      expect(result.pass).toBe(false);
+      expect(result.error).toMatch(/CodeRabbit CLI requires WSL/);
+      expect(result.error).toMatch(/wsl --install/);
+      expect(result.error).toMatch(/installation-troubleshooting/);
+    });
+
+    it('surfaces a clear error when WSL is installed but has no distribution (exit != 0)', async () => {
+      setPlatform('win32');
+      spawnSyncSpy.mockImplementation((cmd) => {
+        if (cmd === 'wsl') {
+          return { status: 1, stdout: '', stderr: 'no distros\n' };
+        }
+        return { status: 0, stdout: '', stderr: '' };
+      });
+      const result = await layer.runCodeRabbit();
+      expect(spawnSyncSpy).toHaveBeenCalledWith('wsl', ['-l'], expect.any(Object));
+      expect(result.pass).toBe(false);
+      expect(result.error).toMatch(/CodeRabbit CLI requires WSL/);
+    });
+
+    it('does NOT probe WSL when installation_mode=native on Windows', async () => {
+      setPlatform('win32');
+      layer.coderabbit.installation_mode = 'native';
+      await layer.runCodeRabbit();
+      // The probe MUST NOT have been called when native mode is explicit.
+      const wslProbeCalls = spawnSyncSpy.mock.calls.filter((c) => c[0] === 'wsl');
+      expect(wslProbeCalls).toHaveLength(0);
+    });
+
+    it('does NOT probe WSL on macOS native invocation', async () => {
+      setPlatform('darwin');
+      await layer.runCodeRabbit();
+      const wslProbeCalls = spawnSyncSpy.mock.calls.filter((c) => c[0] === 'wsl');
+      expect(wslProbeCalls).toHaveLength(0);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Add an explicit WSL availability probe in `workflow-executor.js` and `layer2-pr-automation.js` before constructing the `wsl bash -c` command on Windows hosts. Replaces cmd.exe's generic "'wsl' is not recognized" error with framework-aware guidance pointing to install docs, the troubleshooting guide, and the `installation_mode='native'` bypass.

Closes the CodeRabbit suggestion declined in PR #752 (Issue #731) for follow-up.

## Implementation

Both files probe `spawnSync('wsl', ['-l'], { encoding: 'utf8' })` at the top of the wsl-mode branch. The probe fails when:
- `error.code === 'ENOENT'` — wsl binary not installed on the host
- `status !== 0` — wsl installed but no distribution available

In both failure modes, throw:
> CodeRabbit CLI requires WSL on Windows hosts. Install WSL via \`wsl --install\` (https://learn.microsoft.com/windows/wsl/install), then install the CodeRabbit CLI inside the WSL distribution. See docs/guides/installation-troubleshooting.md Issue 10. To bypass this check, set coderabbit.installation_mode='native' in your config.

The graceful-degradation try/catch in `runCodeRabbit` already converts the throw into a soft failure (`{ pass: false, error: <message> }`), so the probe never crashes the quality-gate pipeline — it just turns an opaque CLI failure into an actionable one.

## Refactor for testability

Both files switched from destructured imports (`const { spawn, spawnSync } = require('child_process')`) to namespaced imports (`const childProcess = require('child_process')`) so `jest.spyOn(childProcess, 'spawnSync')` can intercept calls in tests. No behavior change — every call site updated.

## Test coverage

`tests/unit/quality-gates/cross-platform-coderabbit.test.js` extended from 12 to 16 cases:
- Existing 12 WSL command-shape tests now mock `spawnSync` in `beforeEach` to return `{ status: 0 }`, so they continue passing on macOS/Linux dev boxes where wsl is unavailable.
- 4 new tests cover:
  - ENOENT probe failure surfaces actionable error
  - non-zero exit probe failure surfaces same actionable error
  - probe is NOT invoked when `installation_mode='native'` (bypass works)
  - probe is NOT invoked on macOS native invocation (no waste)

Suite: 16/16 pass. Total 77/77 across all related test files. Lint clean. TypeScript clean.

## Test plan

- [x] `npx jest tests/unit/quality-gates/cross-platform-coderabbit.test.js` → 16/16
- [x] `npx jest tests/core/workflow-executor.test.js` → existing tests still green
- [x] `npm run lint` → clean
- [x] `npm run typecheck` → clean
- [ ] Manual smoke on macOS dev: pre-push CodeRabbit gate still runs (mode auto-detects native, probe never fires)
- [ ] Manual smoke (when available): Windows host without WSL — see the new error message instead of cmd.exe's generic one

## Issue

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Windows/WSL compatibility detection for CodeRabbit integration with enhanced validation to prevent execution failures when WSL is unavailable.
  * Enhanced error messaging to guide users on WSL setup or platform configuration options.

* **Tests**
  * Added cross-platform validation tests for WSL availability scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->