### PR TITLE
fix: route environment-bootstrap to @devops and gate greenfield guard

### DIFF
--- a/.aiox-core/development/agents/aiox-master.md
+++ b/.aiox-core/development/agents/aiox-master.md
@@ -30,8 +30,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.aiox-core/development/agents/analyst.md
+++ b/.aiox-core/development/agents/analyst.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.aiox-core/development/agents/architect.md
+++ b/.aiox-core/development/agents/architect.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.aiox-core/development/agents/data-engineer.md
+++ b/.aiox-core/development/agents/data-engineer.md
@@ -22,8 +22,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.aiox-core/development/agents/dev.md
+++ b/.aiox-core/development/agents/dev.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.aiox-core/development/agents/devops.md
+++ b/.aiox-core/development/agents/devops.md
@@ -22,8 +22,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.aiox-core/development/agents/pm.md
+++ b/.aiox-core/development/agents/pm.md
@@ -35,8 +35,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.aiox-core/development/agents/po.md
+++ b/.aiox-core/development/agents/po.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.aiox-core/development/agents/qa.md
+++ b/.aiox-core/development/agents/qa.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.aiox-core/development/agents/sm.md
+++ b/.aiox-core/development/agents/sm.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.aiox-core/development/agents/squad-creator.md
+++ b/.aiox-core/development/agents/squad-creator.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.aiox-core/development/agents/ux-design-expert.md
+++ b/.aiox-core/development/agents/ux-design-expert.md
@@ -26,8 +26,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -8,7 +8,7 @@
 # - File types for categorization
 #
 version: 5.2.9
-generated_at: "2026-05-21T13:48:41.292Z"
+generated_at: "2026-07-26T21:13:40.348Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1129
 files:
@@ -1401,89 +1401,89 @@ files:
     type: development
     size: 5012
   - path: development/agents/aiox-master.md
-    hash: sha256:66175a22e6982e5c0f4123f84af8388eb0cfc81124b8e9ec8f44d502c4ca6cf8
+    hash: sha256:75a8577cb10035441f9e9917286b4c0abb3299f9ca505155046b828c5be025d0
     type: agent
-    size: 21023
+    size: 21453
   - path: development/agents/analyst.md
-    hash: sha256:35150d764c6dc74bc02b61a4d613c9278e87ffb209403db23991339fdda4f8e2
+    hash: sha256:453f239b05f94e9b5c0650e895213ae25673fe7097323471efd507efb04fcc18
     type: agent
-    size: 11758
+    size: 12188
   - path: development/agents/analyst/MEMORY.md
     hash: sha256:b8b52820ba1929ba12403fc437868dd9e8a9c2532abe99296ad05864618693b0
     type: agent
     size: 1254
   - path: development/agents/architect.md
-    hash: sha256:c45b1e71af39b5da34a832dcc3d1c9b41b6270de61f79d4bada3c27b46be19df
+    hash: sha256:428e1906b046a4bcb2af94afc7994f9143c860459e14e641c40173db4065c1c9
     type: agent
-    size: 21210
+    size: 21640
   - path: development/agents/architect/MEMORY.md
     hash: sha256:ee99a68876311e0dc67e0b77ff11f8fa2154f0803f27f4aa89db36df50753d3b
     type: agent
     size: 1385
   - path: development/agents/data-engineer.md
-    hash: sha256:4b921018c23721c6f71a5d23b6495d254f260cd85406db5915f034a90d17c845
+    hash: sha256:2c978db47dfd66af6a70ee817bf600a080ac8223c416003fd065162ea87ffada
     type: agent
-    size: 22440
+    size: 22870
   - path: development/agents/data-engineer/MEMORY.md
     hash: sha256:20024028651bf2078bf4e58e38aaa84191521ef9b5c11b044eb152a026ec8412
     type: agent
     size: 1106
   - path: development/agents/dev.md
-    hash: sha256:91a63332b1cc19af47b3cd2811b5e00635b72a747b5858efc09ce3aa7826d1b7
+    hash: sha256:8dee31ecfd78122a71d90d1963453d9d913610896cd56c7b494f553ff6a26aa9
     type: agent
