### PR TITLE
fix: standardize greenfield guard across claude-code-mastery squad agents

### DIFF
--- a/squads/claude-code-mastery/agents/claude-mastery-chief.md
+++ b/squads/claude-code-mastery/agents/claude-mastery-chief.md
@@ -20,8 +20,9 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "Project Status: Greenfield project — no git repository detected" instead of git narrative
-         - Do NOT run any git commands during activation
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, if the working directory is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory — decided from the path already in the system prompt, zero I/O: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory."
+         - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode
       2. Show: "**Role:** {persona.role}"
          - Append: "Story: {active story from docs/stories/}" if detected + "Branch: `{branch}`" if not main/master

--- a/squads/claude-code-mastery/agents/config-engineer.md
+++ b/squads/claude-code-mastery/agents/config-engineer.md
@@ -21,9 +21,11 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "**Project Status:** Greenfield project -- no git repository detected" instead of git narrative
-         - After substep 6: show "**Recommended:** Run `*configure` to bootstrap Claude Code settings for this project"
-         - Do NOT run any git commands during activation -- they will fail and produce errors
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend a project command
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `*configure` to bootstrap Claude Code settings for this project"
+         - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [Ask], [Auto], [Explore])
       2. Show: "**Role:** {persona.role}"
          - Append: "Story: {active story from docs/stories/}" if detected + "Branch: `{branch from gitStatus}`" if not main/master

--- a/squads/claude-code-mastery/agents/hooks-architect.md
+++ b/squads/claude-code-mastery/agents/hooks-architect.md
@@ -21,9 +21,11 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "**Project Status:** Greenfield project -- no git repository detected" instead of git narrative
-         - After substep 6: show "**Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
-         - Do NOT run any git commands during activation -- they will fail and produce errors
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend a project command
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [Ask], [Auto], [Explore])
       2. Show: "**Role:** {persona.role}"
          - Append: "Story: {active story from docs/stories/}" if detected + "Branch: `{branch from gitStatus}`" if not main/master

--- a/squads/claude-code-mastery/agents/mcp-integrator.md
+++ b/squads/claude-code-mastery/agents/mcp-integrator.md
@@ -21,9 +21,11 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "Project Status: Greenfield project -- no git repository detected" instead of git narrative
-         - After substep 6: show "Recommended: Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
-         - Do NOT run any git commands during activation -- they will fail and produce errors
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend a project command
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [Ask], [Auto], [Explore])
       2. Show: "**Role:** {persona.role}"
          - Append: "Story: {active story from docs/stories/}" if detected + "Branch: `{branch from gitStatus}`" if not main/master

--- a/squads/claude-code-mastery/agents/project-integrator.md
+++ b/squads/claude-code-mastery/agents/project-integrator.md
@@ -21,9 +21,11 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "Project Status: Greenfield project -- no git repository detected" instead of git narrative
-         - After substep 6: show "Recommended: Run `*integrate-project` to scaffold the full AI-assisted development infrastructure"
-         - Do NOT run any git commands during activation -- they will fail and produce errors
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend a project command
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `*integrate-project` to scaffold the full AI-assisted development infrastructure"
+         - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [Ask], [Auto], [Explore])
       2. Show: "**Role:** {persona.role}"
          - Append: "Story: {active story from docs/stories/}" if detected + "Branch: `{branch from gitStatus}`" if not main/master

--- a/squads/claude-code-mastery/agents/roadmap-sentinel.md
+++ b/squads/claude-code-mastery/agents/roadmap-sentinel.md
@@ -21,9 +21,11 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "**Project Status:** Greenfield project -- no git repository detected" instead of git narrative
-         - After substep 6: show "**Recommended:** Run `*check-updates` to assess your Claude Code version and feature readiness"
-         - Do NOT run any git commands during activation -- they will fail and produce errors
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend a project command
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `*check-updates` to assess your Claude Code version and feature readiness"
+         - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [Ask], [Auto], [Explore])
       2. Show: "**Role:** {persona.role}"
          - Append: "Story: {active story from docs/stories/}" if detected + "Branch: `{branch from gitStatus}`" if not main/master

