### PR TITLE
chore(release): sync full version lockstep set to 5.4.1

### DIFF
--- a/.aiox-core/install-manifest.yaml
+++ b/.aiox-core/install-manifest.yaml
@@ -7,8 +7,8 @@
 # - SHA256 hashes for change detection
 # - File types for categorization
 #
-version: 5.4.0
-generated_at: "2026-08-15T17:16:26.019Z"
+version: 5.4.1
+generated_at: "2026-08-15T18:03:37.513Z"
 generator: scripts/generate-install-manifest.js
 file_count: 1172
 files:
@@ -3865,7 +3865,7 @@ files:
     type: monitor
     size: 856
   - path: package.json
-    hash: sha256:bc9e3ffae60d398652ac6f1732e49cb01373f33d47ef32e7f46c081263d1fe72
+    hash: sha256:f7de5907215c34b2a28ad1ce7c9cf6696e6eacec15681902b9408cc062a27e1f
     type: other
     size: 1445
   - path: product/checklists/accessibility-wcag-checklist.md

--- a/.aiox-core/package.json
+++ b/.aiox-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/core-internal",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Internal package manifest for AIOX framework — declares runtime dependencies consumed by scripts under .aiox-core/. This is NOT published independently; it ships inside @aiox-squads/core (the top-level package). Kept name-distinct from the parent (`-internal` suffix) to avoid npm registry confusion. Version follows the parent package.",
   "private": true,
   "main": "index.js",

--- a/compat/aiox-core/package.json
+++ b/compat/aiox-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aiox-core",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Compatibility wrapper for @aiox-squads/core.",
   "license": "MIT",
   "bin": {
@@ -15,7 +15,7 @@
     "README.md"
   ],
   "dependencies": {
-    "@aiox-squads/core": "5.4.0"
+    "@aiox-squads/core": "5.4.1"
   },
   "engines": {
     "node": ">=18"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aiox-squads/core",
-      "version": "5.4.0",
+      "version": "5.4.1",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aiox-squads/core",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Synkra AIOX: AI-Orchestrated System for Full Stack Development - Core Framework",
   "bin": {
     "aiox": "bin/aiox.js",


### PR DESCRIPTION
## Why

Applying today's lesson from #825/#826: bump root, `.aiox-core`, and `compat/aiox-core` **together** in one commit, instead of splitting them and re-discovering the lockstep-validator gap under CI pressure.

v5.4.1 (#829, tar dependency fix) was published to `@aiox-squads/core` via `Semantic Release` run `31899973262` ("The next release version is 5.4.1"), but — same root cause tracked in #827 for the 5.4.0 release — that job's local version bump never persists back to `main` (no `@semantic-release/git` plugin).

## What

- `package.json`: `5.4.0` → `5.4.1`
- `.aiox-core/package.json` + `compat/aiox-core/package.json`: synced via `node scripts/sync-version-lockstep.js 5.4.1` (the pipeline's own tool, byte-identical to what the automated flow produces)
- `package-lock.json`: root `"version"` fields synced via `npm install --package-lock-only` (no dependency changes)
- `.aiox-core/install-manifest.yaml`: regenerated via `npm run generate:manifest`

## Verified locally before pushing

- `node bin/utils/validate-publish.js` → `PUBLISH SAFETY GATE: PASS`
- `npx jest tests/cli/validate-publish.test.js` → 15 passed, 0 failed
- `npm run validate:manifest` → Manifest is VALID and up-to-date

## Next step after merge

Re-dispatch `npm-publish.yml -f packages=all` (the `#828` `always()` fix isn't merged yet, so `packages=aiox-core` alone still won't run `publish_legacy_aiox_core`) to publish the now-correct legacy `aiox-core` wrapper at `5.4.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>