-    size: 25645
+    size: 26075
   - path: development/agents/dev/MEMORY.md
     hash: sha256:7c6197418798fa00617f63f93ea6e87dbbbc1bebdb1fb92276433cb7990fd7c0
     type: agent
     size: 2486
   - path: development/agents/devops.md
-    hash: sha256:fb4555b484be4b93e11ed1e974b3e904ba7cddecb01ce44ac26828c7e8a8e382
+    hash: sha256:bd49df08f938ae032024699e1f15f2c297b6aabf8551574de139ec1edcf6d4bb
     type: agent
-    size: 27902
+    size: 28324
   - path: development/agents/devops/MEMORY.md
     hash: sha256:eb2ee887047c94db3441126cd0198cac44cec779026d7842a3a1c7eba936027f
     type: agent
     size: 1398
   - path: development/agents/pm.md
-    hash: sha256:8c81fd9b6df9b98fa3d3654062464498396ddb4eaf0b6dc3a644ae4227982f4b
+    hash: sha256:c50e11fc8b191fec17d133b8f1fe4cf9d06d982947c6bf40ff1e82f8f477ce67
     type: agent
-    size: 16696
+    size: 17126
   - path: development/agents/pm/MEMORY.md
     hash: sha256:6a8a5661a32cdf440a21531004ad64767da700b70ff8483faddfb7bcde937f2b
     type: agent
     size: 1220
   - path: development/agents/po.md
-    hash: sha256:f0090329fd2c2871d3b46d0b2ea1bb9ff3fe48c589fc25ed3d90cf2032621cfd
+    hash: sha256:7a58c3c69a0329322a11d4250c285ff174f6beaa163c544fe618f4b693a2b6d5
     type: agent
-    size: 14338
+    size: 14768
   - path: development/agents/po/MEMORY.md
     hash: sha256:4295cbf549671ec6a267bef05871d66fffeb6b898ada166ab1663f7d03632354
     type: agent
     size: 1376
   - path: development/agents/qa.md
-    hash: sha256:506a44a6828ce6e0bc2fc89aaaced9df54fefea293525e5c1ce2e3bc37661c90
+    hash: sha256:7aecc47aeff9a53a1416a6d845f07a898686e05cbec1a011760699e521951cd7
     type: agent
-    size: 20013
+    size: 20443
   - path: development/agents/qa/MEMORY.md
     hash: sha256:eec482f057d09635940e9a46bdd6cbb677af12dc4deed64bf71196d551b93abf
     type: agent
     size: 1367
   - path: development/agents/sm.md
-    hash: sha256:b09334044d3ba581f5403d5d15e0d35c25e580634e712f24bb5a1bc73c9d1cf3
+    hash: sha256:1ba32cc57cdc251af3e82159e844f41fe2cf157797f1a07ffa494b0869494611
     type: agent
-    size: 12664
+    size: 13094
   - path: development/agents/sm/MEMORY.md
     hash: sha256:4abaa92d85f4574a79a308f098e9ae719c28f72101e746f2a574ad92e120dcf4
     type: agent
     size: 1123
   - path: development/agents/squad-creator.md
-    hash: sha256:9ae479d628a74fdf8372da4e5a306fdc93235bce8f4957b44ad9adc76643f8e1
+    hash: sha256:57020f4710071855459fca4726392b219e96026275fab0084e9869806d0e9836
     type: agent
-    size: 13894
+    size: 14324
   - path: development/agents/ux-design-expert.md
-    hash: sha256:b6a552405cf1a1eab76e307a505e8b431bffa30ab9681a16169b1427373b8a99
+    hash: sha256:4434bebc0f8e511d3cf83782a35bfb95106bf66b1572b2ad4ee7e9d1d3aa4146
     type: agent
-    size: 19995
+    size: 20425
   - path: development/agents/ux/MEMORY.md
     hash: sha256:39e36c9af4aa959fb547152bed812954c33a4c6c8d1a5aababd49052f229fde6
     type: agent
@@ -2719,19 +2719,19 @@ files:
   - path: development/templates/service-template/__tests__/index.test.ts.hbs
     hash: sha256:4617c189e75ab362d4ef2cabcc3ccce3480f914fd915af550469c17d1b68a4fe
     type: template
