### PR TITLE
test: guard metrics runtime files in publish gate

### DIFF
--- a/bin/utils/validate-publish.js
+++ b/bin/utils/validate-publish.js
@@ -21,6 +21,11 @@ const { execSync, execFileSync } = require('child_process');
 const PROJECT_ROOT = path.join(__dirname, '..', '..');
 const MIN_FILE_COUNT = 50;
 const PRO_PATH_PATTERN = /^pro(?:\/|$)/;
+const REQUIRED_PUBLIC_FILES = [
+  '.aiox-core/quality/metrics-collector.js',
+  '.aiox-core/quality/seed-metrics.js',
+  '.aiox-core/quality/schemas/quality-metrics.schema.json',
+];
 const DEFAULT_PACK_TIMEOUT_MS = 300000;
 const parsedPackTimeoutMs = Number.parseInt(
   process.env.AIOX_VALIDATE_PUBLISH_PACK_TIMEOUT_MS || '',
@@ -104,6 +109,22 @@ try {
     passed = false;
   } else {
     console.log('PASS: Public package excludes pro/ content');
+  }
+
+  const missingRequiredFiles = REQUIRED_PUBLIC_FILES.filter(
+    (filePath) => !packedFiles.includes(filePath),
+  );
+  if (missingRequiredFiles.length > 0) {
+    console.error(
+      `FAIL: Public package is missing ${missingRequiredFiles.length} required runtime file(s).`,
+    );
+    console.error('  Metrics CLI commands require these files at boot.');
+    for (const filePath of missingRequiredFiles) {
+      console.error(`  - ${filePath}`);
+    }
+    passed = false;
+  } else {
+    console.log('PASS: Public package includes metrics runtime files');
   }
 } catch (err) {
   console.error(`FAIL: npm pack --dry-run failed: ${err.message}`);

--- a/tests/cli/validate-publish.test.js
+++ b/tests/cli/validate-publish.test.js
@@ -30,6 +30,13 @@ describe('Publish Safety Gate (Story INS-4.10 / PRO-13.5)', () => {
       expect(scriptSource).toContain('Public package excludes pro/ content');
     });
 
+    test('script requires metrics runtime files in npm pack output', () => {
+      expect(scriptSource).toContain('REQUIRED_PUBLIC_FILES');
+      expect(scriptSource).toContain('.aiox-core/quality/metrics-collector.js');
+      expect(scriptSource).toContain('.aiox-core/quality/seed-metrics.js');
+      expect(scriptSource).toContain('Public package includes metrics runtime files');
+    });
+
     test('legacy npm notice parser strips size prefixes before path checks', () => {
       expect(scriptSource).toContain('npm notice\\s+[\\d.]+[kMG]?B?\\s+(.+)');
     });
@@ -116,6 +123,7 @@ describe('Publish Safety Gate (Story INS-4.10 / PRO-13.5)', () => {
       });
       expect(result).toContain('PUBLISH SAFETY GATE: PASS');
       expect(result).toContain('PASS: Public package excludes pro/ content');
+      expect(result).toContain('PASS: Public package includes metrics runtime files');
     });
 
     test('script produces human-readable output with pass/fail indicators', () => {


### PR DESCRIPTION
## Summary
- add an explicit publish safety-gate check for the metrics runtime files required by `.aiox-core/cli/commands/metrics/*`
- extend the publish-gate Jest coverage to assert the new required-file guard and PASS output

## Verification
- `npx jest tests\cli\validate-publish.test.js --runInBand`
- `node bin\utils\validate-publish.js`
- `git diff --check`

Notes from issue #782: the compatibility `aiox-core` package is a small wrapper, while the runtime metrics modules live in `@aiox-squads/core`. This PR makes the core package fail publish validation if those files are ever omitted from the tarball.

Closes #782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced package validation to verify all required runtime files are included in published npm packages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SynkraAI/aiox-core/pull/783?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->