### PR TITLE
fix(ci): add always() to publish_legacy_aiox_core so scoped packages=aiox-core dispatches actually run

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -397,8 +397,21 @@ jobs:
     # in parallel, the legacy smoke test races against npm propagation of the
     # scoped package and times out — making the workflow appear failed even
     # though both packages were published successfully.
+    #
+    # `needs.publish.result == 'skipped'` is an intentionally allowed case
+    # (a scoped `packages=aiox-core` dispatch, without `core`, skips `publish`
+    # by design). GitHub Actions propagates a skipped `needs` job to this job
+    # by default REGARDLESS of a custom `if:` — the only way to opt out of
+    # that default propagation is to start the expression with `always()`.
+    # Without it, this whole condition was dead code: a scoped
+    # `packages=aiox-core` dispatch could never actually run this job. See
+    # https://github.com/SynkraAI/aiox-core/issues/827 (Bug 3).
+    #
+    # `always()` also bypasses the *failure*-propagation default, so the
+    # `test`/`build` success checks below are load-bearing, not redundant —
+    # without them this job would run even when `test` or `build` failed.
     needs: [test, build, publish]
-    if: ${{ contains(format(',{0},', needs.build.outputs.packages), ',aiox-core,') && (needs.publish.result == 'success' || needs.publish.result == 'skipped') }}
+    if: ${{ always() && needs.test.result == 'success' && needs.build.result == 'success' && contains(format(',{0},', needs.build.outputs.packages), ',aiox-core,') && (needs.publish.result == 'success' || needs.publish.result == 'skipped') }}
     runs-on: ubuntu-latest
     outputs:
       published: ${{ steps.should-publish.outputs.should_publish }}


### PR DESCRIPTION
## Why

Bug 3 from #827: `publish_legacy_aiox_core`'s `if:` explicitly tries to allow `needs.publish.result == 'skipped'` (the expected state when a scoped `packages=aiox-core` dispatch, without `core`, causes `publish`'s own `if:` to evaluate false). But GitHub Actions propagates a skipped `needs` job to dependents **by default, regardless of a custom `if:` expression** — the only way to opt out is to start the expression with `always()`. Without it, the "skipped is OK" branch of the condition was dead code: a scoped `packages=aiox-core`-only dispatch could never actually run this job.

Verified live in two separate runs: [`#31897480528`](https://github.com/SynkraAI/aiox-core/actions/runs/31897480528) and [`#31898069540`](https://github.com/SynkraAI/aiox-core/actions/runs/31898069540) — both `packages=aiox-core`-only dispatches, both show `publish_legacy_aiox_core: skipped`.

## What

```diff
-    if: ${{ contains(format(',{0},', needs.build.outputs.packages), ',aiox-core,') && (needs.publish.result == 'success' || needs.publish.result == 'skipped') }}
+    if: ${{ always() && needs.test.result == 'success' && needs.build.result == 'success' && contains(format(',{0},', needs.build.outputs.packages), ',aiox-core,') && (needs.publish.result == 'success' || needs.publish.result == 'skipped') }}
```

`always()` also removes the *implicit* failure-propagation default for **every** `needs` entry, not just `publish` — so the added `needs.test.result == 'success' && needs.build.result == 'success'` checks are load-bearing, not decorative. Without them this job would now run even when `test` or `build` failed.

## Blast radius

No behavior change intended for the `packages=all` / `packages=core` paths already exercised in production ([`#31898409032`](https://github.com/SynkraAI/aiox-core/actions/runs/31898409032), which correctly ran `publish_legacy_aiox_core` and published `aiox-core@5.4.0` because `publish` itself was **not** skipped there) — this only changes what happens for the previously-dead `packages=aiox-core`-only input.

## Not in scope

Sibling jobs in this workflow (e.g. `smoke_test_exports`) may share the same class of skip-propagation gap — not audited/fixed here, flagged in #827 for a separate pass.

**Not urgent** — no `--admin`, waiting for full green CI before merge, per team decision after today's release incident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>