-    size: 9573
+    size: 9810
   - path: development/templates/service-template/client.ts.hbs
     hash: sha256:f342c60695fe611192002bdb8c04b3a0dbce6345b7fa39834ea1898f71689198
     type: template
-    size: 11810
+    size: 12213
   - path: development/templates/service-template/errors.ts.hbs
     hash: sha256:e0be40d8be19b71b26e35778eadffb20198e7ca88e9d140db9da1bfe12de01ec
     type: template
-    size: 5213
+    size: 5395
   - path: development/templates/service-template/index.ts.hbs
     hash: sha256:d44012d54b76ab98356c7163d257ca939f7fed122f10fecf896fe1e7e206d10a
     type: template
-    size: 3086
+    size: 3206
   - path: development/templates/service-template/jest.config.js
     hash: sha256:1681bfd7fbc0d330d3487d3427515847c4d57ef300833f573af59e0ad69ed159
     type: template
@@ -2739,11 +2739,11 @@ files:
   - path: development/templates/service-template/package.json.hbs
     hash: sha256:d89d35f56992ee95c2ceddf17fa1d455c18007a4d24af914ba83cf4abc38bca9
     type: template
-    size: 2227
+    size: 2314
   - path: development/templates/service-template/README.md.hbs
     hash: sha256:2c3dd4c2bf6df56b9b6db439977be7e1cc35820438c0e023140eccf6ccd227a0
     type: template
-    size: 3426
+    size: 3584
   - path: development/templates/service-template/tsconfig.json
     hash: sha256:8b465fcbdd45c4d6821ba99aea62f2bd7998b1bca8de80486a1525e77d43c9a1
     type: template
@@ -2751,7 +2751,7 @@ files:
   - path: development/templates/service-template/types.ts.hbs
     hash: sha256:3e52e0195003be8cd1225a3f27f4d040686c8b8c7762f71b41055f04cd1b841b
     type: template
-    size: 2516
+    size: 2661
   - path: development/templates/squad-template/agents/example-agent.yaml
     hash: sha256:824a1b349965e5d4ae85458c231b78260dc65497da75dada25b271f2cabbbe67
     type: agent
@@ -2759,7 +2759,7 @@ files:
   - path: development/templates/squad-template/LICENSE
     hash: sha256:ff7017aa403270cf2c440f5ccb4240d0b08e54d8bf8a0424d34166e8f3e10138
     type: template
-    size: 1071
+    size: 1092
   - path: development/templates/squad-template/package.json
     hash: sha256:8f68627a0d74e49f94ae382d0c2b56ecb5889d00f3095966c742fb5afaf363db
     type: template
@@ -3523,11 +3523,11 @@ files:
   - path: infrastructure/templates/aiox-sync.yaml.template
     hash: sha256:0040ad8a9e25716a28631b102c9448b72fd72e84f992c3926eb97e9e514744bb
     type: template
-    size: 8385
+    size: 8567
   - path: infrastructure/templates/coderabbit.yaml.template
     hash: sha256:91a4a76bbc40767a4072fb6a87c480902bb800cfb0a11e9fc1b3183d8f7f3a80
     type: template
-    size: 8042
+    size: 8321
   - path: infrastructure/templates/core-config/core-config-brownfield.tmpl.yaml
     hash: sha256:9bdb0c0e09c765c991f9f142921f7f8e2c0d0ada717f41254161465dc0622d02
     type: template
@@ -3539,11 +3539,11 @@ files:
   - path: infrastructure/templates/github-workflows/ci.yml.template
     hash: sha256:acbfa2a8a84141fd6a6b205eac74719772f01c221c0afe22ce951356f06a605d
     type: template
-    size: 4920
+    size: 5089
   - path: infrastructure/templates/github-workflows/pr-automation.yml.template
     hash: sha256:c236077b4567965a917e48df9a91cc42153ff97b00a9021c41a7e28179be9d0f
     type: template
-    size: 10609
+    size: 10939
   - path: infrastructure/templates/github-workflows/README.md
     hash: sha256:6b7b5cb32c28b3e562c81a96e2573ea61849b138c93ccac6e93c3adac26cadb5
     type: template
@@ -3551,23 +3551,23 @@ files:
   - path: infrastructure/templates/github-workflows/release.yml.template
     hash: sha256:b771145e61a254a88dc6cca07869e4ece8229ce18be87132f59489cdf9a66ec6
     type: template
