### PR TITLE
fix(release): sync root package.json to 5.4.0, complete the lockstep set

### DIFF
--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -7,8 +7,8 @@
 # - SHA256 hashes for change detection
 # - File types for categorization
 #
-version: 5.3.0
-generated_at: "2026-08-15T17:07:27.850Z"
+version: 5.4.0
+generated_at: "2026-08-15T17:16:26.019Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1172
 files:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aiox-squads/core",
-      "version": "5.3.0",
+      "version": "5.4.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "Synkra AIOX: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aiox": "bin/aiox.js",


### PR DESCRIPTION
## Why

PR #825 bumped `.aiox-core/package.json` and `compat/aiox-core/package.json` to `5.4.0` but deliberately left root `package.json` untouched. That broke the publish safety gate: `validate-aiox-core-namespace.js` (invoked by `bin/utils/validate-publish.js`, covered by `tests/cli/validate-publish.test.js`) requires root `package.json` and `.aiox-core/package.json` to match exactly, with root as SOT. Before #825 both were consistently `5.3.0` (stale vs. the tag, but internally matched); #825 bumped only one side, introducing a new drift that broke CI on `main` — visible in PR #825's own CI checks (which were not checked before merging with `--admin`), and confirmed when re-dispatching `npm-publish.yml` for the legacy `aiox-core` package (`test` job failed).

## What

- `package.json`: `5.3.0` → `5.4.0` (matches the already-published `@aiox-squads/core@5.4.0` and the `v5.4.0` tag from #823's release)
- `package-lock.json`: root `"version"` fields synced via `npm install --package-lock-only` (no dependency changes, just the two version strings npm keeps in lockstep with `package.json`)
- `.aiox-core/install-manifest.yaml`: regenerated via `npm run generate:manifest` (version header + hash), since it also reads root `package.json`'s version

## Verified locally before pushing

- `node bin/utils/validate-publish.js` → `PUBLISH SAFETY GATE: PASS`
- `npx jest tests/cli/validate-publish.test.js` → 15 passed, 0 failed
- `npm run validate:manifest` → Manifest is VALID and up-to-date

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>