### PR TITLE
fix(wis): remove redundant agent handoff workflow

### DIFF
--- a/.aiox-core/data/entity-registry.yaml
+++ b/.aiox-core/data/entity-registry.yaml
@@ -1,6 +1,6 @@
 metadata:
   version: 1.0.0
-  lastUpdated: '2026-05-18T05:34:46.620Z'
+  lastUpdated: '2026-05-18T16:26:51.453Z'
   entityCount: 820
   checksumAlgorithm: sha256
   resolutionRate: 100
@@ -15511,8 +15511,8 @@ entities:
         score: 0.5
         constraints: []
         extensionPoints: []
-      checksum: sha256:0e90d71ce0cc218d8710c1f195f74a24d3aa7513f5728f5e65da9220612c3617
-      lastVerified: '2026-05-18T05:34:46.480Z'
+      checksum: sha256:a8ca099258eef7744315ae575cfdc3b7ebf2a3942d182ee6293b3661414260c3
+      lastVerified: '2026-05-18T16:26:51.443Z'
     workflow-state-schema:
       path: .aiox-core/data/workflow-state-schema.yaml
       layer: L3

--- a/.aiox-core/data/workflow-patterns.yaml
+++ b/.aiox-core/data/workflow-patterns.yaml
@@ -30,6 +30,8 @@ workflows:
       - develop-preflight
       - review-qa
       - apply-qa-fixes
+      - fix-qa-issues
+      - run-tests
       - pre-push-quality-gate
       - github-pr-automation
     trigger_threshold: 2
@@ -79,9 +81,39 @@ workflows:
             args_template: ""
             description: "Apply QA feedback and fixes"
             priority: 1
+          - command: fix-qa-issues
+            args_template: ""
+            description: "Resolve structured QA fix requests"
+            priority: 2
           - command: pre-push-quality-gate
             args_template: ""
             description: "Run final quality checks before push"
+            priority: 3
+      fixes_applied:
+        trigger: "apply-qa-fixes completed"
+        confidence: 0.85
+        greeting_message: "QA fixes applied. Ready for final verification."
+        next_steps:
+          - command: run-tests
+            args_template: ""
+            description: "Verify fixes with tests"
+            priority: 1
+          - command: pre-push-quality-gate
+            args_template: ""
+            description: "Run final quality gate"
+            priority: 2
+      qa_fix_request_resolved:
+        trigger: "fix-qa-issues completed"
+        confidence: 0.85
+        greeting_message: "QA fix request resolved. Ready for final verification."
+        next_steps:
+          - command: run-tests
+            args_template: ""
+            description: "Verify fixes with tests"
+            priority: 1
+          - command: pre-push-quality-gate
+            args_template: ""
+            description: "Run final quality gate"
             priority: 2
 
   # Epic Creation Workflow
@@ -679,69 +711,6 @@ workflows:
           - command: build-status
             args_template: "--all"
             description: "Check all build statuses"
-            priority: 2
-
-  # Cross-Agent Handoff Workflow (Story ACT-5)
-  agent_handoff:
-    description: "Handoff between agents during multi-agent story execution"
-    agent_sequence:
-      - dev        # Development
-      - qa         # Review
-      - dev        # Fix issues
-      - devops     # Push
-    key_commands:
-      - develop
-      - develop-yolo
-      - review-qa
-      - apply-qa-fixes
-      - fix-qa-issues
-      - run-tests
-      - pre-push-quality-gate
-    trigger_threshold: 2
-    typical_duration: "0.5-2 days"
-    success_indicators:
-      - "Development complete"
-      - "QA passed"
-      - "Ready for push"
-    transitions:
-      dev_complete:
-        trigger: "develop completed"
-        confidence: 0.90
-        greeting_message: "Development complete. Handing off to QA."
-        next_steps:
-          - command: review-qa
-            args_template: "${story_path}"
-            description: "Run QA review"
-            priority: 1
-          - command: run-tests
-            args_template: ""
-            description: "Run test suite"
-            priority: 2
-      qa_issues_found:
-        trigger: "review-qa completed"
-        confidence: 0.85
-        greeting_message: "QA review complete. Issues to address."
-        next_steps:
-          - command: fix-qa-issues
-            args_template: ""
-            description: "Fix QA issues from review"
-            priority: 1
-          - command: apply-qa-fixes
-            args_template: ""
-            description: "Apply QA feedback"
-            priority: 2
-      fixes_applied:
-        trigger: "fix-qa-issues completed"
-        confidence: 0.85
-        greeting_message: "Fixes applied. Ready for quality gate."
-        next_steps:
-          - command: run-tests
-            args_template: ""
-            description: "Verify fixes with tests"
-            priority: 1
-          - command: pre-push-quality-gate
-            args_template: ""
-            description: "Run final quality gate"
             priority: 2
 
 # ============================================================

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.2.7
-generated_at: "2026-05-18T15:42:34.055Z"
+generated_at: "2026-05-18T16:27:23.965Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1128
 files:
@@ -1297,7 +1297,7 @@ files:
     type: data
     size: 9590
   - path: data/entity-registry.yaml
-    hash: sha256:2196d36637457245daf242bb209277f03407245fb95f014cb63dd7c8b62ed717
+    hash: sha256:986a8c998bb0ca11980f0bf11882f2d661cf53885e56317fef684fb872037b30
     type: data
     size: 579527
   - path: data/learned-patterns.yaml
@@ -1369,9 +1369,9 @@ files:
     type: data
     size: 5055
   - path: data/workflow-patterns.yaml
-    hash: sha256:0e90d71ce0cc218d8710c1f195f74a24d3aa7513f5728f5e65da9220612c3617
+    hash: sha256:a8ca099258eef7744315ae575cfdc3b7ebf2a3942d182ee6293b3661414260c3
     type: data
-    size: 28054
+    size: 27228
   - path: data/workflow-state-schema.yaml
     hash: sha256:d80a645a9c48b8ab8168ddbe36279662d72de4fb5cd8953a6685e5d1bd9968db
     type: data
@@ -4449,9 +4449,9 @@ files:
     type: workflow-intelligence
     size: 10679
   - path: workflow-intelligence/__tests__/integration.test.js
-    hash: sha256:8f7eb4cff6d36493b49322b3221231db6d6b4259aaa2da4a2c5cdd6d61effded
+    hash: sha256:8efad6313702dff2f76e9a102ebe642c4429afd5d8351a8c547ed1dfb78bc44b
     type: workflow-intelligence
-    size: 11101
+    size: 11214
   - path: workflow-intelligence/__tests__/suggestion-engine.test.js
     hash: sha256:993741ed68c63db9bb50e58133b47159dd9fb1c4844e2fc99a5e618adb8fa12f
     type: workflow-intelligence
@@ -4461,9 +4461,9 @@ files:
     type: workflow-intelligence
     size: 15055
   - path: workflow-intelligence/__tests__/workflow-registry.test.js
-    hash: sha256:fee70788995d95180f647eea86a012d1f90d8157405c9abf3d8004e1e347a424
+    hash: sha256:759b36fb6ea30c9f6dcee9b5d8c06986f90f0fc51158d53be2dd1cc86b427fbf
     type: workflow-intelligence
-    size: 9967
+    size: 10255
   - path: workflow-intelligence/engine/confidence-scorer.js
     hash: sha256:6ab69ac846e0f3b49fd7d76a720ab1dc305f402b54518bbcf8ce876f269d0c18
     type: workflow-intelligence