-    size: 6595
+    size: 6791
   - path: infrastructure/templates/gitignore/gitignore-aiox-base.tmpl
     hash: sha256:9088975ee2bf4d88e23db6ac3ea5d27cccdc72b03db44450300e2f872b02e935
     type: template
-    size: 788
+    size: 851
   - path: infrastructure/templates/gitignore/gitignore-brownfield-merge.tmpl
     hash: sha256:ce4291a3cf5677050c9dafa320809e6b0ca5db7e7f7da0382d2396e32016a989
     type: template
-    size: 488
+    size: 506
   - path: infrastructure/templates/gitignore/gitignore-node.tmpl
     hash: sha256:5179f78de7483274f5d7182569229088c71934db1fd37a63a40b3c6b815c9c8e
     type: template
-    size: 951
+    size: 1036
   - path: infrastructure/templates/gitignore/gitignore-python.tmpl
     hash: sha256:d7aac0b1e6e340b774a372a9102b4379722588449ca82ac468cf77804bbc1e55
     type: template
-    size: 1580
+    size: 1725
   - path: infrastructure/templates/project-docs/coding-standards-tmpl.md
     hash: sha256:377acf85463df8ac9923fc59d7cfeba68a82f8353b99948ea1d28688e88bc4a9
     type: template
@@ -3663,43 +3663,43 @@ files:
   - path: monitor/hooks/lib/__init__.py
     hash: sha256:bfab6ee249c52f412c02502479da649b69d044938acaa6ab0aa39dafe6dee9bf
     type: monitor
-    size: 29
+    size: 30
   - path: monitor/hooks/lib/enrich.py
     hash: sha256:20dfa73b4b20d7a767e52c3ec90919709c4447c6e230902ba797833fc6ddc22c
     type: monitor
-    size: 1644
+    size: 1702
   - path: monitor/hooks/lib/send_event.py
     hash: sha256:59d61311f718fb373a5cf85fd7a01c23a4fd727e8e022ad6930bba533ef4615d
     type: monitor
-    size: 1190
+    size: 1237
   - path: monitor/hooks/notification.py
     hash: sha256:8a1a6ce0ff2b542014de177006093b9caec9b594e938a343dc6bd62df2504f22
     type: monitor
-    size: 499
+    size: 528
   - path: monitor/hooks/post_tool_use.py
     hash: sha256:47dbe37073d432c55657647fc5b907ddb56efa859d5c3205e8362aa916d55434
     type: monitor
-    size: 1140
+    size: 1185
   - path: monitor/hooks/pre_compact.py
     hash: sha256:f287cf45e83deed6f1bc0e30bd9348dfa1bf08ad770c5e58bb34e3feb210b30b
     type: monitor
-    size: 500
+    size: 529
   - path: monitor/hooks/pre_tool_use.py
     hash: sha256:a4d1d3ffdae9349e26a383c67c9137effff7d164ac45b2c87eea9fa1ab0d6d98
     type: monitor
-    size: 981
+    size: 1021
   - path: monitor/hooks/stop.py
     hash: sha256:edb382f0cf46281a11a8588bc20eafa7aa2b5cc3f4ad775d71b3d20a7cfab385
     type: monitor
-    size: 490
+    size: 519
   - path: monitor/hooks/subagent_stop.py
     hash: sha256:fa5357309247c71551dba0a19f28dd09bebde749db033d6657203b50929c0a42
     type: monitor
-    size: 512
+    size: 541
   - path: monitor/hooks/user_prompt_submit.py
     hash: sha256:af57dca79ef55cdf274432f4abb4c20a9778b95e107ca148f47ace14782c5828
     type: monitor
-    size: 818
+    size: 856
   - path: package.json
     hash: sha256:d8dbe037240a366d545ca4259d2059e705b709706dcf2a18a5a52d9b543b7ed9
     type: other
@@ -3847,7 +3847,7 @@ files:
   - path: product/templates/adr.hbs
     hash: sha256:d68653cae9e64414ad4f58ea941b6c6e337c5324c2c7247043eca1461a652d10
     type: template