--- a/squads/claude-code-mastery/agents/skill-craftsman.md
+++ b/squads/claude-code-mastery/agents/skill-craftsman.md
@@ -21,9 +21,11 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "Project Status: Greenfield project -- no git repository detected" instead of git narrative
-         - After substep 6: show "Recommended: Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
-         - Do NOT run any git commands during activation -- they will fail and produce errors
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend a project command
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [Ask], [Auto], [Explore])
       2. Show: "**Role:** {persona.role}"
          - Append: "Story: {active story from docs/stories/}" if detected + "Branch: `{branch from gitStatus}`" if not main/master

--- a/squads/claude-code-mastery/agents/swarm-orchestrator.md
+++ b/squads/claude-code-mastery/agents/swarm-orchestrator.md
@@ -21,8 +21,10 @@ activation-instructions:
       Display greeting using native context (zero JS execution):
       0. GREENFIELD GUARD: If gitStatus in system prompt says "Is a git repository: false" OR git commands return "not a git repository":
          - For substep 2: skip the "Branch:" append
-         - For substep 3: show "📊 **Project Status:** Greenfield project — no git repository detected" instead of git narrative
-         - After substep 6: show "💡 **Recommended:** Run `*environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
+         - For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
+         - After substep 6, decide from the working directory path already in the system prompt (zero I/O):
+           - If it is a user home directory (e.g. `C:\Users\{name}`, `/home/{name}`, `/Users/{name}`) or any other non-project directory: show "💡 **Tip:** Activate agents from inside the project directory — never run `git init` in a home directory." and do NOT recommend a project command
+           - Otherwise (an actual project directory): show "💡 **Recommended:** Run `@devops *environment-bootstrap` to initialize git, GitHub remote, and CI/CD"
          - Do NOT run any git commands during activation — they will fail and produce errors
       1. Show: "{icon} {persona_profile.communication.greeting_levels.archetypal}" + permission badge from current permission mode (e.g., [⚠️ Ask], [🟢 Auto], [🔍 Explore])
       2. Show: "**Role:** {persona.role}"

--- a/squads/claude-code-mastery/agents/swarm-orchestrator.md
+++ b/squads/claude-code-mastery/agents/swarm-orchestrator.md
@@ -548,14 +548,14 @@ voice_dna:
     (not structure), fan-out/fan-in (not split/merge). Prefers diagrams and
     decision trees over prose. Every recommendation includes the cost implication.
   lexicon:
-    - "topology" (preferred over "structure" or "architecture" for agent arrangements)
-    - "spawn" (preferred over "create" for agent instantiation)
-    - "converge" (preferred over "combine" for result synthesis)
-    - "fan-out / fan-in" (preferred over "split / merge" for parallel patterns)
-    - "isolation boundary" (preferred over "separation" for context/file boundaries)
-    - "heartbeat" (for health monitoring of long-running teammates)
-    - "claim" (for task acquisition in swarm patterns)
-    - "unblock" (for dependency resolution in task pipelines)
+    - '"topology" (preferred over "structure" or "architecture" for agent arrangements)'
+    - '"spawn" (preferred over "create" for agent instantiation)'
+    - '"converge" (preferred over "combine" for result synthesis)'
+    - '"fan-out / fan-in" (preferred over "split / merge" for parallel patterns)'
+    - '"isolation boundary" (preferred over "separation" for context/file boundaries)'
+    - '"heartbeat" (for health monitoring of long-running teammates)'
+    - '"claim" (for task acquisition in swarm patterns)'
+    - '"unblock" (for dependency resolution in task pipelines)'
 
 # ──────────────────────────────────────────────────────
 # OUTPUT EXAMPLES


### PR DESCRIPTION
## 📋 Description

Companion to #813, applying the same `GREENFIELD GUARD` fix to the 8 agents in `squads/claude-code-mastery/`, which carried the same defects — plus two problems of their own.

**1. Agent Authority violation (Constitution Article II).** 4 of the 8 agents recommended `*environment-bootstrap`, a **@devops-exclusive** command that none of them owns: `hooks-architect`, `mcp-integrator`, `skill-craftsman`, `swarm-orchestrator`. Verified with `grep -lE "^  - name: environment-bootstrap$"` across the squad — zero matches.

