### PR TITLE
fix(core): shell-level visual-terminal guard in pm.sh spawn_terminal (#802 follow-up)

### DIFF
--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.3.0
-generated_at: "2026-07-11T16:43:33.419Z"
+generated_at: "2026-07-11T17:07:50.052Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1164
 files:
@@ -4553,9 +4553,9 @@ files:
     type: script
     size: 9488
   - path: scripts/pm.sh
-    hash: sha256:5e066c431a20e8ff1be7c1d17ef04f0a76e9bcd82efa9cdd8e8887662a34d1e1
+    hash: sha256:dae90035d05e3756bc450526e6b7336625d017552d6809bb00012a2f525cd4b1
     type: script
-    size: 15321
+    size: 15958
   - path: scripts/README.md
     hash: sha256:4b0aa7d4664919c7d7b241b6451bd97bf07ca66e7e5f6d4b455e12e094d0e6ae
     type: script

--- a/.aiox-core/scripts/pm.sh
+++ b/.aiox-core/scripts/pm.sh
@@ -98,6 +98,9 @@ Environment Variables:
   AIOX_DEBUG         Enable debug mode (default: false)
   AIOX_TIMEOUT       Timeout in seconds (default: 300)
   AIOX_INLINE_MODE   Run without a visual terminal (default: false)
+  AIOX_NO_VISUAL_TERMINAL
+                     Never open a visual terminal, force inline (default: false;
+                     also implied by JEST_WORKER_ID, NODE_ENV=test, or CI=true)
   CLAUDE_CMD         Claude CLI command (default: claude)
   AIOX_MODEL_BUDGET_CEILING_USD
                      Required positive ceiling for automated model dispatch
@@ -482,7 +485,11 @@ spawn_terminal() {
   log_debug "Created lock file: $LOCK_FILE"
 
   # Check for inline mode (Story 12.10 - fallback for non-visual environments)
-  if [[ "$INLINE_MODE" == "true" ]]; then
+  # Shell-level defense in depth (#802 review follow-up): direct `bash pm.sh …`
+  # invocations bypass the Node spawner's detectEnvironment(), so mirror its
+  # guards here — test runners (JEST_WORKER_ID / NODE_ENV=test), CI, and the
+  # explicit AIOX_NO_VISUAL_TERMINAL opt-out must never open a real terminal.
+  if [[ "$INLINE_MODE" == "true" || -n "${JEST_WORKER_ID:-}" || "${NODE_ENV:-}" == "test" || "${CI:-false}" == "true" || "${AIOX_NO_VISUAL_TERMINAL:-false}" == "true" ]]; then
     local inline_result=0
     spawn_inline || inline_result=$?
     if [[ $inline_result -ne 0 ]]; then

--- a/tests/unit/terminal-spawner-shell-safety.test.js
+++ b/tests/unit/terminal-spawner-shell-safety.test.js
@@ -23,4 +23,22 @@ describe('terminal dispatch shell safety', () => {
     expect(source).not.toContain('full_cmd+=" ${PARAMS}"');
     expect(source).toContain('osascript - "$cmd"');
   });
+
+  it('guards spawn_terminal at the shell level against test/CI/no-visual environments (#802 follow-up)', () => {
+    // Direct `bash pm.sh …` invocations bypass the Node spawner's
+    // detectEnvironment(); the shell guard must mirror it so a test runner,
+    // CI, or an explicit opt-out can never open a real terminal window.
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../.aiox-core/scripts/pm.sh'),
+      'utf8',
+    );
+    const guard = source
+      .split('\n')
+      .find((line) => line.includes('if [[') && line.includes('$INLINE_MODE'));
+    expect(guard).toBeDefined();
+    expect(guard).toContain('JEST_WORKER_ID');
+    expect(guard).toContain('NODE_ENV');
+    expect(guard).toContain('${CI:-false}');
+    expect(guard).toContain('AIOX_NO_VISUAL_TERMINAL');
+  });
 });


### PR DESCRIPTION
Implements the single non-blocking follow-up from the #802 review (cc @oalanicolas):

> **`pm.sh` `spawn_terminal()` still only checks `INLINE_MODE` at the shell level.** Anyone invoking `bash pm.sh dev test` DIRECTLY (not via the Node spawner) from a native macOS shell — a script, a doc example, a future test — still opens a real Terminal window.

## What

- **`pm.sh` `spawn_terminal()`**: the shell guard now mirrors the Node spawner's `detectEnvironment()` — forces the inline path when `JEST_WORKER_ID` is set, `NODE_ENV=test`, `CI=true`, or `AIOX_NO_VISUAL_TERMINAL=true` (in addition to the existing `AIOX_INLINE_MODE`). Defense in depth: the Node layer keeps covering Node callers; the shell layer now covers direct invocations.
- **`pm.sh --help`**: documents `AIOX_NO_VISUAL_TERMINAL` + the implied signals in the env-vars section (as the review asked).
- **Sentinel test** in `tests/unit/terminal-spawner-shell-safety.test.js` locks the guard in (same source-assertion pattern as the existing shell-safety sentinels).

## Verification (native macOS — the exact field scenario)

```
AIOX_NO_VISUAL_TERMINAL=true -> exit=5 | [INFO] Running in inline mode (no visual terminal)
JEST_WORKER_ID=1             -> exit=5 | [INFO] Running in inline mode (no visual terminal)
NODE_ENV=test                -> exit=5 | [INFO] Running in inline mode (no visual terminal)
CI=true                      -> exit=5 | [INFO] Running in inline mode (no visual terminal)
```

Each direct `bash pm.sh dev <task>` run under a guard signal routed inline and hit the dispatch-governance gate (exit 5, no model call) — **zero Terminal windows opened**. `bash -n` clean, sentinel suite 3/3 green, ESLint clean. No behavior change for interactive human invocations (no guard signal → visual terminal as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to prevent visual terminal windows from opening, enabling inline command execution.

* **Bug Fixes**
  * Terminal commands now automatically run inline in test and continuous integration environments, improving reliability and preventing unexpected terminal windows.

* **Tests**
  * Added coverage to verify terminal safety across supported inline-execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->