-    size: 2212
+    size: 2337
   - path: product/templates/agent-template.yaml
     hash: sha256:98676fcc493c0d5f09264dcc52fcc2cf1129f9a195824ecb4c2ec035c2515121
     type: template
@@ -3899,7 +3899,7 @@ files:
   - path: product/templates/dbdr.hbs
     hash: sha256:5a2781ffaa3da9fc663667b5a63a70b7edfc478ed14cad02fc6ed237ff216315
     type: template
-    size: 4139
+    size: 4380
   - path: product/templates/design-story-tmpl.yaml
     hash: sha256:2bfefc11ae2bcfc679dbd924c58f8b764fa23538c14cb25344d6edef41968f29
     type: template
@@ -3963,7 +3963,7 @@ files:
   - path: product/templates/epic.hbs
     hash: sha256:dcbcc26f6dd8f3782b3ef17aee049b689f1d6d92931615c3df9513eca0de2ef7
     type: template
-    size: 3868
+    size: 4080
   - path: product/templates/eslintrc-security.json
     hash: sha256:657d40117261d6a52083984d29f9f88e79040926a64aa4c2058a602bfe91e0d5
     type: template
@@ -4071,7 +4071,7 @@ files:
   - path: product/templates/pmdr.hbs
     hash: sha256:d529cebbb562faa82c70477ece70de7cda871eaa6896f2962b48b2a8b67b1cbe
     type: template
-    size: 3239
+    size: 3425
   - path: product/templates/prd-tmpl.yaml
     hash: sha256:25c239f40e05f24aee1986601a98865188dbe3ea00a705028efc3adad6d420f3
     type: template
@@ -4079,11 +4079,11 @@ files:
   - path: product/templates/prd-v2.0.hbs
     hash: sha256:21a20ef5333a85a11f5326d35714e7939b51bab22bd6e28d49bacab755763bea
     type: template
-    size: 4512
+    size: 4728
   - path: product/templates/prd.hbs
     hash: sha256:4a1a030a5388c6a8bf2ce6ea85e54cae6cf1fe64f1bb2af7f17d349d3c24bf1d
     type: template
-    size: 3425
+    size: 3626
   - path: product/templates/project-brief-tmpl.yaml
     hash: sha256:b8d388268c24dc5018f48a87036d591b11cb122fafe9b59c17809b06ea5d9d58
     type: template
@@ -4131,7 +4131,7 @@ files:
   - path: product/templates/story.hbs
     hash: sha256:3f0ac8b39907634a2b53f43079afc33663eee76f46e680d318ff253e0befc2c4
     type: template
-    size: 5583
+    size: 5846
   - path: product/templates/task-execution-report.md
     hash: sha256:e0f08a3e199234f3d2207ba8f435786b7d8e1b36174f46cb82fc3666b9a9309e
     type: template
@@ -4143,67 +4143,67 @@ files:
   - path: product/templates/task.hbs
     hash: sha256:621e987e142c455cd290dc85d990ab860faa0221f66cf1f57ac296b076889ea5
     type: template
-    size: 2705
+    size: 2875
   - path: product/templates/tmpl-comment-on-examples.sql
     hash: sha256:254002c3fbc63cfcc5848b1d4b15822ce240bf5f57e6a1c8bb984e797edc2691
     type: template
-    size: 6215
+    size: 6373
   - path: product/templates/tmpl-migration-script.sql
     hash: sha256:44ef63ea475526d21a11e3c667c9fdb78a9fddace80fdbaa2312b7f2724fbbb5
     type: template
-    size: 2947
+    size: 3038
   - path: product/templates/tmpl-rls-granular-policies.sql
     hash: sha256:36c2fd8c6d9eebb5d164acb0fb0c87bc384d389264b4429ce21e77e06318f5f3
     type: template
-    size: 3322
+    size: 3426
   - path: product/templates/tmpl-rls-kiss-policy.sql
     hash: sha256:5210d37fce62e5a9a00e8d5366f5f75653cd518be73fbf96333ed8a6712453c7
     type: template
-    size: 299
+    size: 309
   - path: product/templates/tmpl-rls-roles.sql
     hash: sha256:2d032a608a8e87440c3a430c7d69ddf9393d8813d8d4129270f640dd847425c3
     type: template