**2. False positive in non-project directories.** Same as #813: the trigger is only "not a git repository", so activating from `C:\Users\{name}` produced a recommendation whose task would `git init` over the user's profile, while labelling that directory a "Greenfield project".

**3. Four typographic variants of the same three lines.** Across the 8 files the guard existed as `--` vs `—`, with and without `**bold**`, with and without the 📊 emoji.

**4. Unparseable YAML in `swarm-orchestrator.md`.** Pre-existing, found while validating this change, and fixed in the second commit — details below.

## 📦 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🎯 Scope
- [x] Squad (`squads/`)

## 📝 Changes Made

### Commit 1 — guard standardization

| Agent | Before | After |
|---|---|---|
| `hooks-architect` | `*environment-bootstrap` | `@devops *environment-bootstrap` |
| `mcp-integrator` | `*environment-bootstrap` | `@devops *environment-bootstrap` |
| `skill-craftsman` | `*environment-bootstrap` | `@devops *environment-bootstrap` |
| `swarm-orchestrator` | `*environment-bootstrap` | `@devops *environment-bootstrap` |
| `config-engineer` | `*configure` | unchanged — owns it |
| `project-integrator` | `*integrate-project` | unchanged — owns it |
| `roadmap-sentinel` | `*check-updates` | unchanged — owns it |
| `claude-mastery-chief` | no recommendation | tip-only branch |

Each of the three retained commands was verified to exist in its own agent's `commands` block, so no further phantom commands are being recommended.

All 8 now carry byte-identical guard lines, matching the wording landed for the core agents in #813:

```
- For substep 3: show "📊 **Project Status:** No git repository detected in the working directory" instead of git narrative
- After substep 6, decide from the working directory path already in the system prompt (zero I/O):
  - If it is a user home directory (...) or any other non-project directory: show "💡 **Tip:** ..." and do NOT recommend a project command
  - Otherwise (an actual project directory): show "💡 **Recommended:** Run `<command>` ..."
- Do NOT run any git commands during activation — they will fail and produce errors
```

### Commit 2 — invalid YAML in `voice_dna.lexicon`

The 8 entries had the shape:

```yaml
- "topology" (preferred over "structure" for agent arrangements)
```

YAML closes the scalar at the second quote and the trailing ` (preferred ...)` becomes a stray token, so js-yaml rejected the **entire** embedded block (`bad indentation of a sequence entry`) — the agent definition was unparseable by any tooling that reads it as YAML. Each entry is now single-quoted, which keeps the inner double quotes verbatim and keeps the parenthetical inside the value instead of turning it into a comment:

```yaml
- '"topology" (preferred over "structure" for agent arrangements)'
```

Entries elsewhere in the squad of the form `- "text" # comment` were deliberately left alone: the `#` makes the tail a comment, so those already parse.

## 🧪 Testing

- Guard uniformity: `grep -h 'For substep 3' squads/claude-code-mastery/agents/*.md | sort | uniq -c` → **8 identical lines** (was 4 variants). Same for the `Do NOT run` line.
- No undelegated bootstrap recommendation remains in the squad.
- YAML parse of the embedded block in all 8 agents → **8 valid, 0 invalid** (was 7/1 before commit 2).
- `voice_dna.lexicon` still yields **8 entries** after the fix, text unchanged.
- `npm run lint` and `npm run typecheck` pass, though neither inspects markdown.

## ⚠️ One thing for maintainers

**`validate:agents` does not cover squads.** `npm run validate:agents` validates only the 12 core agents in `.aiox-core/development/agents/`, so squad definitions have no automated YAML or consistency gate. That is precisely why 4 typographic variants and a YAML block that no parser accepts could coexist here unnoticed. Extending the validator to `squads/*/agents/` would have caught both problems in this PR before they shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated agent activation “Project Status” messaging when no git repository is detected.
  * Added clearer, path-based guidance for home/non-project directories, including a tip to activate from inside the project directory.
  * Added improved recommendations for actual project directories (e.g., running the relevant project setup/check commands).
  * Continued to avoid running git commands during activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->