### PR TITLE
fix(ci): unblock pro submodule fallback sync

### DIFF
--- a/.github/workflows/sync-pro-submodule.yml
+++ b/.github/workflows/sync-pro-submodule.yml
@@ -62,7 +62,8 @@ jobs:
         run: |
           TARGET_SHA="$INPUT_SHA"
           if [ -z "$TARGET_SHA" ]; then
-            TARGET_SHA=$(git ls-remote "$PRO_REPO_URL" refs/heads/main | awk '{print $1}')
+            TARGET_SHA=$(git -c http.https://github.com/.extraheader= \
+              ls-remote "$PRO_REPO_URL" refs/heads/main | awk '{print $1}')
           fi
 
           CURRENT_SHA=$(git ls-tree HEAD pro | awk '{print $3}')
@@ -115,7 +116,7 @@ jobs:
       - name: Create or update PR
         if: steps.resolve.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PRO_SUBMODULE_TOKEN }}
           SHORT_SHA: ${{ steps.resolve.outputs.short_sha }}
           TARGET_SHA: ${{ steps.resolve.outputs.target_sha }}
           CURRENT_SHA: ${{ steps.resolve.outputs.current_sha }}

--- a/.github/workflows/sync-pro-submodule.yml
+++ b/.github/workflows/sync-pro-submodule.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Create or update PR
         if: steps.resolve.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.PRO_SUBMODULE_TOKEN }}
+          GH_TOKEN: ${{ secrets.PRO_PR_TOKEN }}
           SHORT_SHA: ${{ steps.resolve.outputs.short_sha }}
           TARGET_SHA: ${{ steps.resolve.outputs.target_sha }}
           CURRENT_SHA: ${{ steps.resolve.outputs.current_sha }}


### PR DESCRIPTION
## Summary
- Clear the checkout-injected GitHub token extraheader when resolving `aiox-pro` via the authenticated `PRO_SUBMODULE_TOKEN` remote.
- Use `PRO_SUBMODULE_TOKEN` for `gh pr create/edit` because the organization blocks `GITHUB_TOKEN` from creating pull requests.

## Validation
- `npx yaml-lint .github/workflows/sync-pro-submodule.yml`
- Local `git ls-remote` simulation with a bogus checkout extraheader confirmed the explicit empty extraheader lets the authenticated Pro URL resolve `refs/heads/main`.
- Rotated `PRO_SUBMODULE_TOKEN` and confirmed clone/update path works by manual dispatch with explicit `target_sha`; failure moved to PR creation, now addressed by this patch.

Fixes #762

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved submodule synchronization workflow to more reliably resolve upstream targets when an explicit reference is not provided.
  * Switched PR creation authentication to use a stored repository secret, improving permission handling for automated updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->