--- a/.aiox-core/workflow-intelligence/__tests__/integration.test.js
+++ b/.aiox-core/workflow-intelligence/__tests__/integration.test.js
@@ -221,7 +221,9 @@ describe('Workflow Intelligence System Integration', () => {
 
     it('should expose getWorkflowNames function', () => {
       const names = wis.getWorkflowNames();
-      expect(names.length).toBe(10);
+      expect(names.length).toBe(11);
+      expect(names).toContain('bob_orchestration');
+      expect(names).not.toContain('agent_handoff');
     });
 
     it('should expose getWorkflowsByAgent function', () => {
@@ -236,8 +238,8 @@ describe('Workflow Intelligence System Integration', () => {
 
     it('should expose getStats function', () => {
       const stats = wis.getStats();
-      expect(stats.totalWorkflows).toBe(10);
-      expect(stats.workflowsWithTransitions).toBe(10);
+      expect(stats.totalWorkflows).toBe(11);
+      expect(stats.workflowsWithTransitions).toBe(11);
     });
 
     it('should expose factory functions', () => {
@@ -295,7 +297,7 @@ describe('Workflow Intelligence System Integration', () => {
     });
   });
 
-  describe('All 10 workflows have transitions', () => {
+  describe('All 10 WIS core workflows have transitions', () => {
     const workflows = [
       'story_development',
       'epic_creation',

--- a/.aiox-core/workflow-intelligence/__tests__/workflow-registry.test.js
+++ b/.aiox-core/workflow-intelligence/__tests__/workflow-registry.test.js
@@ -48,10 +48,10 @@ describe('WorkflowRegistry', () => {
       expect(typeof workflows).toBe('object');
     });
 
-    it('should return 10 workflows', () => {
+    it('should return 11 workflows', () => {
       const workflows = registry.loadWorkflows();
       const names = Object.keys(workflows);
-      expect(names.length).toBe(10);
+      expect(names.length).toBe(11);
     });
 
     it('should include story_development workflow', () => {
@@ -62,6 +62,11 @@ describe('WorkflowRegistry', () => {
     it('should include epic_creation workflow', () => {
       const workflows = registry.loadWorkflows();
       expect(workflows.epic_creation).toBeDefined();
+    });
+
+    it('should not include redundant agent_handoff workflow', () => {
+      const workflows = registry.loadWorkflows();
+      expect(workflows.agent_handoff).toBeUndefined();
     });
 
     it('should cache loaded workflows', () => {
@@ -99,7 +104,7 @@ describe('WorkflowRegistry', () => {
     it('should return array of workflow names', () => {
       const names = registry.getWorkflowNames();
       expect(Array.isArray(names)).toBe(true);
-      expect(names.length).toBe(10);
+      expect(names.length).toBe(11);
     });
 
     it('should include expected workflows', () => {
@@ -114,6 +119,8 @@ describe('WorkflowRegistry', () => {
       expect(names).toContain('documentation_workflow');
       expect(names).toContain('ux_workflow');
       expect(names).toContain('research_workflow');
+      expect(names).toContain('bob_orchestration');
+      expect(names).not.toContain('agent_handoff');
     });
   });
 
@@ -268,8 +275,8 @@ describe('WorkflowRegistry', () => {
     it('should return registry statistics', () => {
       const stats = registry.getStats();
 
-      expect(stats.totalWorkflows).toBe(10);
-      expect(stats.workflowsWithTransitions).toBe(10);
+      expect(stats.totalWorkflows).toBe(11);
+      expect(stats.workflowsWithTransitions).toBe(11);
       expect(stats.totalTransitions).toBeGreaterThan(0);
     });
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -57,8 +57,6 @@ module.exports = {
     'tests/integration/install-transaction.test.js',
     // License tests require network/crypto resources unavailable in CI (pre-existing)
     'tests/license/',
-    // Workflow intelligence tests - assertion count mismatches (pre-existing)
-    '.aiox-core/workflow-intelligence/__tests__/',
   ],
 
   // Coverage collection (Story TD-3: Updated paths)

--- a/tests/core/workflow-navigator-integration.test.js
+++ b/tests/core/workflow-navigator-integration.test.js
@@ -555,22 +555,22 @@ describe('WorkflowNavigator Integration (Story ACT-5)', () => {
       }
     });
 
-    test('agent_handoff workflow exists for cross-agent transitions', () => {
-      expect(patterns.workflows.agent_handoff).toBeDefined();
+    test('story_development owns cross-agent handoff commands', () => {
+      expect(patterns.workflows.agent_handoff).toBeUndefined();
 
-      const handoffWorkflow = patterns.workflows.agent_handoff;
-      expect(handoffWorkflow.agent_sequence).toContain('dev');
-      expect(handoffWorkflow.agent_sequence).toContain('qa');
-      expect(handoffWorkflow.key_commands).toContain('fix-qa-issues');
-      expect(handoffWorkflow.key_commands).toContain('apply-qa-fixes');
+      const storyWorkflow = patterns.workflows.story_development;
+      expect(storyWorkflow.agent_sequence).toContain('dev');
+      expect(storyWorkflow.agent_sequence).toContain('qa');
+      expect(storyWorkflow.key_commands).toContain('fix-qa-issues');
+      expect(storyWorkflow.key_commands).toContain('run-tests');
+      expect(storyWorkflow.key_commands).toContain('apply-qa-fixes');
     });
 
-    test('agent_handoff has dev_complete and qa_issues_found transitions', () => {
-      const transitions = patterns.workflows.agent_handoff.transitions;
+    test('story_development has QA fix and final-verification transitions', () => {
+      const transitions = patterns.workflows.story_development.transitions;
 
-      expect(transitions.dev_complete).toBeDefined();
-      expect(transitions.qa_issues_found).toBeDefined();
       expect(transitions.fixes_applied).toBeDefined();
+      expect(transitions.qa_fix_request_resolved).toBeDefined();
     });
   });
 
@@ -768,7 +768,7 @@ describe('WorkflowNavigator Integration (Story ACT-5)', () => {
       expect(state.state).toBe('epic_started');
     });
 
-    test('detects agent_handoff from develop completed', () => {
+    test('detects story_development from develop completed', () => {
       const navigator = new WorkflowNavigator();
 
       const state = navigator.detectWorkflowState(
@@ -777,10 +777,21 @@ describe('WorkflowNavigator Integration (Story ACT-5)', () => {
       );
 
       expect(state).not.toBeNull();
-      // Could match story_development in_development OR agent_handoff dev_complete
-      // The first matching workflow wins
-      expect(state).toHaveProperty('workflow');
-      expect(state).toHaveProperty('state');
+      expect(state.workflow).toBe('story_development');
+      expect(state.state).toBe('in_development');
+    });
+
+    test('detects story_development final verification from fix-qa-issues completed', () => {
+      const navigator = new WorkflowNavigator();
+
+      const state = navigator.detectWorkflowState(
+        ['fix-qa-issues completed'],
+        {},
+      );
+
+      expect(state).not.toBeNull();
+      expect(state.workflow).toBe('story_development');
+      expect(state.state).toBe('qa_fix_request_resolved');
     });
 
     test('returns null for unrecognized commands', () => {


### PR DESCRIPTION
## Summary
- Removes the redundant `agent_handoff` workflow from `.aiox-core/data/workflow-patterns.yaml`.
- Moves the useful QA handoff signals into `story_development` so `fix-qa-issues` and `run-tests` remain discoverable without a duplicate workflow.
- Re-enables the Workflow Intelligence Jest suite now that the stale count mismatch is fixed.
- Updates WIS tests to reflect the current canonical set: 10 WIS core workflows plus `bob_orchestration`, with no `agent_handoff`.

Fixes #766.

## Validation
- `npx yaml-lint .aiox-core/data/workflow-patterns.yaml`
- `npm test -- .aiox-core/workflow-intelligence/__tests__/integration.test.js .aiox-core/workflow-intelligence/__tests__/workflow-registry.test.js tests/core/workflow-navigator-integration.test.js --runInBand` (3 suites, 136 tests)
- `npm test -- .aiox-core/workflow-intelligence/__tests__ tests/integration/workflow-intelligence tests/unit/workflow-intelligence --runInBand` (11 suites, 370 tests)
- `npm run lint`
- `npm run typecheck`
- `npm run test:ci -- --silent` (350 suites passed, 8717 tests passed, 12 suites skipped)
- `npm run validate:manifest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended story development workflow with additional QA-related commands and improved transition handling for issue resolution and verification.

* **Tests**
  * Updated workflow intelligence and integration tests to reflect enhanced workflow configurations and system changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/770?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->