### PR TITLE
fix: align Pro install machine fingerprint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14518,7 +14518,7 @@
     },
     "packages/installer": {
       "name": "@aiox-squads/installer",
-      "version": "3.3.8",
+      "version": "3.3.9",
       "license": "MIT",
       "dependencies": {
         "@aiox-squads/core": "^5.1.0",
@@ -14528,6 +14528,7 @@
         "fs-extra": "^11.3.2",
         "inquirer": "^8.2.6",
         "js-yaml": "^4.1.0",
+        "node-machine-id": "^1.1.12",
         "ora": "^5.4.1",
         "semver": "^7.7.2"
       },

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/installer",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "description": "AIOX Installer - Automated setup wizard for AIOX projects (greenfield & brownfield)",
   "main": "src/index.js",
   "bin": {
@@ -42,6 +42,7 @@
     "fs-extra": "^11.3.2",
     "inquirer": "^8.2.6",
     "js-yaml": "^4.1.0",
+    "node-machine-id": "^1.1.12",
     "ora": "^5.4.1",
     "semver": "^7.7.2"
   },

--- a/packages/installer/src/wizard/pro-setup.js
+++ b/packages/installer/src/wizard/pro-setup.js
@@ -137,6 +137,7 @@ function resolveLicenseServerUrl(rawUrl = DEFAULT_LICENSE_SERVER_URL) {
 
 const LICENSE_SERVER_URL = resolveLicenseServerUrl(process.env.AIOX_LICENSE_API_URL);
 const PASSWORD_RESET_URL = new URL('/reset-password', LICENSE_SERVER_URL).toString();
+const MACHINE_ID_HASH_PREFIX = 'aiox-pro-native-machine-id:v1:';
 
 /**
  * Inline License Client — lightweight HTTP client for pre-bootstrap license checks.
@@ -612,6 +613,34 @@ function generateMachineId() {
     return licenseCryptoModule.generateMachineId();
   }
 
+  const nativeMachineId = generateNativeMachineId();
+  if (nativeMachineId) {
+    return nativeMachineId;
+  }
+
+  return generateLegacyMachineId();
+}
+
+function generateNativeMachineId() {
+  const crypto = require('crypto');
+  try {
+    const { machineIdSync } = require('node-machine-id');
+    const nativeMachineId = machineIdSync(true);
+
+    if (!nativeMachineId || typeof nativeMachineId !== 'string') {
+      throw new Error('Native machine id unavailable');
+    }
+
+    return crypto
+      .createHash('sha256')
+      .update(`${MACHINE_ID_HASH_PREFIX}${nativeMachineId}`)
+      .digest('hex');
+  } catch {
+    return null;
+  }
+}
+
+function generateLegacyMachineId() {
   const crypto = require('crypto');
   const os = require('os');
   const components = [];
@@ -2322,6 +2351,8 @@ module.exports = {
     resolveProSourceDir,
     InlineLicenseClient,
     generateMachineId,
+    generateNativeMachineId,
+    generateLegacyMachineId,
     persistLicenseCache,
     resolveLicenseServerUrl,
     resolveNpmInvocation,

--- a/packages/installer/tests/unit/pro-setup-machine-id.test.js
+++ b/packages/installer/tests/unit/pro-setup-machine-id.test.js
@@ -1,0 +1,16 @@
+const crypto = require('crypto');
+const { machineIdSync } = require('node-machine-id');
+
+const { _testing } = require('../../src/wizard/pro-setup');
+
+describe('pro setup machine id', () => {
+  test('uses the same native machine id fingerprint as the Pro runtime', () => {
+    const nativeMachineId = machineIdSync(true);
+    const expected = crypto
+      .createHash('sha256')
+      .update(`aiox-pro-native-machine-id:v1:${nativeMachineId}`)
+      .digest('hex');
+
+    expect(_testing.generateMachineId()).toBe(expected);
+  });
+});

--- a/packages/installer/tests/unit/pro-setup-machine-id.test.js
+++ b/packages/installer/tests/unit/pro-setup-machine-id.test.js
@@ -1,9 +1,14 @@
 const crypto = require('crypto');
 const { machineIdSync } = require('node-machine-id');
 
-const { _testing } = require('../../src/wizard/pro-setup');
+const { _testing } = require('@aiox-squads/installer/pro-setup');
 
 describe('pro setup machine id', () => {
+  afterEach(() => {
+    jest.dontMock('node-machine-id');
+    jest.dontMock('os');
+  });
+
   test('uses the same native machine id fingerprint as the Pro runtime', () => {
     const nativeMachineId = machineIdSync(true);
     const expected = crypto
@@ -12,5 +17,30 @@ describe('pro setup machine id', () => {
       .digest('hex');
 
     expect(_testing.generateMachineId()).toBe(expected);
+  });
+
+  test('falls back to the legacy fingerprint when native machine id is unavailable', () => {
+    jest.doMock('node-machine-id', () => ({
+      machineIdSync: jest.fn(() => {
+        throw new Error('Native machine id unavailable');
+      }),
+    }));
+    jest.doMock('os', () => ({
+      hostname: jest.fn(() => 'fallback-host'),
+      cpus: jest.fn(() => [{ model: 'fallback-cpu' }]),
+      networkInterfaces: jest.fn(() => ({
+        en0: [{ internal: false, mac: 'aa:bb:cc:dd:ee:ff' }],
+      })),
+    }));
+
+    jest.isolateModules(() => {
+      const { _testing: isolatedTesting } = require('@aiox-squads/installer/pro-setup');
+      const expected = crypto
+        .createHash('sha256')
+        .update('fallback-host|fallback-cpu|aa:bb:cc:dd:ee:ff')
+        .digest('hex');
+
+      expect(isolatedTesting.generateMachineId()).toBe(expected);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Align Pro setup machine fingerprint with the @aiox-squads/pro runtime native machine-id format.
- Add node-machine-id as a direct installer dependency.
- Bump @aiox-squads/installer to 3.3.9 and add focused unit coverage.

## Validation
- npm test -- --runInBand packages/installer/tests/unit/pro-setup-machine-id.test.js
- Published @aiox-squads/installer@3.3.9
- E2E from clean temp project using published packages:
  - npx -y aiox-core@latest install --ci --yes --ide claude-code
  - npx -y @aiox-squads/aiox-pro-cli@latest install
  - npx -y @aiox-squads/aiox-pro-cli@latest validate
  - npx -y aiox-core@latest validate --detailed

## Notes
- Core-only install produced no Pro artifact files before Pro activation.
- After Pro install, no new files were added under .claude/agents or .claude/skills; Pro squad commands were added under .claude/commands and .codex/agents as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Installer now prefers a native machine identifier for Pro setup, improving fingerprint stability and maintaining robust fallbacks.

* **Chores**
  * Added a runtime dependency to support native machine-id retrieval.

* **Tests**
  * Added unit tests covering native machine-id hashing and legacy fallback behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->