-    size: 4592
+    size: 4727
   - path: product/templates/tmpl-rls-simple.sql
     hash: sha256:f67af0fa1cdd2f2af9eab31575ac3656d82457421208fd9ccb8b57ca9785275e
     type: template
-    size: 2915
+    size: 2992
   - path: product/templates/tmpl-rls-tenant.sql
     hash: sha256:36629ed87a2c72311809cc3fb96298b6f38716bba35bc56c550ac39d3321757a
     type: template
-    size: 4978
+    size: 5130
   - path: product/templates/tmpl-rollback-script.sql
     hash: sha256:8b84046a98f1163faf7350322f43831447617c5a63a94c88c1a71b49804e022b
     type: template
-    size: 2657
+    size: 2734
   - path: product/templates/tmpl-seed-data.sql
     hash: sha256:a65e73298f46cd6a8e700f29b9d8d26e769e12a57751a943a63fd0fe15768615
     type: template
-    size: 5576
+    size: 5716
   - path: product/templates/tmpl-smoke-test.sql
     hash: sha256:aee7e48bb6d9c093769dee215cacc9769939501914e20e5ea8435b25fad10f3c
     type: template
-    size: 723
+    size: 739
   - path: product/templates/tmpl-staging-copy-merge.sql
     hash: sha256:55988caeb47cc04261665ba7a37f4caa2aa5fac2e776fdbc5964e0587af24450
     type: template
-    size: 4081
+    size: 4220
   - path: product/templates/tmpl-stored-proc.sql
     hash: sha256:2b205ff99dc0adfade6047a4d79f5b50109e50ceb45386e5c886437692c7a2a3
     type: template
-    size: 3839
+    size: 3979
   - path: product/templates/tmpl-trigger.sql
     hash: sha256:93abdc92e1b475d1370094e69a9d1b18afd804da6acb768b878355c798bd8e0e
     type: template
-    size: 5272
+    size: 5424
   - path: product/templates/tmpl-view-materialized.sql
     hash: sha256:47935510f03d4ad9b2200748e65441ce6c2d6a7c74750395eca6831d77c48e91
     type: template
-    size: 4363
+    size: 4496
   - path: product/templates/tmpl-view.sql
     hash: sha256:22557b076003a856b32397f05fa44245a126521de907058a95e14dd02da67aff
     type: template
-    size: 4916
+    size: 5093
   - path: product/templates/token-exports-css-tmpl.css
     hash: sha256:d937b8d61cdc9e5b10fdff871c6cb41c9f756004d060d671e0ae26624a047f62
     type: template

