### PR TITLE
fix(deps): add tar to root dependencies — pro-setup.js MODULE_NOT_FOUND in published aiox-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "picocolors": "^1.1.1",
         "proper-lockfile": "^4.1.2",
         "semver": "^7.7.2",
+        "tar": "^7.5.7",
         "validator": "^13.15.15"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "picocolors": "^1.1.1",
     "proper-lockfile": "^4.1.2",
     "semver": "^7.7.2",
+    "tar": "^7.5.7",
     "validator": "^13.15.15"
   },
   "keywords": [


### PR DESCRIPTION
## Critical regression

v5.4.0's tar-based Pro artifact extraction (#823) broke Pro activation **worse** than the bug it fixed. `tar` was added to `packages/installer/package.json`'s `dependencies` and to root `package.json`'s `overrides` block — but never to root `package.json`'s `dependencies`. `overrides` only pins the resolved version of a transitive dependency if something else already requires it; it does not, by itself, cause npm to install the package. `@aiox-squads/core` (the published root package, which `aiox-core` — what students actually install — depends on) bundles `packages/` as plain files via its `files` array, not as a linked npm workspace, so `packages/installer/package.json`'s own `dependencies` are never consulted by a consumer's `npm install`.

**Verified in a clean directory, installing the real published `aiox-core@5.4.0` tarball:**
```
node -e "require('.../packages/installer/src/wizard/pro-setup.js')"
→ Error: Cannot find module 'tar'
```
Since `pro-setup.js` is lazy-required (only reached on Pro activation, not on `--help`/other commands), this was masked in casual smoke testing — the crash happens exactly when a student reaches Pro setup, same failure point as before #823, now with a different error.

## Fix

- `package.json`: add `"tar": "^7.5.7"` to `dependencies` (same range already pinned in `overrides`, and in `packages/installer/package.json`)
- `package-lock.json`: synced via `npm install` (1 line — `tar` was already resolved in the tree via `overrides` + the installer workspace's own dependency, this just adds root's `dependencies` pointer)

## Audit of other packages/*/package.json deps vs root (per instruction, not fixed beyond `tar` without sign-off)

- `packages/installer`: only `tar` was missing — fixed here
- `packages/aiox-install`: no gaps
- `packages/aiox-pro-cli`: **`open` is missing from root `dependencies`** — same class of bug, **not fixed in this PR**, flagging for a separate decision

## Verification (new protocol, against the real publishable artifact — not the repo checkout)

1. `npm pack` this package for real → `@aiox-squads/core@5.4.0`, 2104 files
2. Installed that exact `.tgz` in a clean directory outside the repo
3. `node -e "require('.../packages/installer/src/wizard/pro-setup.js'); console.log('LOAD OK')"` → **`LOAD OK`**
4. Built a minimal `@aiox-squads/pro` fixture tarball via `npm pack` (same pattern as the existing test suite) and called `_testing.extractProArtifactToTemp()` from the **installed** module (not the repo checkout) against it → extracted correctly, `package.json` + `squads/index.js` present and intact at the expected path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>