### PR TITLE
chore(release): bump to 5.2.8

### DIFF
--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -7,8 +7,8 @@
 # - SHA256 hashes for change detection
 # - File types for categorization
 #
-version: 5.2.7
-generated_at: "2026-05-20T17:56:37.529Z"
+version: 5.2.8
+generated_at: "2026-05-21T00:21:31.048Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1129
 files:
@@ -3701,7 +3701,7 @@ files:
     type: monitor
     size: 818
   - path: package.json
-    hash: sha256:8335dc568cb25279628e511f1a2ef4d10f0573e843df0c8ec0829235e0f7c004
+    hash: sha256:bc1bd0eae7c04feb1d1659fb9715a7c908e1cf2bb146341ed3b0d24f630cc9a9
     type: other
     size: 1445
   - path: product/checklists/accessibility-wcag-checklist.md

--- a/.aiox-core/package.json
+++ b/.aiox-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/core-internal",
-  "version": "5.2.7",
+  "version": "5.2.8",
   "description": "Internal package manifest for AIOX framework — declares runtime dependencies consumed by scripts under .aiox-core/. This is NOT published independently; it ships inside @aiox-squads/core (the top-level package). Kept name-distinct from the parent (`-internal` suffix) to avoid npm registry confusion. Version follows the parent package.",
   "private": true,
   "main": "index.js",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to Synkra AIOX will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.2.8] - 2026-05-21
+
+### Fixed
+
+- **Pro activation errors now surface the real license-server cause instead of opaque `HTTP 403`** (#775).
+  - Root cause: the installer read `parsed.message` / `parsed.code` at the response root while the license-server returns the PRO-16 structured envelope under `error`.
+  - Fix: `InlineLicenseClient` now reads nested `error.message` / `error.code` first, preserves the full envelope, and keeps legacy root-shaped responses compatible.
+  - This restores typed handling for `NOT_A_BUYER`, `SEAT_LIMIT_EXCEEDED`, `REVOKED_KEY`, and related Pro activation failures.
+- **Pro CLI error rendering is resilient to raw, null, and malformed errors** (#775).
+  - Added safe normalization before rendering user-facing messages.
+  - Added OS-aware recovery commands so Windows users receive PowerShell-compatible cleanup steps.
+
+### Changed
+
+- `@aiox-squads/installer` bumped to `3.3.7` to ship the activation-envelope parser fix.
+- `@aiox-squads/aiox-pro-cli` bumped to `0.2.2` to ship the Pro CLI error UX bridge.
+
+### Notes
+
+- This release targets the user-visible install failure where login succeeds, buyer access is confirmed, and activation then prints only `HTTP 403`.
+
 ## [5.2.7] - 2026-05-18
 
 ### Fixed

--- a/compat/aiox-core/package.json
+++ b/compat/aiox-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiox-core",
-  "version": "5.2.7",
+  "version": "5.2.8",
   "description": "Compatibility wrapper for @aiox-squads/core.",
   "license": "MIT",
   "bin": {
@@ -15,7 +15,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@aiox-squads/core": "5.2.7"
+    "@aiox-squads/core": "5.2.8"
   },
   "engines": {
     "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.2.7",
+  "version": "5.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aiox-squads/core",
-      "version": "5.2.7",
+      "version": "5.2.8",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -14503,7 +14503,7 @@
     },
     "packages/aiox-pro-cli": {
       "name": "@aiox-squads/aiox-pro-cli",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@aiox-squads/installer": "^3.3.2",
@@ -14518,7 +14518,7 @@
     },
     "packages/installer": {
       "name": "@aiox-squads/installer",
-      "version": "3.3.6",
+      "version": "3.3.7",
       "license": "MIT",
       "dependencies": {
         "@aiox-squads/core": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.2.7",
+  "version": "5.2.8",
   "description": "Synkra AIOX: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aiox": "bin/aiox.js",

--- a/packages/aiox-pro-cli/package.json
+++ b/packages/aiox-pro-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/aiox-pro-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "CLI for AIOX Pro — install, activate and manage your license",
   "bin": {
     "aiox-pro": "bin/aiox-pro.js"

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/installer",
-  "version": "3.3.6",
+  "version": "3.3.7",
   "description": "AIOX Installer - Automated setup wizard for AIOX projects (greenfield & brownfield)",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
## Release

- @aiox-squads/core: 5.2.8
- @aiox-squads/installer: 3.3.7
- @aiox-squads/aiox-pro-cli: 0.2.2

## Context

Ships PR #775 fix for Pro activation UX: installer now preserves the license-server structured error envelope instead of collapsing activation failures to opaque HTTP 403.

## Local validation

- npm run lint
- npm run test:ci
- npx jest tests/installer/ --no-coverage
- npm run validate:publish
- npm view confirmed target versions are not published yet


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pro activation now shows detailed license-server error information instead of a generic HTTP 403.
  * Pro CLI error handling is more resilient to raw, null, or malformed errors.

* **User Guidance**
  * Installer now provides OS-aware recovery/cleanup commands (including Windows PowerShell) for activation failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->