--- a/.claude/skills/AIOX/agents/aiox-master/SKILL.md
+++ b/.claude/skills/AIOX/agents/aiox-master/SKILL.md
@@ -40,8 +40,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.claude/skills/AIOX/agents/analyst/SKILL.md
+++ b/.claude/skills/AIOX/agents/analyst/SKILL.md
@@ -31,8 +31,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.claude/skills/AIOX/agents/architect/SKILL.md
+++ b/.claude/skills/AIOX/agents/architect/SKILL.md
@@ -31,8 +31,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.claude/skills/AIOX/agents/data-engineer/SKILL.md
+++ b/.claude/skills/AIOX/agents/data-engineer/SKILL.md
@@ -32,8 +32,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.claude/skills/AIOX/agents/dev/SKILL.md
+++ b/.claude/skills/AIOX/agents/dev/SKILL.md
@@ -31,8 +31,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.claude/skills/AIOX/agents/devops/SKILL.md
+++ b/.claude/skills/AIOX/agents/devops/SKILL.md
@@ -32,8 +32,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.claude/skills/AIOX/agents/pm/SKILL.md
+++ b/.claude/skills/AIOX/agents/pm/SKILL.md
@@ -45,8 +45,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.claude/skills/AIOX/agents/po/SKILL.md
+++ b/.claude/skills/AIOX/agents/po/SKILL.md
@@ -31,8 +31,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.claude/skills/AIOX/agents/qa/SKILL.md
+++ b/.claude/skills/AIOX/agents/qa/SKILL.md
@@ -31,8 +31,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.claude/skills/AIOX/agents/sm/SKILL.md
+++ b/.claude/skills/AIOX/agents/sm/SKILL.md
@@ -31,8 +31,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.claude/skills/AIOX/agents/squad-creator/SKILL.md
+++ b/.claude/skills/AIOX/agents/squad-creator/SKILL.md
@@ -31,8 +31,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.claude/skills/AIOX/agents/ux-design-expert/SKILL.md
+++ b/.claude/skills/AIOX/agents/ux-design-expert/SKILL.md
@@ -36,8 +36,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.codex/agents/aiox-master.md
+++ b/.codex/agents/aiox-master.md
@@ -30,8 +30,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.codex/agents/analyst.md
+++ b/.codex/agents/analyst.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.codex/agents/architect.md
+++ b/.codex/agents/architect.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.codex/agents/data-engineer.md
+++ b/.codex/agents/data-engineer.md
@@ -22,8 +22,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.codex/agents/dev.md
+++ b/.codex/agents/dev.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.codex/agents/devops.md
+++ b/.codex/agents/devops.md
@@ -22,8 +22,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.codex/agents/pm.md
+++ b/.codex/agents/pm.md
@@ -35,8 +35,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.codex/agents/po.md
+++ b/.codex/agents/po.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.codex/agents/qa.md
+++ b/.codex/agents/qa.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.codex/agents/sm.md
+++ b/.codex/agents/sm.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.codex/agents/squad-creator.md
+++ b/.codex/agents/squad-creator.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.codex/agents/ux-design-expert.md
+++ b/.codex/agents/ux-design-expert.md
@@ -26,8 +26,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.gemini/rules/AIOX/agents/aiox-master.md
+++ b/.gemini/rules/AIOX/agents/aiox-master.md
@@ -30,8 +30,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.gemini/rules/AIOX/agents/analyst.md
+++ b/.gemini/rules/AIOX/agents/analyst.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.gemini/rules/AIOX/agents/architect.md
+++ b/.gemini/rules/AIOX/agents/architect.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.gemini/rules/AIOX/agents/data-engineer.md
+++ b/.gemini/rules/AIOX/agents/data-engineer.md
@@ -22,8 +22,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.gemini/rules/AIOX/agents/dev.md
+++ b/.gemini/rules/AIOX/agents/dev.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.gemini/rules/AIOX/agents/devops.md
+++ b/.gemini/rules/AIOX/agents/devops.md
@@ -22,8 +22,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.gemini/rules/AIOX/agents/pm.md
+++ b/.gemini/rules/AIOX/agents/pm.md
@@ -35,8 +35,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.gemini/rules/AIOX/agents/po.md
+++ b/.gemini/rules/AIOX/agents/po.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.gemini/rules/AIOX/agents/qa.md
+++ b/.gemini/rules/AIOX/agents/qa.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.gemini/rules/AIOX/agents/sm.md
+++ b/.gemini/rules/AIOX/agents/sm.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.gemini/rules/AIOX/agents/squad-creator.md
+++ b/.gemini/rules/AIOX/agents/squad-creator.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.gemini/rules/AIOX/agents/ux-design-expert.md
+++ b/.gemini/rules/AIOX/agents/ux-design-expert.md
@@ -26,8 +26,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.kimi/skills/aiox-analyst/SKILL.md
+++ b/.kimi/skills/aiox-analyst/SKILL.md
@@ -76,8 +76,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.kimi/skills/aiox-architect/SKILL.md
+++ b/.kimi/skills/aiox-architect/SKILL.md
@@ -83,8 +83,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.kimi/skills/aiox-data-engineer/SKILL.md
+++ b/.kimi/skills/aiox-data-engineer/SKILL.md
@@ -91,8 +91,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.kimi/skills/aiox-dev/SKILL.md
+++ b/.kimi/skills/aiox-dev/SKILL.md
@@ -105,8 +105,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.kimi/skills/aiox-devops/SKILL.md
+++ b/.kimi/skills/aiox-devops/SKILL.md
@@ -106,8 +106,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.kimi/skills/aiox-master/SKILL.md
+++ b/.kimi/skills/aiox-master/SKILL.md
@@ -109,8 +109,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.kimi/skills/aiox-pm/SKILL.md
+++ b/.kimi/skills/aiox-pm/SKILL.md
@@ -92,8 +92,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.kimi/skills/aiox-po/SKILL.md
+++ b/.kimi/skills/aiox-po/SKILL.md
@@ -80,8 +80,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.kimi/skills/aiox-qa/SKILL.md
+++ b/.kimi/skills/aiox-qa/SKILL.md
@@ -87,8 +87,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.kimi/skills/aiox-sm/SKILL.md
+++ b/.kimi/skills/aiox-sm/SKILL.md
@@ -69,8 +69,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.kimi/skills/aiox-squad-creator/SKILL.md
+++ b/.kimi/skills/aiox-squad-creator/SKILL.md
@@ -84,8 +84,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/.kimi/skills/aiox-ux-design-expert/SKILL.md
+++ b/.kimi/skills/aiox-ux-design-expert/SKILL.md
@@ -108,8 +108,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend bootstrap
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"


### PR DESCRIPTION
## 📋 Description

The `GREENFIELD GUARD` in the activation instructions had two defects that surfaced when an agent was activated from a directory that is not a git repository (a user home directory, in this case):

1. **Agent Authority violation (Constitution Article II).** The guard told the user to run `*environment-bootstrap` — a **@devops-exclusive** command — from 11 agents that do not own it (`aiox-master`, `dev`, `qa`, `pm`, `po`, `sm`, `architect`, `analyst`, `data-engineer`, `ux-design-expert`, `squad-creator`).
2. **False positive in any non-project directory.** Because the trigger is only "not a git repository", activating from `C:\Users\{name}` produced a bootstrap recommendation whose task would run `git init` over the user's entire profile (Documents, Downloads, `.ssh`, …). It also labelled that directory a "Greenfield project", which it is not.

## 🎯 AIOX Story Reference

**Story ID:** none — defect found during live agent activation, not from a story.

## 📦 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🎯 Scope
- [x] Core framework (`aiox-core/`)
- [x] Other: IDE derivatives (`.claude`, `.codex`, `.gemini`, `.kimi`)

## 📝 Changes Made

- 11 agents now **delegate**: `@devops *environment-bootstrap`. `devops.md` keeps the direct `*environment-bootstrap` call, since it owns the command.
- The guard now decides from the working directory path **already present in the system prompt** (zero extra I/O at activation, honouring "do NOT scan filesystem during startup"):
  - home directory (`C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any non-project directory → shows a tip to activate from inside the project directory, and does **not** recommend bootstrap;
  - an actual project directory → recommends `@devops *environment-bootstrap` as before.
- Status line changed from `Greenfield project — no git repository detected` to `No git repository detected in the working directory`.
- IDE derivatives regenerated with `npm run sync:ide`. `.cursor` and `.antigravity` are untouched **by design** — their condensed format does not carry `activation-instructions`, so they never had the guard.

## 🧪 Testing

- `npm run validate:agents` → **12 agents, 0 errors** (121 warnings are pre-existing missing `checklists/`+`data/` dependencies, unrelated to this change).
- `npm run lint` → **PASS**
- `npm run typecheck` → **PASS**
- `npm test` → 14 suites / 222 tests failing, **identical to the `main` baseline** (verified by running the full suite on `main` before and on this branch after: `14 failed, 341 passed` both times). No regression introduced. The greeting suites (`greeting-preference-manager`, `greeting-preference`) were checked specifically on both refs: 21 failures on each, unchanged. Most failures stem from CodeRabbit CLI/WSL expectations on a Windows host.
- Manual: not exercised end-to-end, since it changes activation-time instruction text rather than executable code.

## ⚠️ Note for maintainers

Unrelated defect found while committing this, worth its own issue: the **IDS post-commit/pre-push hook rewrites `.aiox-core/data/entity-registry.yaml` destructively**, emptying `usedBy: []` across hundreds of entities (230 insertions vs **818 deletions** on a commit touching only 12 agents) — it appears to process only the entities touched by the commit and rebuild the graph from scratch. That diff was **deliberately excluded** from this PR and reverted locally; the registry here is untouched. Left as-is for the maintainers to triage, since the versioned registry feeds IDS impact analysis and gates G1–G6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved guidance when no Git repository is detected.
  * Activation now distinguishes home or non-project directories from actual project directories.
  * Users in non-project directories are advised to activate from the correct project location.
  * Project directories receive a clearer environment-bootstrap recommendation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->